### PR TITLE
Add deletion of project attachments

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -671,6 +671,27 @@ class GutachtenEditDeleteTests(TestCase):
         self.assertFalse(path.exists())
 
 
+class ProjektFileDeleteTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("deluser", password="pass")
+        self.client.login(username="deluser", password="pass")
+        self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        self.file = BVProjectFile.objects.create(
+            projekt=self.projekt,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("a.txt", b"data"),
+            text_content="Text",
+        )
+
+    def test_delete_removes_file(self):
+        path = Path(self.file.upload.path)
+        url = reverse("projekt_file_delete", args=[self.file.pk])
+        resp = self.client.post(url)
+        self.assertRedirects(resp, reverse("projekt_detail", args=[self.projekt.pk]))
+        self.assertFalse(BVProjectFile.objects.filter(pk=self.file.pk).exists())
+        self.assertFalse(path.exists())
+
+
 class ProjektFileCheckResultTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user("vuser", password="pass")

--- a/core/urls.py
+++ b/core/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
     path('work/anlage/<int:pk>/check-view/', views.projekt_file_check_view, name='projekt_file_check_view'),
     path('work/anlage/<int:pk>/edit-json/', views.projekt_file_edit_json, name='projekt_file_edit_json'),
     path('work/anlage/<int:pk>/email/', views.anlage1_generate_email, name='anlage1_generate_email'),
+    path('work/anlage/<int:pk>/delete/', views.projekt_file_delete, name='projekt_file_delete'),
     path('work/projekte/<int:pk>/gap-analysis/', views.projekt_gap_analysis, name='projekt_gap_analysis'),
     path('work/projekte/<int:pk>/summary/', views.projekt_management_summary, name='projekt_management_summary'),
     path('work/projekte/<int:pk>/gutachten/', views.projekt_gutachten, name='projekt_gutachten'),

--- a/core/views.py
+++ b/core/views.py
@@ -991,6 +991,21 @@ def anlage1_generate_email(request, pk):
     return JsonResponse({"text": text})
 
 
+@login_required
+@require_http_methods(["POST"])
+def projekt_file_delete(request, pk):
+    """Löscht eine Anlage und entfernt die Datei."""
+    try:
+        anlage = BVProjectFile.objects.get(pk=pk)
+    except BVProjectFile.DoesNotExist:
+        raise Http404
+    path = Path(settings.MEDIA_ROOT) / anlage.upload.name
+    path.unlink(missing_ok=True)
+    projekt_pk = anlage.projekt.pk
+    anlage.delete()
+    return redirect("projekt_detail", pk=projekt_pk)
+
+
 def _validate_llm_output(text: str) -> tuple[bool, str]:
     """Prüfe, ob die LLM-Antwort technisch brauchbar ist."""
     if not text:

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -43,6 +43,7 @@
             <th class="px-2 py-1">Datei</th>
             <th class="px-2 py-1 text-center">Prüfen</th>
             <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
+            <th class="px-2 py-1 text-center">Löschen</th>
         </tr>
     </thead>
     <tbody>
@@ -60,9 +61,15 @@
                    class="bg-purple-600 text-white px-2 py-1 rounded">Analyse bearbeiten</a>
             {% endif %}
             </td>
+            <td class="px-2 py-1 text-center">
+                <form method="post" action="{% url 'projekt_file_delete' a.pk %}" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="text-red-700 underline">Löschen</button>
+                </form>
+            </td>
         </tr>
     {% empty %}
-        <tr><td colspan="4">Keine Anlagen vorhanden</td></tr>
+        <tr><td colspan="5">Keine Anlagen vorhanden</td></tr>
     {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- add route for deleting attachments
- implement `projekt_file_delete` view to remove records and uploaded files
- show delete button on each attachment row
- test deleting a project file

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6846f4d8f494832b8947836f4901e14c