### PR TITLE
Extract DocxValidationMixin

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -64,7 +64,18 @@ class TranscriptUploadForm(forms.Form):
         return f
 
 
-class BVProjectForm(forms.ModelForm):
+class DocxValidationMixin:
+    """Mixin mit Validierung für DOCX-Dateien."""
+
+    def clean_docx_file(self):
+        """Erlaubt nur Dateien mit der Endung .docx."""
+        f = self.cleaned_data.get("docx_file")
+        if f and not f.name.lower().endswith(".docx"):
+            raise forms.ValidationError("Nur .docx Dateien erlaubt")
+        return f
+
+
+class BVProjectForm(DocxValidationMixin, forms.ModelForm):
     docx_file = forms.FileField(
         required=False,
         label="DOCX-Datei",
@@ -94,24 +105,14 @@ class BVProjectForm(forms.ModelForm):
         cleaned = ", ".join(names)
         return cleaned
 
-    def clean_docx_file(self):
-        f = self.cleaned_data.get("docx_file")
-        if f and not f.name.lower().endswith(".docx"):
-            raise forms.ValidationError("Nur .docx Dateien erlaubt")
-        return f
 
 
-class BVProjectUploadForm(forms.Form):
+class BVProjectUploadForm(DocxValidationMixin, forms.Form):
     docx_file = forms.FileField(
         label="DOCX-Datei",
         widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
     )
 
-    def clean_docx_file(self):
-        f = self.cleaned_data.get("docx_file")
-        if f and not f.name.lower().endswith(".docx"):
-            raise forms.ValidationError("Nur .docx Dateien erlaubt")
-        return f
 
 
 class BVProjectFileForm(forms.ModelForm):

--- a/core/tests.py
+++ b/core/tests.py
@@ -21,6 +21,7 @@ from tempfile import NamedTemporaryFile
 from docx import Document
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from .forms import BVProjectForm, BVProjectUploadForm
 from .workflow import set_project_status
 from .llm_tasks import (
     classify_system,
@@ -82,6 +83,25 @@ class DocxExtractTests(TestCase):
         finally:
             Path(tmp.name).unlink(missing_ok=True)
         self.assertIn("Das ist ein Test", text)
+
+
+class BVProjectFormTests(TestCase):
+    def test_project_form_docx_validation(self):
+        data = {
+            "beschreibung": "",
+            "software_typen": "A",
+            "status": BVProject.STATUS_NEW,
+        }
+        valid = BVProjectForm(data, {"docx_file": SimpleUploadedFile("t.docx", b"d")})
+        self.assertTrue(valid.is_valid())
+        invalid = BVProjectForm(data, {"docx_file": SimpleUploadedFile("t.txt", b"d")})
+        self.assertFalse(invalid.is_valid())
+
+    def test_upload_form_docx_validation(self):
+        valid = BVProjectUploadForm({}, {"docx_file": SimpleUploadedFile("t.docx", b"d")})
+        self.assertTrue(valid.is_valid())
+        invalid = BVProjectUploadForm({}, {"docx_file": SimpleUploadedFile("t.txt", b"d")})
+        self.assertFalse(invalid.is_valid())
 
 class BVProjectFileTests(TestCase):
     def test_create_project_with_files(self):


### PR DESCRIPTION
## Summary
- add `DocxValidationMixin` to handle docx validation logic
- use mixin in `BVProjectForm` and `BVProjectUploadForm`
- test docx validation for both forms

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684717554e44832bb53a55ccc9dbfb92