### PR TITLE
Implement question deletion in admin form

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -898,3 +898,29 @@ class LLMConfigNoticeMiddlewareTests(TestCase):
         self.assertTrue(any("LLM-Einstellungen" in m for m in msgs))
 
 
+class AdminAnlage1ViewTests(TestCase):
+    def setUp(self):
+        admin_group = Group.objects.create(name="admin")
+        self.user = User.objects.create_user("a1admin", password="pass")
+        self.user.groups.add(admin_group)
+        self.client.login(username="a1admin", password="pass")
+
+    def test_delete_question(self):
+        url = reverse("admin_anlage1")
+        questions = list(Anlage1Question.objects.all())
+        q = questions[0]
+        data = {}
+        for question in questions:
+            if question.id == q.id:
+                data[f"delete{question.id}"] = "on"
+            if question.parser_enabled:
+                data[f"parser_enabled{question.id}"] = "on"
+            if question.llm_enabled:
+                data[f"llm_enabled{question.id}"] = "on"
+            data[f"text{question.id}"] = question.text
+        resp = self.client.post(url, data)
+        self.assertRedirects(resp, url)
+        self.assertFalse(Anlage1Question.objects.filter(id=q.id).exists())
+        self.assertEqual(Anlage1Question.objects.count(), len(questions) - 1)
+
+

--- a/core/views.py
+++ b/core/views.py
@@ -627,6 +627,9 @@ def admin_anlage1(request):
     questions = list(Anlage1Question.objects.all().order_by("num"))
     if request.method == "POST":
         for q in questions:
+            if request.POST.get(f"delete{q.id}"):
+                q.delete()
+                continue
             q.parser_enabled = bool(request.POST.get(f"parser_enabled{q.id}"))
             q.llm_enabled = bool(request.POST.get(f"llm_enabled{q.id}"))
             q.text = request.POST.get(f"text{q.id}", q.text)

--- a/templates/admin_anlage1.html
+++ b/templates/admin_anlage1.html
@@ -10,6 +10,7 @@
                 <th class="py-2">Frage</th>
                 <th class="py-2">Parser</th>
                 <th class="py-2">LLM</th>
+                <th class="py-2">Löschen</th>
                 <th class="py-2">Prompt</th>
             </tr>
         </thead>
@@ -22,6 +23,9 @@
                 </td>
                 <td class="py-1 text-center">
                     <input type="checkbox" name="llm_enabled{{ q.id }}" {% if q.llm_enabled %}checked{% endif %}>
+                </td>
+                <td class="py-1 text-center">
+                    <input type="checkbox" name="delete{{ q.id }}">
                 </td>
                 <td class="py-1">
                     <textarea name="text{{ q.id }}" rows="2" class="border rounded p-2 w-full">{{ q.text }}</textarea>
@@ -36,6 +40,7 @@
             <td class="py-1 text-center">
                 <input type="checkbox" name="new_llm_enabled" checked>
             </td>
+            <td class="py-1 text-center"></td>
             <td class="py-1">
                 <textarea name="new_text" rows="2" class="border rounded p-2 w-full"></textarea>
             </td>


### PR DESCRIPTION
## Summary
- allow deleting Anlage1 questions in admin view
- add delete checkbox to template
- test deleting a question via the admin form

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6846f4dfecc0832baaa0b9039468b429