### PR TITLE
Add per-file LLM check

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -246,5 +246,14 @@ class ProjektFileCheckViewTests(TestCase):
         file_obj = self.projekt.anlagen.get(anlage_nr=1)
         self.assertTrue(file_obj.analysis_json["ok"])
 
+    def test_file_check_pk_endpoint_saves_json(self):
+        file_obj = self.projekt.anlagen.get(anlage_nr=1)
+        url = reverse("projekt_file_check_pk", args=[file_obj.pk])
+        with patch("core.llm_tasks.query_llm", return_value='{"ok": true}'):
+            resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 200)
+        file_obj.refresh_from_db()
+        self.assertTrue(file_obj.analysis_json["ok"])
+
 
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('work/projekte/<int:pk>/check/', views.projekt_check, name='projekt_check'),
     path('work/projekte/<int:pk>/status/', views.projekt_status_update, name='projekt_status_update'),
     path('work/projekte/<int:pk>/anlage/<int:nr>/check/', views.projekt_file_check, name='projekt_file_check'),
+    path('work/anlage/<int:pk>/check/', views.projekt_file_check_pk, name='projekt_file_check_pk'),
     path('work/projekte/<int:pk>/gap-analysis/', views.projekt_gap_analysis, name='projekt_gap_analysis'),
     path('work/projekte/<int:pk>/summary/', views.projekt_management_summary, name='projekt_management_summary'),
     path('projects/<int:pk>/', views.project_detail_api, name='project_detail_api'),

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -26,7 +26,7 @@
     <li class="mb-2">
         Anlage {{ a.anlage_nr }}:
         <a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name }}</a>
-        <button data-url="{% url 'projekt_file_check' projekt.pk a.anlage_nr %}" class="anlage-check-btn bg-green-600 text-white px-2 py-1 rounded ml-2">Prüfen</button>
+        <button data-url="{% url 'projekt_file_check_pk' a.pk %}" class="anlage-check-btn bg-green-600 text-white px-2 py-1 rounded ml-2">Prüfen</button>
         {% if a.manual_comment %}<div class="italic">{{ a.manual_comment }}</div>{% endif %}
     </li>
     {% empty %}


### PR DESCRIPTION
## Summary
- add `projekt_file_check_pk` view to inspect a BVProjectFile by id
- expose new endpoint under `work/anlage/<pk>/check/`
- link new endpoint from project detail view
- cover new behaviour with a test

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68434ec8ff34832baa851c95f110110e