### PR TITLE
Adjust tests for extended review fields

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -213,7 +213,7 @@ class LLMTasksTests(TestCase):
         with patch("core.llm_tasks.query_llm", side_effect=[llm_reply] + [eval_reply] * 9):
             data = check_anlage1(projekt.pk)
         file_obj = projekt.anlagen.get(anlage_nr=1)
-        answers = ["ACME", "IT", [], "raw", "Zweck", [], [], [], ""]
+        answers = [["ACME"], ["IT"], "leer", "raw", "Zweck", "leer", "leer", "leer", "leer"]
         expected["questions"] = {
             str(i): {
                 "answer": answers[i - 1],


### PR DESCRIPTION
## Summary
- update `test_check_anlage1_new_schema` to match the new output format

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6845782af42c832ba594924d015f3f75