### PR TITLE
Allow model selection for LLM checks

### DIFF
--- a/core/management/commands/check_anlage1.py
+++ b/core/management/commands/check_anlage1.py
@@ -6,7 +6,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
+        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, **options):
-        data = check_anlage1(projekt_id)
+    def handle(self, projekt_id, model=None, **options):
+        data = check_anlage1(projekt_id, model_name=model)
         self.stdout.write(self.style.SUCCESS(str(data)))

--- a/core/management/commands/check_anlage2.py
+++ b/core/management/commands/check_anlage2.py
@@ -6,7 +6,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
+        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, **options):
-        data = check_anlage2(projekt_id)
+    def handle(self, projekt_id, model=None, **options):
+        data = check_anlage2(projekt_id, model_name=model)
         self.stdout.write(self.style.SUCCESS(str(data)))

--- a/core/management/commands/check_anlage3.py
+++ b/core/management/commands/check_anlage3.py
@@ -6,7 +6,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
+        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, **options):
-        data = check_anlage3(projekt_id)
+    def handle(self, projekt_id, model=None, **options):
+        data = check_anlage3(projekt_id, model_name=model)
         self.stdout.write(self.style.SUCCESS(str(data)))

--- a/core/management/commands/check_anlage4.py
+++ b/core/management/commands/check_anlage4.py
@@ -6,7 +6,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
+        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, **options):
-        data = check_anlage4(projekt_id)
+    def handle(self, projekt_id, model=None, **options):
+        data = check_anlage4(projekt_id, model_name=model)
         self.stdout.write(self.style.SUCCESS(str(data)))

--- a/core/management/commands/check_anlage5.py
+++ b/core/management/commands/check_anlage5.py
@@ -6,7 +6,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
+        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, **options):
-        data = check_anlage5(projekt_id)
+    def handle(self, projekt_id, model=None, **options):
+        data = check_anlage5(projekt_id, model_name=model)
         self.stdout.write(self.style.SUCCESS(str(data)))

--- a/core/management/commands/check_anlage6.py
+++ b/core/management/commands/check_anlage6.py
@@ -6,7 +6,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
+        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, **options):
-        data = check_anlage6(projekt_id)
+    def handle(self, projekt_id, model=None, **options):
+        data = check_anlage6(projekt_id, model_name=model)
         self.stdout.write(self.style.SUCCESS(str(data)))

--- a/core/management/commands/classify_system.py
+++ b/core/management/commands/classify_system.py
@@ -6,7 +6,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
+        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, **options):
-        data = classify_system(projekt_id)
+    def handle(self, projekt_id, model=None, **options):
+        data = classify_system(projekt_id, model_name=model)
         self.stdout.write(self.style.SUCCESS(str(data)))

--- a/core/management/commands/generate_gutachten.py
+++ b/core/management/commands/generate_gutachten.py
@@ -6,7 +6,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
+        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, **options):
-        path = generate_gutachten(projekt_id)
+    def handle(self, projekt_id, model=None, **options):
+        path = generate_gutachten(projekt_id, model_name=model)
         self.stdout.write(self.style.SUCCESS(str(path)))

--- a/templates/projekt_file_check_result.html
+++ b/templates/projekt_file_check_result.html
@@ -2,6 +2,16 @@
 {% block title %}Pr\u00fcfergebnis{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Pr\u00fcfergebnis f\u00fcr Anlage {{ anlage.anlage_nr }}</h1>
+<form method="get" class="mb-4">
+    <label class="font-semibold">LLM-Modell:</label>
+    {% for m in models %}
+        <label class="ml-2">
+            <input type="radio" name="model" value="{{ m }}" {% if m == model %}checked{% endif %}>
+            {{ m }}
+        </label>
+    {% endfor %}
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded ml-2">Neu prüfen</button>
+</form>
 <form method="post" class="space-y-4">
     {% csrf_token %}
     {{ form.non_field_errors }}

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -27,13 +27,22 @@
     </div>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
     {% if projekt %}
-    <button type="button" data-url="{% url 'projekt_check' projekt.pk %}" class="llm-check-btn bg-green-600 text-white px-4 py-2 rounded ml-2">
-        {% if projekt.llm_geprueft %}LLM-Prüfung wiederholen{% else %}System per LLM prüfen{% endif %}
-    </button>
+    <div class="mt-4">
+        <label class="font-semibold">LLM-Modell:</label>
+        {% for m in models %}
+            <label class="ml-2">
+                <input type="radio" name="llm_model" value="{{ m }}" {% if m == model %}checked{% endif %}>
+                {{ m }}
+            </label>
+        {% endfor %}
+        <button type="button" data-url="{% url 'projekt_check' projekt.pk %}" class="llm-check-btn bg-green-600 text-white px-4 py-2 rounded ml-2">
+            {% if projekt.llm_geprueft %}LLM-Prüfung wiederholen{% else %}System per LLM prüfen{% endif %}
+        </button>
+    </div>
     {% endif %}
 </form>
 <script>
 function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
-document.querySelectorAll('.llm-check-btn').forEach(btn=>{btn.addEventListener('click',ev=>{ev.preventDefault();fetch(btn.dataset.url,{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')}}).then(r=>r.json()).then(data=>{if(data.status==='ok'){alert('LLM-Prüfung abgeschlossen');btn.textContent='LLM-Prüfung wiederholen';}else{alert('Fehler bei der LLM-Prüfung');}}).catch(()=>alert('Fehler bei der LLM-Prüfung'));});});
+document.querySelectorAll('.llm-check-btn').forEach(btn=>{btn.addEventListener('click',ev=>{ev.preventDefault();const m=document.querySelector('input[name="llm_model"]:checked');const body=new URLSearchParams();if(m){body.append('model',m.value);}fetch(btn.dataset.url,{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body}).then(r=>r.json()).then(data=>{if(data.status==='ok'){alert('LLM-Prüfung abgeschlossen');btn.textContent='LLM-Prüfung wiederholen';}else{alert('Fehler bei der LLM-Prüfung');}}).catch(()=>alert('Fehler bei der LLM-Prüfung'));});});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow selecting a model in `projekt_check` and `projekt_file_check*`
- add model option to file check view
- show radio buttons in project and file check templates
- support `--model` option for management commands
- test that selected models are passed to query functions

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(not run due to failed dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_6847d401ea90832ba9e704334692c140