### PR TITLE
Add check_anlage2 usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ von einem LLM nach Funktionen durchsucht. Die erkannten Funktionen werden mit
 den Angaben aus Anlage 2 verglichen. Fehlende oder zusätzliche Funktionen werden
 als JSON in Anlage 2 gespeichert.
 
+### Anlage 2 prüfen
+
+Um eine hochgeladene zweite Anlage auf Vollständigkeit zu prüfen, dient
+
+```bash
+python manage.py check_anlage2 <projekt_id>
+```
+
+Der Befehl liest den Text der Datei aus und speichert das Ergebnis als JSON im
+zugehörigen Datenbankeintrag der Anlage.
+
 ### Kachel-Zugriff verwalten
 
 Im Admin-Bereich können einzelnen Benutzern Kacheln zugewiesen werden. Nach der


### PR DESCRIPTION
## Summary
- document `python manage.py check_anlage2 <projekt_id>` in README

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'docx')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_6848164f52c4832b9491aa93cc6a68dc