### PR TITLE
Add admin delete button for projects

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -36,6 +36,18 @@ class AdminProjectsTests(TestCase):
         self.assertFalse(BVProject.objects.filter(id=self.p1.id).exists())
         self.assertTrue(BVProject.objects.filter(id=self.p2.id).exists())
 
+    def test_delete_single_project(self):
+        url = reverse("admin_project_delete", args=[self.p2.id])
+        resp = self.client.post(url)
+        self.assertRedirects(resp, reverse("admin_projects"))
+        self.assertFalse(BVProject.objects.filter(id=self.p2.id).exists())
+
+    def test_delete_single_requires_post(self):
+        url = reverse("admin_project_delete", args=[self.p1.id])
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 405)
+        self.assertTrue(BVProject.objects.filter(id=self.p1.id).exists())
+
 
 
 class DocxExtractTests(TestCase):

--- a/core/urls.py
+++ b/core/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path('transcribe/<int:pk>/', views.transcribe_recording, name='transcribe_recording'),
     path('talkdiary-admin/', views.admin_talkdiary, name='admin_talkdiary'),
     path('projects-admin/', views.admin_projects, name='admin_projects'),
+    path('projects-admin/<int:pk>/delete/', views.admin_project_delete, name='admin_project_delete'),
     path('work/projekte/', views.projekt_list, name='projekt_list'),
     path('work/projekte/neu/', views.projekt_create, name='projekt_create'),
     path('work/projekte/upload/', views.projekt_upload, name='projekt_upload'),

--- a/core/views.py
+++ b/core/views.py
@@ -540,6 +540,19 @@ def admin_projects(request):
 
 
 @login_required
+@admin_required
+@require_http_methods(["POST"])
+def admin_project_delete(request, pk):
+    """Löscht ein einzelnes Projekt."""
+    try:
+        projekt = BVProject.objects.get(pk=pk)
+    except BVProject.DoesNotExist:
+        raise Http404
+    projekt.delete()
+    return redirect("admin_projects")
+
+
+@login_required
 def projekt_list(request):
     projekte = BVProject.objects.all().order_by("-created_at")
     context = {

--- a/templates/admin_projects.html
+++ b/templates/admin_projects.html
@@ -12,6 +12,7 @@
                 <th class="py-2">Software-Typen</th>
                 <th class="py-2">Status</th>
                 <th class="py-2">LLM geprüft</th>
+                <th class="py-2 text-center">Aktion</th>
                 <th class="py-2 text-center">Löschen</th>
             </tr>
         </thead>
@@ -23,10 +24,17 @@
                 <td class="py-1">{{ p.software_typen }}</td>
                 <td class="py-1">{{ p.get_status_display }}</td>
                 <td class="py-1">{{ p.llm_geprueft|yesno:'Ja,Nein' }}</td>
+                <td class="py-1 text-center">
+                    <a href="{% url 'projekt_edit' p.pk %}" class="px-2 py-1 bg-blue-600 text-white rounded mr-2">Bearbeiten</a>
+                    <form action="{% url 'admin_project_delete' p.pk %}" method="post" class="inline">
+                        {% csrf_token %}
+                        <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Projekt wirklich löschen?');">Löschen</button>
+                    </form>
+                </td>
                 <td class="py-1 text-center"><input type="checkbox" name="delete" value="{{ p.id }}" class="form-checkbox"></td>
             </tr>
         {% empty %}
-            <tr><td colspan="6" class="py-2">Keine Projekte</td></tr>
+            <tr><td colspan="7" class="py-2">Keine Projekte</td></tr>
         {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- allow editing/deleting each project in admin list
- implement `admin_project_delete` view
- route `/projects-admin/<pk>/delete/`
- test single project delete via new route

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68436042727c832b9cb4c4938ba7c7f9