### PR TITLE
Add result view for attachment check

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('work/projekte/<int:pk>/status/', views.projekt_status_update, name='projekt_status_update'),
     path('work/projekte/<int:pk>/anlage/<int:nr>/check/', views.projekt_file_check, name='projekt_file_check'),
     path('work/anlage/<int:pk>/check/', views.projekt_file_check_pk, name='projekt_file_check_pk'),
+    path('work/anlage/<int:pk>/check-view/', views.projekt_file_check_view, name='projekt_file_check_view'),
     path('work/anlage/<int:pk>/edit-json/', views.projekt_file_edit_json, name='projekt_file_edit_json'),
     path('work/projekte/<int:pk>/gap-analysis/', views.projekt_gap_analysis, name='projekt_gap_analysis'),
     path('work/projekte/<int:pk>/summary/', views.projekt_management_summary, name='projekt_management_summary'),

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -39,7 +39,7 @@
     <li class="mb-2">
         Anlage {{ a.anlage_nr }}:
         <a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name }}</a>
-        <button data-url="{% url 'projekt_file_check_pk' a.pk %}" class="anlage-check-btn bg-green-600 text-white px-2 py-1 rounded ml-2">Prüfen</button>
+        <a href="{% url 'projekt_file_check_view' a.pk %}" class="bg-green-600 text-white px-2 py-1 rounded ml-2">Prüfen</a>
         <a href="{% url 'projekt_file_edit_json' a.pk %}" class="text-blue-700 underline ml-2">Analyse bearbeiten</a>
         {% if a.manual_comment %}<div class="italic">{{ a.manual_comment }}</div>{% endif %}
     </li>
@@ -117,16 +117,5 @@ function sendCheck(payload){
 }
 
 document.addEventListener('DOMContentLoaded',loadLLM);
-document.addEventListener('DOMContentLoaded',()=>{
-  document.querySelectorAll('.anlage-check-btn').forEach(btn=>{
-    btn.addEventListener('click',ev=>{
-      ev.preventDefault();
-      fetch(btn.dataset.url,{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')}})
-      .then(r=>r.json()).then(d=>{
-        if(d.status==='ok'){alert('Anlage geprüft');}else{alert('Fehler bei der Anlagenprüfung');}
-      }).catch(()=>alert('Fehler bei der Anlagenprüfung'));
-    });
-  });
-});
 </script>
 {% endblock %}

--- a/templates/projekt_file_check_result.html
+++ b/templates/projekt_file_check_result.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block title %}Pr\u00fcfergebnis{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Pr\u00fcfergebnis f\u00fcr Anlage {{ anlage.anlage_nr }}</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.analysis_json.label_tag }}<br>
+        {{ form.analysis_json }}
+        {{ form.analysis_json.errors }}
+    </div>
+    <div>
+        {{ form.manual_analysis_json.label_tag }}<br>
+        {{ form.manual_analysis_json }}
+        {{ form.manual_analysis_json.errors }}
+    </div>
+    <div class="space-x-2">
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+        <a href="{% url 'projekt_detail' anlage.projekt.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zur\u00fcck</a>
+        <button type="button" id="copy-email" class="bg-green-600 text-white px-4 py-2 rounded">E-Mail kopieren</button>
+    </div>
+</form>
+<script>
+document.getElementById('copy-email').addEventListener('click', function(){
+    const analysis = document.getElementById('{{ form.analysis_json.id_for_label }}').value;
+    const manual = document.getElementById('{{ form.manual_analysis_json.id_for_label }}').value;
+    const text = `Pr\u00fcfergebnis Anlage {{ anlage.anlage_nr }}\n\nAnalyse:\n${analysis}\n\nManuelle Analyse:\n${manual}`;
+    navigator.clipboard.writeText(text).then(()=>alert('In Zwischenablage kopiert'));
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- show result of attachment checks on a new page
- link from project details to the new view
- allow copying info for email
- add tests for new behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68445e148c80832b92b645e5b7d36148