### PR TITLE
Add email helper to project analysis

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -168,12 +168,12 @@ class Anlage1ReviewForm(forms.Form):
         for i in get_anlage1_numbers():
             self.fields[f"q{i}_ok"] = forms.BooleanField(
                 required=False,
-                label=f"Frage {i} ok",
+                label=f"Frage {i} geprüft und in Ordnung",
                 widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
             )
             self.fields[f"q{i}_note"] = forms.CharField(
                 required=False,
-                label=f"Frage {i} Kommentar",
+                label=f"Frage {i} Kommentar intern",
                 widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
             )
             self.fields[f"q{i}_status"] = forms.ChoiceField(
@@ -184,12 +184,12 @@ class Anlage1ReviewForm(forms.Form):
             )
             self.fields[f"q{i}_hinweis"] = forms.CharField(
                 required=False,
-                label=f"Frage {i} Hinweis",
+                label=f"Frage {i} Hinweise PMO",
                 widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
             )
             self.fields[f"q{i}_vorschlag"] = forms.CharField(
                 required=False,
-                label=f"Frage {i} Vorschlag",
+                label=f"Frage {i} Vorschlag an Fachbereich",
                 widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
             )
             self.initial[f"q{i}_ok"] = data.get(str(i), {}).get("ok", False)

--- a/core/tests.py
+++ b/core/tests.py
@@ -753,6 +753,26 @@ class AdminModelsViewTests(TestCase):
         self.assertEqual(self.cfg.anlagen_model, "b")
 
 
+class Anlage1EmailTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("emailer", password="pass")
+        self.client.login(username="emailer", password="pass")
+        self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        self.file = BVProjectFile.objects.create(
+            projekt=self.projekt,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("a.txt", b"data"),
+            question_review={"1": {"vorschlag": "Text"}},
+        )
+
+    def test_generate_email(self):
+        url = reverse("anlage1_generate_email", args=[self.file.pk])
+        with patch("core.views.query_llm", return_value="Mail"):
+            resp = self.client.post(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["text"], "Mail")
+
+
 
 class TileVisibilityTests(TestCase):
     def setUp(self):

--- a/core/urls.py
+++ b/core/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path('work/anlage/<int:pk>/check/', views.projekt_file_check_pk, name='projekt_file_check_pk'),
     path('work/anlage/<int:pk>/check-view/', views.projekt_file_check_view, name='projekt_file_check_view'),
     path('work/anlage/<int:pk>/edit-json/', views.projekt_file_edit_json, name='projekt_file_edit_json'),
+    path('work/anlage/<int:pk>/email/', views.anlage1_generate_email, name='anlage1_generate_email'),
     path('work/projekte/<int:pk>/gap-analysis/', views.projekt_gap_analysis, name='projekt_gap_analysis'),
     path('work/projekte/<int:pk>/summary/', views.projekt_management_summary, name='projekt_management_summary'),
     path('work/projekte/<int:pk>/gutachten/', views.projekt_gutachten, name='projekt_gutachten'),

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -11,10 +11,10 @@
                 <th class="border px-2">Frage</th>
                 <th class="border px-2">Antwort</th>
                 <th class="border px-2">Status</th>
-                <th class="border px-2">Hinweis</th>
-                <th class="border px-2">Vorschlag</th>
-                <th class="border px-2">OK</th>
-                <th class="border px-2">Kommentar</th>
+                <th class="border px-2">Hinweise PMO</th>
+                <th class="border px-2">Vorschlag an Fachbereich</th>
+                <th class="border px-2">geprüft und in Ordnung</th>
+                <th class="border px-2">Kommentar intern</th>
             </tr>
         </thead>
         <tbody>
@@ -32,6 +32,23 @@
         {% endfor %}
         </tbody>
     </table>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    <div class="space-x-2 mt-2">
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+        <button type="button" id="generate-email" class="bg-green-600 text-white px-4 py-2 rounded">E-Mail generieren</button>
+    </div>
 </form>
+<script>
+function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
+document.getElementById('generate-email').addEventListener('click', function(){
+    const btn=this;btn.disabled=true;
+    fetch('{% url "anlage1_generate_email" anlage.pk %}', {
+        method:'POST',
+        headers:{'X-CSRFToken':getCookie('csrftoken')}
+    }).then(r=>r.json()).then(data=>{
+        btn.disabled=false;
+        if(data.text){navigator.clipboard.writeText(data.text).then(()=>alert('E-Mail Text kopiert'));}
+        else if(data.error){alert('Fehler: '+data.error);}
+    }).catch(()=>{btn.disabled=false;alert('Fehler bei der Generierung');});
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- update labels in `Anlage1ReviewForm`
- rename columns and add email button in the review template
- implement view to generate an email text using LLM
- expose new endpoint in `urls.py`
- add test for email generation

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6845e045926c832b9af4e233961b727e