### PR TITLE
Add openai and generativeai requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ obsws-python
 markdown
 torch
 git+https://github.com/openai/whisper.git
+openai
+google-generativeai


### PR DESCRIPTION
## Summary
- add missing openai and google-generativeai to requirements

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6841f29f00c8832ba0765f81033f03df