### PR TITLE
Allow per-question LLM toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,13 @@ Der Aufruf
 python manage.py check_anlage1 42
 ```
 
-führt eine hybride Analyse der Systembeschreibung durch. Der Parser sucht dabei
-nach jeder im Admin hinterlegten Frage im Text und verwendet den
-darauffolgenden Abschnitt als Antwort. Nur wenn dieser Ansatz scheitert, wird
-die Gemini‑basierte LLM-Analyse gestartet. Das Ergebnis wird als JSON in der
-zugehörigen Anlage gespeichert. Das JSON enthält für jede der neun Fragen neben
-der Antwort die Felder `status`, `hinweis` und `vorschlag`. Diese lassen sich
-nachträglich im Webinterface anpassen und dokumentieren die manuelle
-Bewertung.
+führt eine hybride Analyse der Systembeschreibung durch. Zunächst versucht der
+Parser zu jeder im Admin hinterlegten Frage eine Antwort direkt aus dem Text zu
+extrahieren. Anschließend werden – abhängig von den Einstellungen – einzelne
+Fragen zusätzlich einem LLM vorgelegt. Das Ergebnis wird als JSON in der
+zugehörigen Anlage gespeichert. Für jede Frage enthält es neben der Antwort die
+Felder `status`, `hinweis` und `vorschlag`. Diese lassen sich nachträglich im
+Webinterface anpassen und dokumentieren die manuelle Bewertung.
 
 Im Admin-Bereich kann pro Frage separat festgelegt werden, ob sie beim
 Parserlauf (`parser_enabled`) und/oder bei der LLM-Auswertung

--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -258,15 +258,14 @@ def check_anlage1(projekt_id: int, model_name: str | None = None) -> dict:
 
     cfg = Anlage1Config.objects.first()
 
-    # Eine Frage gilt nur dann als aktiv, wenn sowohl ``q.llm_enabled`` als auch
-    # das entsprechende Flag in ``Anlage1Config`` gesetzt sind.
-    def _is_enabled(q: Anlage1Question) -> bool:
+    # Ermittele separat, welche Fragen für das LLM aktiviert sind.
+    def _llm_enabled(q: Anlage1Question) -> bool:
         enabled = q.llm_enabled
         if cfg:
             enabled = enabled and getattr(cfg, f"enable_q{q.num}", True)
         return enabled
 
-    question_objs = [q for q in question_objs if _is_enabled(q)]
+    llm_questions = [q for q in question_objs if _llm_enabled(q)]
 
     # Debug-Log für den zu parsenden Text
     logger.debug("check_anlage1: Zu parsende Anlage1 text_content (ersten 500 Zeichen): %r", anlage.text_content[:500] if anlage.text_content else None)
@@ -281,7 +280,7 @@ def check_anlage1(projekt_id: int, model_name: str | None = None) -> dict:
         data = {"task": "check_anlage1", "source": "parser"}
     else:
         parts = [_ANLAGE1_INTRO]
-        for q in question_objs:
+        for q in llm_questions:
             parts.append(get_prompt(f"anlage1_q{q.num}", q.text) + "\n")
         insert_at = 3 if len(parts) > 2 else len(parts)
         parts.insert(insert_at, _ANLAGE1_IT)
@@ -325,10 +324,7 @@ def check_anlage1(projekt_id: int, model_name: str | None = None) -> dict:
         if ans in (None, "", []):
             ans = "leer"
         q_data = {"answer": ans, "status": None, "hinweis": "", "vorschlag": ""}
-        enabled = q.llm_enabled
-        if cfg:
-            enabled = enabled and getattr(cfg, f"enable_q{q.num}", True)
-        if enabled:
+        if _llm_enabled(q):
             prompt = _ANLAGE1_EVAL.format(
                 num=q.num, question=q.text, answer=ans
             )

--- a/core/tests.py
+++ b/core/tests.py
@@ -356,7 +356,8 @@ class LLMTasksTests(TestCase):
             data = check_anlage1(projekt.pk)
         prompt = mock_q.call_args_list[0].args[0]
         self.assertNotIn("Frage 1", prompt)
-        self.assertNotIn("1", data["questions"])
+        self.assertIn("1", data["questions"])
+        self.assertIsNone(data["questions"]["1"]["status"])
 
 
 class PromptTests(TestCase):


### PR DESCRIPTION
## Summary
- let `check_anlage1` always record parser results
- evaluate answers via LLM only for enabled questions
- update test to reflect new behaviour
- clarify README about optional LLM step

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6845cf14bf74832b9ea605b1f7db1be0