### PR TITLE
Implement new parser for Anlage 1

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -228,7 +228,10 @@ class LLMTasksTests(TestCase):
 
     def test_check_anlage1_parser(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        text = "1.->Q1?\u00b6A1\u00b62.->Q2?\u00b6A2"
+        text = (
+            "Frage 1: Extrahiere alle Unternehmen als Liste.\u00b6A1\u00b6"
+            "Frage 2: Extrahiere alle Fachbereiche als Liste.\u00b6A2"
+        )
         BVProjectFile.objects.create(
             projekt=projekt,
             anlage_nr=1,


### PR DESCRIPTION
## Summary
- add `parse_anlage1_questions` to detect answers by question text
- use the new parser in `check_anlage1`
- adjust unit test for the parser

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6845623d43a0832bbcd9dfb90edea692