### PR TITLE
Add German docstrings to test stubs

### DIFF
--- a/google/__init__.py
+++ b/google/__init__.py
@@ -1,5 +1,10 @@
+"""Vereinfachter Google-Stub f\u00fcr Tests ohne echte API."""
+
+
 class generativeai:
+    """Dummy-Namespace f\u00fcr die generative KI."""
     class GenerativeModel:
+        """Sehr einfache Modellklasse f\u00fcr Tests."""
         def __init__(self, *args, **kwargs):
             pass
         def generate_content(self, *args, **kwargs):

--- a/markdown.py
+++ b/markdown.py
@@ -1,2 +1,6 @@
+"""Sehr einfacher Markdown-Ersatz f\u00fcr Tests."""
+
+
 def markdown(text):
+    """Gibt den Text unver\u00e4ndert zur\u00fcck."""
     return text

--- a/obsws_python/__init__.py
+++ b/obsws_python/__init__.py
@@ -1,4 +1,8 @@
+"""Dummymodul f\u00fcr OBS-Websocket-Aufrufe in Tests."""
+
+
 class ReqClient:
+    """Einfache Nachbildung des OBS-Clients."""
     def __init__(self, *args, **kwargs):
         pass
     def start_record(self):

--- a/openai.py
+++ b/openai.py
@@ -1,4 +1,8 @@
+"""Ersatzmodul f\u00fcr OpenAI, das nur f\u00fcr Tests gedacht ist."""
+
+
 class Client:
+    """Platzhalter-Client zur Simulation der OpenAI-Bibliothek."""
     def __init__(self):
         pass
 
@@ -6,4 +10,5 @@ def ChatCompletion_create(*args, **kwargs):
     return {"choices": [{"message": {"content": ""}}]}
 
 class ChatCompletion:
+    """Minimaler Wrapper f\u00fcr ChatCompletion im Test."""
     create = staticmethod(ChatCompletion_create)

--- a/torch.py
+++ b/torch.py
@@ -1,4 +1,8 @@
+"""Minimaler Torch-Stub f\u00fcr Testumgebungen."""
+
+
 class cuda:
+    """Nachbildung der CUDA-Schnittstelle."""
     @staticmethod
     def is_available():
         return False

--- a/whisper.py
+++ b/whisper.py
@@ -1,4 +1,8 @@
+"""Leichtgewichtiger Whisper-Ersatz f\u00fcr Testl\u00e4ufe."""
+
+
 class DummyModel:
+    """Imitiert ein Whisper-Modell."""
     def transcribe(self, *args, **kwargs):
         return {"text": ""}
 


### PR DESCRIPTION
## Summary
- add kurze Modul- und Klassen-Kommentare in den Test-Stubs

## Testing
- `python -m pip install -r requirements.txt` *(fails: Operation cancelled / heavy deps)*
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68471ab16730832bb7f60fed9d9dbeac