### PR TITLE
Add dev requirements and setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# NOESIS
+
+Dieses Projekt ist eine Django-Anwendung zur Verwaltung und Analyse von Audio-Aufnahmen und Transkripten.
+
+## Installation
+
+1. Installiere Python 3.11 und `pip`.
+2. Erstelle und aktiviere eine virtuelle Umgebung:
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+3. Installiere die Abhängigkeiten:
+   ```bash
+   pip install -r requirements.txt
+   # Für Entwicklungs- und Testwerkzeuge:
+   pip install -r requirements-dev.txt
+   ```
+
+## Tests und Checks
+
+Vor jedem Commit müssen laut `AGENTS.md` folgende Befehle erfolgreich laufen:
+
+```bash
+python manage.py makemigrations --check
+python manage.py test
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+coverage


### PR DESCRIPTION
## Summary
- document setup commands in README
- add `requirements-dev.txt` for development

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6841900414bc832b8eab5aedea9b9d66