### PR TITLE
Add prompt check for Anlage2

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -275,6 +275,23 @@ class LLMTasksTests(TestCase):
         self.assertTrue(file_obj.analysis_json["ok"]["value"])
         self.assertTrue(data["ok"]["value"])
 
+    def test_check_anlage2_prompt_contains_text(self):
+        """Der Prompt enth\u00E4lt den gesamten Anlagentext."""
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("a.txt", b"data"),
+            text_content="Testinhalt Anlage2",
+        )
+        with patch("core.llm_tasks.query_llm", return_value='{"ok": true}') as mock_q:
+            data = check_anlage2(projekt.pk)
+        prompt = mock_q.call_args_list[0].args[0]
+        self.assertIn("Testinhalt Anlage2", prompt)
+        file_obj = projekt.anlagen.get(anlage_nr=2)
+        self.assertTrue(file_obj.analysis_json["ok"]["value"])
+        self.assertTrue(data["ok"]["value"])
+
     def test_analyse_anlage2(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="b")
         BVProjectFile.objects.create(


### PR DESCRIPTION
## Summary
- add regression test ensuring `check_anlage2` sends file text to LLM

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684805abfca0832bbf5a5708c27964fa