### PR TITLE
Add extended review fields

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -3,6 +3,14 @@ from pathlib import Path
 from .models import Recording, BVProject, BVProjectFile
 
 
+# Auswahloptionen für die Bewertung einer Frage in Anlage 1
+REVIEW_STATUS_CHOICES = [
+    ("ok", "ok"),
+    ("unklar", "unklar"),
+    ("unvollständig", "unvollständig"),
+]
+
+
 class RecordingForm(forms.ModelForm):
     class Meta:
         model = Recording
@@ -159,17 +167,43 @@ class Anlage1ReviewForm(forms.Form):
                 label=f"Frage {i} Kommentar",
                 widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
             )
+            self.fields[f"q{i}_status"] = forms.ChoiceField(
+                required=False,
+                choices=REVIEW_STATUS_CHOICES,
+                label=f"Frage {i} Status",
+                widget=forms.Select(attrs={"class": "border rounded p-2"}),
+            )
+            self.fields[f"q{i}_hinweis"] = forms.CharField(
+                required=False,
+                label=f"Frage {i} Hinweis",
+                widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
+            )
+            self.fields[f"q{i}_vorschlag"] = forms.CharField(
+                required=False,
+                label=f"Frage {i} Vorschlag",
+                widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
+            )
             self.initial[f"q{i}_ok"] = data.get(str(i), {}).get("ok", False)
             self.initial[f"q{i}_note"] = data.get(str(i), {}).get("note", "")
+            self.initial[f"q{i}_status"] = data.get(str(i), {}).get("status", "")
+            self.initial[f"q{i}_hinweis"] = data.get(str(i), {}).get("hinweis", "")
+            self.initial[f"q{i}_vorschlag"] = data.get(str(i), {}).get("vorschlag", "")
 
     def get_json(self) -> dict:
         out = {}
         if not self.is_valid():
             return out
         for i in range(1, 10):
-            out[str(i)] = {
-                "ok": self.cleaned_data.get(f"q{i}_ok", False),
-                "note": self.cleaned_data.get(f"q{i}_note", ""),
+            key = str(i)
+            q_data: dict[str, object] = {
+                "status": self.cleaned_data.get(f"q{i}_status", ""),
+                "hinweis": self.cleaned_data.get(f"q{i}_hinweis", ""),
+                "vorschlag": self.cleaned_data.get(f"q{i}_vorschlag", ""),
             }
+            if f"q{i}_ok" in self.cleaned_data:
+                q_data["ok"] = self.cleaned_data.get(f"q{i}_ok", False)
+            if f"q{i}_note" in self.cleaned_data:
+                q_data["note"] = self.cleaned_data.get(f"q{i}_note", "")
+            out[key] = q_data
         return out
 

--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -238,6 +238,8 @@ def check_anlage1(projekt_id: int, model_name: str | None = None) -> dict:
             data = json.loads(reply)
         except Exception:  # noqa: BLE001
             data = {"raw": reply}
+        if data.get("task") != "check_anlage1":
+            data = {"task": "check_anlage1"}
 
         def _val(key: str):
             if isinstance(data.get(key), dict) and "value" in data[key]:

--- a/core/tests.py
+++ b/core/tests.py
@@ -489,6 +489,23 @@ class ProjektFileJSONEditTests(TestCase):
         self.assertTrue(self.anlage1.question_review["1"]["ok"])
         self.assertEqual(self.anlage1.question_review["1"]["note"], "Hinweis")
 
+    def test_question_review_extended_fields_saved(self):
+        url = reverse("projekt_file_edit_json", args=[self.anlage1.pk])
+        resp = self.client.post(
+            url,
+            {
+                "q1_status": "unvollst\u00e4ndig",
+                "q1_hinweis": "Fehlt",
+                "q1_vorschlag": "Mehr Infos",
+            },
+        )
+        self.assertRedirects(resp, reverse("projekt_detail", args=[self.projekt.pk]))
+        self.anlage1.refresh_from_db()
+        data = self.anlage1.question_review["1"]
+        self.assertEqual(data["status"], "unvollst\u00e4ndig")
+        self.assertEqual(data["hinweis"], "Fehlt")
+        self.assertEqual(data["vorschlag"], "Mehr Infos")
+
 
 class ProjektGutachtenViewTests(TestCase):
     def setUp(self):

--- a/core/views.py
+++ b/core/views.py
@@ -903,7 +903,16 @@ def projekt_file_edit_json(request, pk):
         for i in range(1, 10):
             answers[str(i)] = q_data.get(str(i), {}).get("answer", "")
         qa = [
-            (i, answers.get(str(i), ""), form[f"q{i}_ok"], form[f"q{i}_note"]) for i in range(1, 10)
+            (
+                i,
+                answers.get(str(i), ""),
+                form[f"q{i}_status"],
+                form[f"q{i}_hinweis"],
+                form[f"q{i}_vorschlag"],
+                form[f"q{i}_ok"],
+                form[f"q{i}_note"],
+            )
+            for i in range(1, 10)
         ]
     else:
         if request.method == "POST":

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -9,15 +9,21 @@
             <tr>
                 <th class="border px-2">Frage</th>
                 <th class="border px-2">Antwort</th>
+                <th class="border px-2">Status</th>
+                <th class="border px-2">Hinweis</th>
+                <th class="border px-2">Vorschlag</th>
                 <th class="border px-2">OK</th>
                 <th class="border px-2">Kommentar</th>
             </tr>
         </thead>
         <tbody>
-        {% for num, ans, ok_field, note_field in qa %}
+        {% for num, ans, status_field, hinweis_field, vorschlag_field, ok_field, note_field in qa %}
             <tr>
                 <td class="border px-2">{{ num }}</td>
                 <td class="border px-2">{{ ans }}</td>
+                <td class="border px-2">{{ status_field }}</td>
+                <td class="border px-2">{{ hinweis_field }}</td>
+                <td class="border px-2">{{ vorschlag_field }}</td>
                 <td class="border px-2">{{ ok_field }}</td>
                 <td class="border px-2">{{ note_field }}</td>
             </tr>


### PR DESCRIPTION
## Summary
- add `REVIEW_STATUS_CHOICES` for Anlage1 review
- extend `Anlage1ReviewForm` with status/hinweis/vorschlag fields
- return new data in `get_json`
- display extra fields in Anlage1 review template
- adjust view logic
- ensure LLM result without task key defaults to minimal data
- test saving of new fields

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: test_check_anlage1_new_schema)*

------
https://chatgpt.com/codex/tasks/task_e_684574b956dc832bafe4a7538f98cb60