### PR TITLE
Add extended project states

### DIFF
--- a/core/migrations/0011_alter_bvproject_status_choices.py
+++ b/core/migrations/0011_alter_bvproject_status_choices.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0010_bvprojectfile_manual_comment"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="bvproject",
+            name="status",
+            field=models.CharField(
+                "Status",
+                max_length=20,
+                choices=[
+                    ("NEW", "Neu"),
+                    ("CLASSIFIED", "Klassifiziert"),
+                    ("GUTACHTEN_OK", "Gutachten OK"),
+                    ("IN_PRUEFUNG_ANLAGE_X", "In Prüfung Anlage X"),
+                    ("FB_IN_PRUEFUNG", "FB in Prüfung"),
+                    ("ENDGEPRUEFT", "Endgeprüft"),
+                ],
+                default="NEW",
+            ),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -56,10 +56,17 @@ class BVProject(models.Model):
     STATUS_NEW = "NEW"
     STATUS_CLASSIFIED = "CLASSIFIED"
     STATUS_GUTACHTEN_OK = "GUTACHTEN_OK"
+    STATUS_IN_PRUEFUNG_ANLAGE_X = "IN_PRUEFUNG_ANLAGE_X"
+    STATUS_FB_IN_PRUEFUNG = "FB_IN_PRUEFUNG"
+    STATUS_ENDGEPRUEFT = "ENDGEPRUEFT"
+
     STATUS_CHOICES = [
         (STATUS_NEW, "Neu"),
         (STATUS_CLASSIFIED, "Klassifiziert"),
         (STATUS_GUTACHTEN_OK, "Gutachten OK"),
+        (STATUS_IN_PRUEFUNG_ANLAGE_X, "In Prüfung Anlage X"),
+        (STATUS_FB_IN_PRUEFUNG, "FB in Prüfung"),
+        (STATUS_ENDGEPRUEFT, "Endgeprüft"),
     ]
     status = models.CharField(
         "Status",

--- a/core/tests.py
+++ b/core/tests.py
@@ -110,6 +110,17 @@ class WorkflowTests(TestCase):
         with self.assertRaises(ValueError):
             set_project_status(projekt, "XXX")
 
+    def test_set_project_status_new_states(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        for status in [
+            BVProject.STATUS_IN_PRUEFUNG_ANLAGE_X,
+            BVProject.STATUS_FB_IN_PRUEFUNG,
+            BVProject.STATUS_ENDGEPRUEFT,
+        ]:
+            set_project_status(projekt, status)
+            projekt.refresh_from_db()
+            self.assertEqual(projekt.status, status)
+
 
 class LLMTasksTests(TestCase):
     def test_classify_system(self):

--- a/core/workflow.py
+++ b/core/workflow.py
@@ -5,7 +5,7 @@ def set_project_status(projekt: BVProject, status: str) -> None:
     """Setzt den Status eines BVProject.
 
     :param projekt: Das zu aktualisierende Projekt
-    :param status: Neuer Status
+    :param status: Neuer Status aus ``BVProject.STATUS_CHOICES``
     :raises ValueError: Wenn der Status ungültig ist
     """
     valid = [s[0] for s in BVProject.STATUS_CHOICES]

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -2,6 +2,7 @@
 {% block title %}Projekt {{ projekt.title }}{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">{{ projekt.title }}</h1>
+<p class="mb-2"><strong>Aktueller Status:</strong> {{ projekt.get_status_display }}</p>
 <p class="mb-2"><strong>Beschreibung:</strong> {{ projekt.beschreibung }}</p>
 <p class="mb-2"><strong>Software-Typen:</strong> {{ projekt.software_typen }}</p>
 <form method="post" action="{% url 'projekt_status_update' projekt.pk %}" class="mb-4">


### PR DESCRIPTION
## Summary
- expand `BVProject.STATUS_CHOICES` with more states
- show the current status in project detail view
- alter status field via migration
- test new status transitions

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68433d63e514832b8871412f515f11f8