### PR TITLE
Add attachment check via LLM

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('work/projekte/<int:pk>/anlage/', views.projekt_file_upload, name='projekt_file_upload'),
     path('work/projekte/<int:pk>/check/', views.projekt_check, name='projekt_check'),
     path('work/projekte/<int:pk>/status/', views.projekt_status_update, name='projekt_status_update'),
+    path('work/projekte/<int:pk>/anlage/<int:nr>/check/', views.projekt_file_check, name='projekt_file_check'),
     path('work/projekte/<int:pk>/gap-analysis/', views.projekt_gap_analysis, name='projekt_gap_analysis'),
     path('work/projekte/<int:pk>/summary/', views.projekt_management_summary, name='projekt_management_summary'),
     path('projects/<int:pk>/', views.project_detail_api, name='project_detail_api'),

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -26,6 +26,7 @@
     <li class="mb-2">
         Anlage {{ a.anlage_nr }}:
         <a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name }}</a>
+        <button data-url="{% url 'projekt_file_check' projekt.pk a.anlage_nr %}" class="anlage-check-btn bg-green-600 text-white px-2 py-1 rounded ml-2">Prüfen</button>
         {% if a.manual_comment %}<div class="italic">{{ a.manual_comment }}</div>{% endif %}
     </li>
     {% empty %}
@@ -102,5 +103,16 @@ function sendCheck(payload){
 }
 
 document.addEventListener('DOMContentLoaded',loadLLM);
+document.addEventListener('DOMContentLoaded',()=>{
+  document.querySelectorAll('.anlage-check-btn').forEach(btn=>{
+    btn.addEventListener('click',ev=>{
+      ev.preventDefault();
+      fetch(btn.dataset.url,{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')}})
+      .then(r=>r.json()).then(d=>{
+        if(d.status==='ok'){alert('Anlage geprüft');}else{alert('Fehler bei der Anlagenprüfung');}
+      }).catch(()=>alert('Fehler bei der Anlagenprüfung'));
+    });
+  });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `projekt_file_check` view to verify attachments via LLM
- route new endpoint in `core/urls.py`
- show a "Prüfen" button next to each attachment
- handle attachment check in JS on the project detail page
- test that the endpoint saves `analysis_json`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6843484f61ec832b8ef433dfd4101d26