### PR TITLE
Add Django templating frontend new

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.home, name='home'),
+    path('work/', views.work, name='work'),
+    path('personal/', views.personal, name='personal'),
+]

--- a/core/views.py
+++ b/core/views.py
@@ -1,3 +1,13 @@
 from django.shortcuts import render
 
-# Create your views here.
+
+def home(request):
+    return render(request, 'home.html')
+
+
+def work(request):
+    return render(request, 'work.html')
+
+
+def personal(request):
+    return render(request, 'personal.html')

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'core',
 ]
 
 MIDDLEWARE = [
@@ -54,7 +55,7 @@ ROOT_URLCONF = 'noesis.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -115,6 +116,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATICFILES_DIRS = [BASE_DIR / 'static']
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/noesis/urls.py
+++ b/noesis/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('core.urls')),
 ]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,4 @@
+/* Custom styles for card hover effects */
+.group:hover .group-hover\:scale-105 {
+    transform: scale(1.05);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Noesis Assistant{% endblock %}</title>
+    <!-- Tailwind CSS via CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-mK8e1zgS60F7uO3cu6UytzszbmWzxubUANe0yoyS9MhUlCT3ocOITkkpFmS6r30YIOCwRvDDDeZz7eGRIDcNQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="{% static 'css/style.css' %}">
+</head>
+<body class="flex flex-col min-h-screen bg-white text-gray-900">
+    <header class="bg-gradient-to-r from-blue-600 to-blue-800 text-white">
+        <div class="container mx-auto flex items-center justify-between p-4">
+            <div class="text-xl font-semibold">
+                <a href="/">Logo</a>
+            </div>
+            <nav class="space-x-4">
+                <a href="/" class="hover:underline">Home</a>
+                {% if user.is_authenticated %}
+                    <span>{{ user.username }}</span>
+                    <a href="/logout/" class="hover:underline">Logout</a>
+                {% else %}
+                    <a href="/login/" class="hover:underline">Login</a>
+                {% endif %}
+            </nav>
+        </div>
+    </header>
+
+    <main class="flex-1 container mx-auto p-4">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="bg-gray-100 text-center py-4">
+        <p>&copy; 2024 Noesis Assistant</p>
+    </footer>
+</body>
+</html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+
+{% block title %}Home - Noesis Assistant{% endblock %}
+
+{% block content %}
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+    <a href="{% url 'work' %}" class="group block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">
+        <div class="h-48 bg-cover bg-center flex items-center justify-center" style="background-image: linear-gradient(to bottom right, #0052A5, #00B2FF);">
+            <i class="fas fa-briefcase text-white text-5xl"></i>
+        </div>
+        <div class="p-4">
+            <h3 class="text-xl font-semibold mb-2">Work Assistant</h3>
+            <p class="text-gray-600">Organize your professional tasks and schedules.</p>
+        </div>
+    </a>
+    <a href="{% url 'personal' %}" class="group block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">
+        <div class="h-48 bg-cover bg-center flex items-center justify-center" style="background-image: linear-gradient(to bottom right, #0070D1, #6EB5FF);">
+            <i class="fas fa-user text-white text-5xl"></i>
+        </div>
+        <div class="p-4">
+            <h3 class="text-xl font-semibold mb-2">Personal Hub</h3>
+            <p class="text-gray-600">Manage your personal reminders and notes.</p>
+        </div>
+    </a>
+</div>
+{% endblock %}

--- a/templates/personal.html
+++ b/templates/personal.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block title %}Personal Hub{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Personal Hub</h1>
+<p>This is a placeholder page for personal features.</p>
+{% endblock %}

--- a/templates/work.html
+++ b/templates/work.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block title %}Work Assistant{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Work Assistant</h1>
+<p>This is a placeholder page for work-related tools.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add core app routes and placeholder views
- integrate templates folder and Tailwind + FontAwesome
- create base layout with header/footer and login placeholders
- build responsive home page with work/personal tiles

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684032a65bdc832b940535650f72d14e