### PR TITLE
Hybride Analyse für Anlage 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ Der Aufruf
 python manage.py check_anlage1 <projekt_id>
 ```
 
-löst die Gemini-basierte Analyse der Systembeschreibung aus. Das Ergebnis wird
-als JSON in der zugehörigen Anlage gespeichert.
+führt eine hybride Analyse der Systembeschreibung durch. Zuerst versucht ein
+einfacher Parser, strukturierte Frage-Antwort-Formate direkt auszulesen. Nur
+wenn das fehlschlägt, wird die Gemini-basierte LLM-Analyse gestartet. Das
+Ergebnis wird als JSON in der zugehörigen Anlage gespeichert.
 
 ### Kachel-Zugriff verwalten
 


### PR DESCRIPTION
## Summary
- ergänze `parse_structured_anlage` um strukturierte Dokumente ohne LLM zu parsen
- erweitere `check_anlage1` um Parser-Fallback
- dokumentiere hybriden Ablauf im README
- teste den Parser in der Test-Suite

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6844b78497ac832b90b52c1241c447c0