### PR TITLE
Parser toleriert Sonderzeichen

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -89,6 +89,15 @@ def parse_structured_anlage(text_content: str) -> dict | None:
     return parsed if parsed else None
 
 
+def _clean_text(text: str) -> str:
+    """Bereinigt Sonderzeichen vor dem Parsen."""
+    text = text.replace("\\n", " ")
+    text = text.replace("\n", " ").replace("\r", " ").replace("\t", " ")
+    text = text.replace("\u00b6", " ")
+    text = re.sub(r" {2,}", " ", text)
+    return text.strip()
+
+
 def parse_anlage1_questions(text_content: str) -> dict | None:
     """Sucht die Texte der Anlage-1-Fragen und extrahiert die Antworten."""
     logger.debug(
@@ -99,6 +108,8 @@ def parse_anlage1_questions(text_content: str) -> dict | None:
         logger.debug("parse_anlage1_questions: Kein Text übergeben.")
         return None
 
+    text_content = _clean_text(text_content)
+
     questions = list(
         Anlage1Question.objects.filter(enabled=True).order_by("num")
     )
@@ -108,7 +119,7 @@ def parse_anlage1_questions(text_content: str) -> dict | None:
 
     matches: list[tuple[int, int, int]] = []
     for q in questions:
-        pattern = re.escape(q.text)
+        pattern = re.escape(_clean_text(q.text))
         m = re.search(pattern, text_content)
         if m:
             matches.append((m.start(), m.end(), q.num))

--- a/core/tests.py
+++ b/core/tests.py
@@ -299,6 +299,15 @@ class LLMTasksTests(TestCase):
         parsed = parse_anlage1_questions(text)
         self.assertEqual(parsed, {"1": "A1", "2": "A2"})
 
+    def test_parse_anlage1_questions_with_newlines(self):
+        """Extraktion funktioniert trotz Zeilenumbr\u00fcche."""
+        text = (
+            "Frage 1:\nExtrahiere alle Unternehmen als Liste.\nA1\n"
+            "Frage 2:\nExtrahiere alle Fachbereiche als Liste.\nA2"
+        )
+        parsed = parse_anlage1_questions(text)
+        self.assertEqual(parsed, {"1": "A1", "2": "A2"})
+
     def test_generate_gutachten_twice_replaces_file(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         first = generate_gutachten(projekt.pk, text="Alt")


### PR DESCRIPTION
## Summary
- entferne Zeilenumbrüche vor dem Parsen von Anlage 1
- neue Tests decken die Bereinigung ab

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6845b0e08a64832baaaadade8b497d95