### PR TITLE
Implement transcript upload and improve TalkDiary

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -19,3 +19,26 @@ class RecordingForm(forms.ModelForm):
         if f.content_type not in ["audio/wav", "audio/x-wav", "audio/mpeg"]:
             raise forms.ValidationError("Nur WAV oder MP3 erlaubt")
         return f
+
+
+class TranscriptUploadForm(forms.Form):
+    """Formular zum manuellen Hochladen eines Transkripts."""
+
+    recording = forms.ModelChoiceField(queryset=Recording.objects.none())
+    transcript_file = forms.FileField(
+        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"})
+    )
+
+    def __init__(self, *args, user=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if user:
+            self.fields["recording"].queryset = Recording.objects.filter(
+                user=user, transcript_file=""
+            )
+        self.fields["recording"].widget.attrs.update({"class": "border rounded p-2"})
+
+    def clean_transcript_file(self):
+        f = self.cleaned_data["transcript_file"]
+        if not f.name.endswith(".md"):
+            raise forms.ValidationError("Nur .md Dateien erlaubt")
+        return f

--- a/core/urls.py
+++ b/core/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('toggle-recording/<str:bereich>/', views.toggle_recording_view, name='toggle_recording'),
     path('upload/', views.upload_recording, name='upload_recording'),
     path('dashboard/', views.dashboard, name='dashboard'),
+    path('upload-transcript/', views.upload_transcript, name='upload_transcript'),
     path('personal/talkdiary/', views.talkdiary, {'bereich': 'personal'}, name='talkdiary_personal'),
     path('work/talkdiary/', views.talkdiary, {'bereich': 'work'}, name='talkdiary_work'),
     path('talkdiary/<int:pk>/', views.talkdiary_detail, name='talkdiary_detail'),

--- a/templates/talkdiary.html
+++ b/templates/talkdiary.html
@@ -3,10 +3,13 @@
 {% block title %}TalkDiary {{ bereich|capfirst }}{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">TalkDiary {{ bereich|capfirst }}</h1>
-<div class="mb-6 flex items-center space-x-4">
+<div class="mb-6 flex flex-wrap items-center space-x-4">
 
     {% if is_recording %}
-    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-white bg-red-600 hover:bg-red-700">Aufnahme stoppen</a>
+    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-white bg-red-600 hover:bg-red-700 flex items-center">
+        Aufnahme stoppen
+        <span class="ml-2 animate-pulse">&#9679;</span>
+    </a>
     {% else %}
     <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-white bg-green-600 hover:bg-green-700">Aufnahme starten</a>
     {% endif %}
@@ -14,13 +17,21 @@
     <form method="get" class="inline-block">
         <button name="rescan" value="1" class="px-4 py-2 bg-gray-600 text-white rounded">Rescan</button>
     </form>
+    <a href="{% url 'upload_transcript' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Transcript hochladen</a>
+    {% if is_admin %}
+    <a href="{% url 'admin_talkdiary' %}" class="px-4 py-2 bg-purple-600 text-white rounded">Admin</a>
+    {% endif %}
 </div>
 <h2 class="text-xl font-semibold mb-2">Original files</h2>
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
     {% for rec in recordings %}
-    <div class="border p-4 rounded shadow">
+    <div class="border p-4 rounded shadow {{ rec.transcript_file|yesno:'bg-green-50,' }}">
         <audio controls src="{{ rec.audio_file.url }}" class="w-full"></audio>
-        <p class="mt-2 text-sm">{{ rec.audio_file.name|basename }}</p>
+        <p class="mt-2 text-sm flex items-center">
+            <i class="fas fa-microphone text-blue-600 mr-2"></i>
+            {{ rec.audio_file.name|basename }}
+            {% if rec.transcript_file %}<i class="fas fa-check text-green-600 ml-2"></i>{% endif %}
+        </p>
         <p class="text-xs text-gray-500">{{ rec.created_at|date:'d.m.Y H:i' }}</p>
     </div>
     {% empty %}
@@ -32,7 +43,10 @@
     {% for rec in recordings %}
         {% if rec.transcript_file %}
         <a href="{% url 'talkdiary_detail' rec.pk %}" class="block border rounded p-4 bg-gray-50 hover:bg-gray-100">
-            <h3 class="font-semibold">{{ rec.audio_file.name|basename }}</h3>
+            <h3 class="font-semibold flex items-center">
+                <i class="fas fa-file-alt text-green-600 mr-2"></i>
+                {{ rec.audio_file.name|basename }}
+            </h3>
             <p class="text-sm whitespace-pre-line mt-1">{{ rec.excerpt }}</p>
         </a>
         {% endif %}
@@ -40,4 +54,17 @@
     <p>Keine Transkripte.</p>
     {% endfor %}
 </div>
+{% if is_admin %}
+<div class="mt-8">
+    <a href="{% url 'admin_talkdiary' %}" class="block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">
+        <div class="h-32 bg-gradient-to-r from-purple-600 to-purple-800 flex items-center justify-center">
+            <i class="fas fa-tools text-white text-4xl"></i>
+        </div>
+        <div class="p-4 bg-white">
+            <h3 class="text-lg font-semibold mb-2">Transcript Verwaltung</h3>
+            <p class="text-gray-600">Alle Einträge prüfen und bereinigen</p>
+        </div>
+    </a>
+</div>
+{% endif %}
 {% endblock %}

--- a/templates/talkdiary_detail.html
+++ b/templates/talkdiary_detail.html
@@ -4,6 +4,7 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">{{ recording.audio_file.name|basename }}</h1>
 <p class="text-sm text-gray-600 mb-4">{{ recording.created_at|date:'d.m.Y H:i' }} - {{ recording.bereich }}</p>
+<audio controls src="{{ recording.audio_file.url }}" class="mb-4 w-full"></audio>
 <div class="prose max-w-none">
     {{ transcript_html|safe }}
 </div>

--- a/templates/upload_transcript.html
+++ b/templates/upload_transcript.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}Transcript hochladen{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Transcript hochladen</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    <div>
+        {{ form.recording.label_tag }}<br>
+        {{ form.recording }}
+    </div>
+    <div>
+        {{ form.transcript_file.label_tag }}<br>
+        {{ form.transcript_file }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow manual transcript uploads via new form and view
- fix whisper call in processing workflow
- enhance TalkDiary templates with active state indicators and admin tile
- link admin transcript management page

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68414ecd793c832b95bf6515b0e1e232