### PR TITLE
Improve TalkDiary recording controls

### DIFF
--- a/templates/admin_talkdiary.html
+++ b/templates/admin_talkdiary.html
@@ -5,9 +5,9 @@
 <h1 class="text-2xl font-semibold mb-4">Admin TalkDiary</h1>
 <div class="mb-4 space-x-2">
     <a href="?" class="px-3 py-1 rounded bg-gray-200 {% if not filter %}bg-gray-400{% endif %}">Alle</a>
-    <a href="?filter=missing_audio" class="px-3 py-1 rounded bg-gray-200 {% if filter=='missing_audio' %}bg-gray-400{% endif %}">Missing Audio</a>
-    <a href="?filter=missing_transcript" class="px-3 py-1 rounded bg-gray-200 {% if filter=='missing_transcript' %}bg-gray-400{% endif %}">Missing Transcript</a>
-    <a href="?filter=incomplete" class="px-3 py-1 rounded bg-gray-200 {% if filter=='incomplete' %}bg-gray-400{% endif %}">Incomplete</a>
+    <a href="?filter=missing_audio" class="px-3 py-1 rounded bg-gray-200 {% if filter == 'missing_audio' %}bg-gray-400{% endif %}">Missing Audio</a>
+    <a href="?filter=missing_transcript" class="px-3 py-1 rounded bg-gray-200 {% if filter == 'missing_transcript' %}bg-gray-400{% endif %}">Missing Transcript</a>
+    <a href="?filter=incomplete" class="px-3 py-1 rounded bg-gray-200 {% if filter == 'incomplete' %}bg-gray-400{% endif %}">Incomplete</a>
 </div>
 <form method="post">
     {% csrf_token %}

--- a/templates/talkdiary.html
+++ b/templates/talkdiary.html
@@ -3,13 +3,15 @@
 {% block title %}TalkDiary {{ bereich|capfirst }}{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">TalkDiary {{ bereich|capfirst }}</h1>
-<div class="mb-6 flex flex-wrap items-center space-x-4">
 
+<h2 class="text-lg font-semibold mb-2">Aufnahme</h2>
+<div class="mb-6 flex flex-wrap items-center space-x-4">
     {% if is_recording %}
     <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-white bg-red-600 hover:bg-red-700 flex items-center">
         Aufnahme stoppen
         <span class="ml-2 animate-pulse">&#9679;</span>
     </a>
+    <span class="text-red-700 font-semibold">Recording…</span>
     {% else %}
     <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-white bg-green-600 hover:bg-green-700">Aufnahme starten</a>
     {% endif %}
@@ -22,18 +24,19 @@
     <a href="{% url 'admin_talkdiary' %}" class="px-4 py-2 bg-purple-600 text-white rounded">Admin</a>
     {% endif %}
 </div>
-<h2 class="text-xl font-semibold mb-2">Original files</h2>
+
+<h2 class="text-xl font-semibold mb-2">Original Files</h2>
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
     {% for rec in recordings %}
-    <div class="border p-4 rounded shadow {{ rec.transcript_file|yesno:'bg-green-50,' }}">
-        <audio controls src="{{ rec.audio_file.url }}" class="w-full"></audio>
-        <form action="{% url 'transcribe_recording' rec.pk %}" method="post" class="mt-2">
+    <div class="border p-3 rounded shadow text-sm {{ rec.transcript_file|yesno:'bg-green-50,' }}">
+        <audio controls src="{{ rec.audio_file.url }}" class="w-full mb-1"></audio>
+        <form action="{% url 'transcribe_recording' rec.pk %}" method="post" class="mt-1 transcribe-form">
             {% csrf_token %}
-            <button type="submit" class="px-2 py-1 text-sm text-white bg-blue-600 rounded">Transkribieren</button>
+            <button type="submit" class="px-2 py-1 text-white bg-blue-600 rounded">Transkribieren</button>
         </form>
-        <p class="mt-2 text-sm flex items-center">
+        <p class="mt-1 flex items-center break-all">
             <i class="fas fa-microphone text-blue-600 mr-2"></i>
-            {{ rec.audio_file.name|basename }}
+            {{ rec.audio_file.name|basename|truncatechars:30 }}
             {% if rec.transcript_file %}<i class="fas fa-check text-green-600 ml-2"></i>{% endif %}
         </p>
         <p class="text-xs text-gray-500">{{ rec.created_at|date:'d.m.Y H:i' }}</p>
@@ -46,10 +49,10 @@
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     {% for rec in recordings %}
         {% if rec.transcript_file %}
-        <a href="{% url 'talkdiary_detail' rec.pk %}" class="block border rounded p-4 bg-gray-50 hover:bg-gray-100">
+        <a href="{% url 'talkdiary_detail' rec.pk %}" class="block border rounded p-3 bg-gray-50 hover:bg-gray-100 text-sm">
             <h3 class="font-semibold flex items-center">
                 <i class="fas fa-file-alt text-green-600 mr-2"></i>
-                {{ rec.audio_file.name|basename }}
+                {{ rec.audio_file.name|basename|truncatechars:30 }}
             </h3>
             <p class="text-sm whitespace-pre-line mt-1">{{ rec.excerpt }}</p>
         </a>
@@ -71,4 +74,15 @@
     </a>
 </div>
 {% endif %}
+<script>
+document.querySelectorAll('.transcribe-form').forEach(f => {
+    f.addEventListener('submit', () => {
+        const btn = f.querySelector('button[type="submit"]');
+        if (btn) {
+            btn.disabled = true;
+            btn.textContent = 'Transkribiere...';
+        }
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- refine recording toggle logic and add missing message hints
- add logging and messages to transcribe_recording view
- tidy admin filter conditions
- streamline TalkDiary layout and add small JS for transcription

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684169dc1854832bb9fe23166d2fa8aa