### PR TITLE
Implement Gutachten view

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -53,15 +53,16 @@ def classify_system(projekt_id: int) -> dict:
     return data
 
 
-def generate_gutachten(projekt_id: int) -> Path:
+def generate_gutachten(projekt_id: int, text: str | None = None) -> Path:
     """Erstellt ein Gutachten-Dokument mithilfe eines LLM."""
     projekt = BVProject.objects.get(pk=projekt_id)
-    prefix = get_prompt(
-        "generate_gutachten",
-        "Erstelle ein kurzes Gutachten basierend auf diesen Unterlagen:\n\n",
-    )
-    prompt = prefix + _collect_text(projekt)
-    text = query_llm(prompt)
+    if text is None:
+        prefix = get_prompt(
+            "generate_gutachten",
+            "Erstelle ein kurzes Gutachten basierend auf diesen Unterlagen:\n\n",
+        )
+        prompt = prefix + _collect_text(projekt)
+        text = query_llm(prompt)
     doc = Document()
     for line in text.splitlines():
         doc.add_paragraph(line)

--- a/core/urls.py
+++ b/core/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path('work/anlage/<int:pk>/edit-json/', views.projekt_file_edit_json, name='projekt_file_edit_json'),
     path('work/projekte/<int:pk>/gap-analysis/', views.projekt_gap_analysis, name='projekt_gap_analysis'),
     path('work/projekte/<int:pk>/summary/', views.projekt_management_summary, name='projekt_management_summary'),
+    path('work/projekte/<int:pk>/gutachten/', views.projekt_gutachten, name='projekt_gutachten'),
     path('projects/<int:pk>/', views.project_detail_api, name='project_detail_api'),
     path('projects/<int:pk>/llm-check/', views.project_llm_check, name='project_llm_check'),
     path('login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -16,6 +16,14 @@
     <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded ml-2">Aktualisieren</button>
 </form>
 <p class="mb-4">
+    <a href="{% url 'projekt_gutachten' projekt.pk %}" class="text-blue-700 underline">
+        {% if projekt.gutachten_file %}Gutachten bearbeiten{% else %}Gutachten erstellen{% endif %}
+    </a>
+    {% if projekt.gutachten_file %}|
+    <a href="{{ projekt.gutachten_file.url }}" class="text-blue-700 underline">Download</a>
+    {% endif %}
+</p>
+<p class="mb-4">
     <a href="{% url 'projekt_gap_analysis' projekt.pk %}" class="text-blue-700 underline">Gap-Analyse herunterladen</a>
     |
     <a href="{% url 'projekt_management_summary' projekt.pk %}" class="text-blue-700 underline">Management Summary herunterladen</a>

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block title %}Gutachten erstellen{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    <textarea name="prompt" rows="15" class="w-full border rounded p-2">{{ prompt }}</textarea>
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">LLM starten</button>
+</form>
+{% if projekt.gutachten_file %}
+<p class="mt-4">
+    <a href="{{ projekt.gutachten_file.url }}" class="text-blue-700 underline">Gutachten herunterladen</a>
+</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow passing text to `generate_gutachten`
- add view and route for creating project report
- show Gutachten links in project detail
- provide form template for Gutachten
- cover Gutachten view via tests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68435df8de94832b96ac17275c0012f3