### PR TITLE
Show recording tiles only to admin

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -14,12 +14,20 @@ def home(request):
 
 @login_required
 def work(request):
-    return render(request, 'work.html')
+    is_admin = request.user.groups.filter(name='admin').exists()
+    context = {
+        'is_admin': is_admin,
+    }
+    return render(request, 'work.html', context)
 
 
 @login_required
 def personal(request):
-    return render(request, 'personal.html')
+    is_admin = request.user.groups.filter(name='admin').exists()
+    context = {
+        'is_admin': is_admin,
+    }
+    return render(request, 'personal.html', context)
 
 
 @login_required

--- a/templates/personal.html
+++ b/templates/personal.html
@@ -5,7 +5,7 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Persönlicher Bereich</h1>
 <p>Dies ist eine Platzhalterseite für persönliche Funktionen.</p>
-{% if user.groups.filter(name='admin').exists %}
+{% if is_admin %}
 <div class="grid grid-cols-1 sm:grid-cols-2 mt-6">
     <a href="{% url 'recording_page' bereich='personal' %}" class="group block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">
         <div class="h-32 bg-gradient-to-r from-green-600 to-green-800 flex items-center justify-center">

--- a/templates/work.html
+++ b/templates/work.html
@@ -5,7 +5,7 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Arbeitsassistent</h1>
 <p>Dies ist eine Platzhalterseite für arbeitsbezogene Werkzeuge.</p>
-{% if user.groups.filter(name='admin').exists %}
+{% if is_admin %}
 <div class="grid grid-cols-1 sm:grid-cols-2 mt-6">
     <a href="{% url 'recording_page' bereich='work' %}" class="group block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">
         <div class="h-32 bg-gradient-to-r from-blue-600 to-blue-800 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- check admin group membership in work and personal views
- pass `is_admin` flag to templates
- show microphone tile only when `is_admin` is true

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684054fc92a8832b8c4de7c4c6202dc8