### PR TITLE
Add prompt admin view

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -176,6 +176,28 @@ class PromptTests(TestCase):
         self.assertEqual(get_prompt("classify_system", "x"), "DB")
 
 
+class AdminPromptsViewTests(TestCase):
+    def setUp(self):
+        admin_group = Group.objects.create(name="admin")
+        self.user = User.objects.create_user("padmin", password="pass")
+        self.user.groups.add(admin_group)
+        self.client.login(username="padmin", password="pass")
+        self.prompt = Prompt.objects.create(name="p1", text="orig")
+
+    def test_update_prompt(self):
+        url = reverse("admin_prompts")
+        resp = self.client.post(url, {"pk": self.prompt.id, "text": "neu", "action": "save"})
+        self.assertRedirects(resp, url)
+        self.prompt.refresh_from_db()
+        self.assertEqual(self.prompt.text, "neu")
+
+    def test_delete_prompt(self):
+        url = reverse("admin_prompts")
+        resp = self.client.post(url, {"pk": self.prompt.id, "action": "delete"})
+        self.assertRedirects(resp, url)
+        self.assertFalse(Prompt.objects.filter(id=self.prompt.id).exists())
+
+
 class ReportingTests(TestCase):
     def test_gap_analysis_file_created(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")

--- a/core/urls.py
+++ b/core/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path('talkdiary-admin/', views.admin_talkdiary, name='admin_talkdiary'),
     path('projects-admin/', views.admin_projects, name='admin_projects'),
     path('projects-admin/<int:pk>/delete/', views.admin_project_delete, name='admin_project_delete'),
+    path('projects-admin/prompts/', views.admin_prompts, name='admin_prompts'),
     path('work/projekte/', views.projekt_list, name='projekt_list'),
     path('work/projekte/neu/', views.projekt_create, name='projekt_create'),
     path('work/projekte/upload/', views.projekt_upload, name='projekt_upload'),

--- a/templates/admin_projects.html
+++ b/templates/admin_projects.html
@@ -2,6 +2,7 @@
 {% block title %}Admin Projekte{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Admin Projekte</h1>
+<a href="{% url 'admin_prompts' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded">Prompts verwalten</a>
 <form method="post">
     {% csrf_token %}
     <table class="min-w-full">

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block title %}Admin Prompts{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Admin Prompts</h1>
+<table class="min-w-full">
+    <thead>
+        <tr class="border-b text-left">
+            <th class="py-2">Name</th>
+            <th class="py-2">Text</th>
+            <th class="py-2 text-center">Aktion</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for p in prompts %}
+        <tr class="border-b align-top text-sm">
+            <td class="py-1 font-semibold">{{ p.name }}</td>
+            <td class="py-1">
+                <form method="post" class="space-y-2">
+                    {% csrf_token %}
+                    <input type="hidden" name="pk" value="{{ p.id }}">
+                    <textarea name="text" rows="4" class="border rounded p-2 w-full">{{ p.text }}</textarea>
+                    <button name="action" value="save" class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
+                </form>
+            </td>
+            <td class="py-1 text-center">
+                <form method="post" class="inline">
+                    {% csrf_token %}
+                    <input type="hidden" name="pk" value="{{ p.id }}">
+                    <input type="hidden" name="action" value="delete">
+                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Prompt wirklich löschen?');">Löschen</button>
+                </form>
+            </td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="3" class="py-2">Keine Prompts</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a new admin view for editing and deleting prompt entries
- route `/projects-admin/prompts/` for the new page
- show link from project admin to prompt administration
- create template for managing prompts
- test updating and deleting prompts

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6843622192c8832bb060e030880496bb