### PR TITLE
Fix PATH handling for ffmpeg

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -252,9 +252,17 @@ def _process_recordings_for_user(bereich: str, user) -> list:
     rec_dir.mkdir(parents=True, exist_ok=True)
     trans_dir.mkdir(parents=True, exist_ok=True)
 
-    ffmpeg = base_dir / "tools" / ("ffmpeg.exe" if (base_dir / "tools" / "ffmpeg.exe").exists() else "ffmpeg")
+    ffmpeg = base_dir / "tools" / (
+        "ffmpeg.exe" if (base_dir / "tools" / "ffmpeg.exe").exists() else "ffmpeg"
+    )
     if not ffmpeg.exists():
         ffmpeg = "ffmpeg"
+
+    # Pfad zu ffmpeg dem System-PATH hinzufügen, falls notwendig
+    tools_dir = str(base_dir / "tools")
+    current_path = os.environ.get("PATH", "")
+    if tools_dir not in current_path.split(os.pathsep):
+        os.environ["PATH"] = current_path + os.pathsep + tools_dir
 
 
     logger.debug("Konvertiere mkv-Dateien")


### PR DESCRIPTION
## Summary
- ensure ffmpeg tools folder is added to PATH so Whisper can find it

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`
- `python - <<'PY'
import os, shutil, subprocess
from pathlib import Path
base_dir = Path('.')
tools_dir = str(base_dir / 'tools')
if tools_dir not in os.environ.get('PATH', '').split(os.pathsep):
    os.environ['PATH'] += os.pathsep + tools_dir
print('ffmpeg found:', shutil.which('ffmpeg'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68418ff40a8c832b93941c63bf597b69