### PR TITLE
Remove redundant recording tile

### DIFF
--- a/templates/personal.html
+++ b/templates/personal.html
@@ -6,17 +6,7 @@
 <h1 class="text-2xl font-semibold mb-4">Persönlicher Bereich</h1>
 <p>Dies ist eine Platzhalterseite für persönliche Funktionen.</p>
 {% if is_admin %}
-<div class="grid grid-cols-1 sm:grid-cols-2 mt-6">
-    <a href="{% url 'recording_page' bereich='personal' %}" class="group block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">
-        <div class="h-32 bg-gradient-to-r from-green-600 to-green-800 flex items-center justify-center">
-            <i class="fas fa-microphone text-white text-4xl"></i>
-        </div>
-        <div class="p-4 bg-white">
-            <h3 class="text-lg font-semibold mb-2">Aufnahme starten</h3>
-            <p class="text-gray-600">Audioaufnahmen verwalten</p>
-        </div>
-    </a>
-</div>
+{# Keine separate Aufnahmekachel mehr notwendig. Die Aufnahme erfolgt direkt im TalkDiary. #}
 {% endif %}
 <div class="grid grid-cols-1 sm:grid-cols-2 mt-6">
     <a href="{% url 'talkdiary_personal' %}" class="group block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">

--- a/templates/work.html
+++ b/templates/work.html
@@ -6,17 +6,7 @@
 <h1 class="text-2xl font-semibold mb-4">Arbeitsassistent</h1>
 <p>Dies ist eine Platzhalterseite für arbeitsbezogene Werkzeuge.</p>
 {% if is_admin %}
-<div class="grid grid-cols-1 sm:grid-cols-2 mt-6">
-    <a href="{% url 'recording_page' bereich='work' %}" class="group block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">
-        <div class="h-32 bg-gradient-to-r from-blue-600 to-blue-800 flex items-center justify-center">
-            <i class="fas fa-microphone text-white text-4xl"></i>
-        </div>
-        <div class="p-4 bg-white">
-            <h3 class="text-lg font-semibold mb-2">Aufnahme starten</h3>
-            <p class="text-gray-600">Audioaufnahmen verwalten</p>
-        </div>
-    </a>
-</div>
+{# Die separate Aufnahmeseite entfällt, da TalkDiary die Aufnahmefunktionen bereits beinhaltet. #}
 {% endif %}
 <div class="grid grid-cols-1 sm:grid-cols-2 mt-6">
     <a href="{% url 'talkdiary_work' %}" class="group block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">


### PR DESCRIPTION
## Summary
- remove separate recording tile from work and personal pages

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'whisper')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'whisper')*

------
https://chatgpt.com/codex/tasks/task_e_684184cefb40832b9a505582210f2370