### PR TITLE
Add editable flag handling for LLM data

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -16,6 +16,13 @@ from docx import Document
 logger = logging.getLogger(__name__)
 
 
+def _add_editable_flags(data: dict) -> dict:
+    """Ergänzt jedes Feld eines Dictionaries um ein ``editable``-Flag."""
+    if isinstance(data, dict):
+        return {k: {"value": v, "editable": True} for k, v in data.items()}
+    return data
+
+
 def get_prompt(name: str, default: str) -> str:
     """Lade einen Prompt-Text aus der Datenbank."""
     try:
@@ -47,6 +54,7 @@ def classify_system(projekt_id: int, model_name: str | None = None) -> dict:
     except Exception:  # noqa: BLE001
         logger.warning("LLM Antwort kein JSON: %s", reply)
         data = {"raw": reply}
+    data = _add_editable_flags(data)
     projekt.classification_json = data
     projekt.status = BVProject.STATUS_CLASSIFIED
     projekt.save(update_fields=["classification_json", "status"])
@@ -103,6 +111,7 @@ def _check_anlage(projekt_id: int, nr: int, model_name: str | None = None) -> di
     except Exception:  # noqa: BLE001
         data = {"raw": reply}
 
+    data = _add_editable_flags(data)
     anlage.analysis_json = data
     anlage.save(update_fields=["analysis_json"])
     return data

--- a/core/reporting.py
+++ b/core/reporting.py
@@ -10,6 +10,13 @@ from docx import Document
 from .models import BVProject
 
 
+def _get_value(obj):
+    """Extrahiert den Wert aus Strukturen mit ``{"value": x}``."""
+    if isinstance(obj, dict) and "value" in obj:
+        return obj["value"]
+    return obj
+
+
 def _add_json_section(doc: Document, title: str, data: dict | list | str) -> None:
     """F\u00fcgt einen Abschnitt mit JSON-Daten hinzu."""
     doc.add_heading(title, level=2)
@@ -53,8 +60,8 @@ def generate_management_summary(project: BVProject) -> Path:
 
     if project.classification_json:
         data = project.classification_json
-        cat = data.get("kategorie") if isinstance(data, dict) else None
-        begr = data.get("begruendung") if isinstance(data, dict) else None
+        cat = _get_value(data.get("kategorie")) if isinstance(data, dict) else None
+        begr = _get_value(data.get("begruendung")) if isinstance(data, dict) else None
         doc.add_heading("Klassifizierung", level=2)
         if cat:
             doc.add_paragraph(f"Kategorie: {cat}")


### PR DESCRIPTION
## Summary
- add `_add_editable_flags` helper in `llm_tasks`
- wrap LLM JSON results with editable information
- add `_get_value` helper in reporting
- adjust reporting and tests for new structure

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68444f292d48832ba101d93509d28abb