### PR TITLE
Fix PATH handling for ffmpeg

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseBadRequest
 from django.core.files.storage import default_storage
 from django.contrib import messages
+import os
 import subprocess
 import whisper
 import torch
@@ -252,9 +253,17 @@ def _process_recordings_for_user(bereich: str, user) -> list:
     rec_dir.mkdir(parents=True, exist_ok=True)
     trans_dir.mkdir(parents=True, exist_ok=True)
 
-    ffmpeg = base_dir / "tools" / ("ffmpeg.exe" if (base_dir / "tools" / "ffmpeg.exe").exists() else "ffmpeg")
+    ffmpeg = base_dir / "tools" / (
+        "ffmpeg.exe" if (base_dir / "tools" / "ffmpeg.exe").exists() else "ffmpeg"
+    )
     if not ffmpeg.exists():
         ffmpeg = "ffmpeg"
+
+    # Pfad zu ffmpeg dem System-PATH hinzufügen, falls notwendig
+    tools_dir = str(base_dir / "tools")
+    current_path = os.environ.get("PATH", "")
+    if tools_dir not in current_path.split(os.pathsep):
+        os.environ["PATH"] = current_path + os.pathsep + tools_dir
 
 
     logger.debug("Konvertiere mkv-Dateien")


### PR DESCRIPTION
## Summary
- ensure ffmpeg tools folder is added to PATH so Whisper can find it
- import `os` to avoid NameError

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'whisper')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'whisper')*
- `pip install --no-cache-dir -r requirements.txt` *(fails: installation canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68418ff40a8c832b93941c63bf597b69