### PR TITLE
Add JSON edit view for project files

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -121,3 +121,23 @@ class BVProjectFileForm(forms.ModelForm):
             ),
         }
 
+
+class BVProjectFileJSONForm(forms.ModelForm):
+    """Formular zum Bearbeiten der Analyse-Daten einer Anlage."""
+
+    class Meta:
+        model = BVProjectFile
+        fields = ["analysis_json", "manual_analysis_json"]
+        labels = {
+            "analysis_json": "Automatische Analyse (JSON)",
+            "manual_analysis_json": "Manuelle Analyse (JSON)",
+        }
+        widgets = {
+            "analysis_json": forms.Textarea(
+                attrs={"class": "border rounded p-2", "rows": 10}
+            ),
+            "manual_analysis_json": forms.Textarea(
+                attrs={"class": "border rounded p-2", "rows": 10}
+            ),
+        }
+

--- a/core/urls.py
+++ b/core/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path('work/projekte/<int:pk>/status/', views.projekt_status_update, name='projekt_status_update'),
     path('work/projekte/<int:pk>/anlage/<int:nr>/check/', views.projekt_file_check, name='projekt_file_check'),
     path('work/anlage/<int:pk>/check/', views.projekt_file_check_pk, name='projekt_file_check_pk'),
+    path('work/anlage/<int:pk>/edit-json/', views.projekt_file_edit_json, name='projekt_file_edit_json'),
     path('work/projekte/<int:pk>/gap-analysis/', views.projekt_gap_analysis, name='projekt_gap_analysis'),
     path('work/projekte/<int:pk>/summary/', views.projekt_management_summary, name='projekt_management_summary'),
     path('projects/<int:pk>/', views.project_detail_api, name='project_detail_api'),

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -27,6 +27,7 @@
         Anlage {{ a.anlage_nr }}:
         <a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name }}</a>
         <button data-url="{% url 'projekt_file_check_pk' a.pk %}" class="anlage-check-btn bg-green-600 text-white px-2 py-1 rounded ml-2">Prüfen</button>
+        <a href="{% url 'projekt_file_edit_json' a.pk %}" class="text-blue-700 underline ml-2">Analyse bearbeiten</a>
         {% if a.manual_comment %}<div class="italic">{{ a.manual_comment }}</div>{% endif %}
     </li>
     {% empty %}

--- a/templates/projekt_file_json_form.html
+++ b/templates/projekt_file_json_form.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Analyse bearbeiten{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Analyse f\u00fcr Anlage {{ anlage.anlage_nr }} bearbeiten</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.analysis_json.label_tag }}<br>
+        {{ form.analysis_json }}
+        {{ form.analysis_json.errors }}
+    </div>
+    <div>
+        {{ form.manual_analysis_json.label_tag }}<br>
+        {{ form.manual_analysis_json }}
+        {{ form.manual_analysis_json.errors }}
+    </div>
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow editing of analysis JSON for `BVProjectFile`
- link to the edit page from project detail
- validate JSON via form and persist changes
- test editing and error handling

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6843540fce28832ba5f5bfd7151c662f