### PR TITLE
Implement LLM check for Anlage2 functions

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,7 +1,15 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import User
-from .models import Recording, Prompt, Tile, UserTileAccess, Area
+from .models import (
+    Recording,
+    Prompt,
+    Tile,
+    UserTileAccess,
+    Area,
+    Anlage2Function,
+    Anlage2FunctionResult,
+)
 
 
 @admin.register(Recording)
@@ -40,3 +48,20 @@ class CustomUserAdmin(BaseUserAdmin):
 
 admin.site.unregister(User)
 admin.site.register(User, CustomUserAdmin)
+
+
+@admin.register(Anlage2Function)
+class Anlage2FunctionAdmin(admin.ModelAdmin):
+    list_display = ("name",)
+
+
+@admin.register(Anlage2FunctionResult)
+class Anlage2FunctionResultAdmin(admin.ModelAdmin):
+    list_display = (
+        "projekt",
+        "funktion",
+        "technisch_verfuegbar",
+        "einsatz_telefonica",
+        "zur_lv_kontrolle",
+        "ki_beteiligung",
+    )

--- a/core/management/commands/check_anlage2_functions.py
+++ b/core/management/commands/check_anlage2_functions.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+from core.llm_tasks import check_anlage2_functions
+
+
+class Command(BaseCommand):
+    """Pr\u00fcft alle Anlage-2-Funktionen eines Projekts."""
+
+    def add_arguments(self, parser):
+        parser.add_argument("projekt_id", type=int)
+        parser.add_argument("--model", dest="model", default=None)
+
+    def handle(self, projekt_id, model=None, **options):
+        data = check_anlage2_functions(projekt_id, model_name=model)
+        self.stdout.write(self.style.SUCCESS(str(data)))

--- a/core/migrations/0034_anlage2_functions.py
+++ b/core/migrations/0034_anlage2_functions.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+
+
+def create_prompt(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    Prompt.objects.get_or_create(
+        name='check_anlage2_function',
+        defaults={'text': 'Pr\u00fcfe anhand des folgenden Textes, ob die genannte Funktion vorhanden ist. Gib ein JSON mit den Schl\u00fcsseln "technisch_verfuegbar", "einsatz_telefonica", "zur_lv_kontrolle" und "ki_beteiligung" zur\u00fcck.\n\n'}
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0033_analyse_anlage2_prompt'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Anlage2Function',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=200, unique=True)),
+            ],
+            options={'ordering': ['name']},
+        ),
+        migrations.CreateModel(
+            name='Anlage2FunctionResult',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('technisch_verfuegbar', models.BooleanField(null=True)),
+                ('einsatz_telefonica', models.BooleanField(null=True)),
+                ('zur_lv_kontrolle', models.BooleanField(null=True)),
+                ('ki_beteiligung', models.BooleanField(null=True)),
+                ('raw_json', models.JSONField(blank=True, null=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('funktion', models.ForeignKey(on_delete=models.deletion.CASCADE, to='core.anlage2function')),
+                ('projekt', models.ForeignKey(on_delete=models.deletion.CASCADE, to='core.bvproject')),
+            ],
+            options={'ordering': ['funktion__name'], 'unique_together': {('projekt', 'funktion')}},
+        ),
+        migrations.RunPython(create_prompt, migrations.RunPython.noop),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -312,3 +312,35 @@ class UserTileAccess(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return f"{self.user} -> {self.tile}"
+
+
+class Anlage2Function(models.Model):
+    """Funktion aus Anlage 2."""
+
+    name = models.CharField(max_length=200, unique=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.name
+
+
+class Anlage2FunctionResult(models.Model):
+    """Speichert das Prüfergebnis einer Anlage-2-Funktion."""
+
+    projekt = models.ForeignKey(BVProject, on_delete=models.CASCADE)
+    funktion = models.ForeignKey(Anlage2Function, on_delete=models.CASCADE)
+    technisch_verfuegbar = models.BooleanField(null=True)
+    einsatz_telefonica = models.BooleanField(null=True)
+    zur_lv_kontrolle = models.BooleanField(null=True)
+    ki_beteiligung = models.BooleanField(null=True)
+    raw_json = models.JSONField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        unique_together = [("projekt", "funktion")]
+        ordering = ["funktion__name"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.projekt} - {self.funktion}"

--- a/core/urls.py
+++ b/core/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path('work/projekte/<int:pk>/anlage/', views.projekt_file_upload, name='projekt_file_upload'),
     path('work/projekte/<int:pk>/check/', views.projekt_check, name='projekt_check'),
     path('work/projekte/<int:pk>/status/', views.projekt_status_update, name='projekt_status_update'),
+    path('work/projekte/<int:pk>/functions-check/', views.projekt_functions_check, name='projekt_functions_check'),
     path('work/projekte/<int:pk>/anlage/<int:nr>/check/', views.projekt_file_check, name='projekt_file_check'),
     path('work/anlage/<int:pk>/check/', views.projekt_file_check_pk, name='projekt_file_check_pk'),
     path('work/anlage/<int:pk>/check-view/', views.projekt_file_check_view, name='projekt_file_check_view'),

--- a/core/views.py
+++ b/core/views.py
@@ -46,6 +46,7 @@ from .llm_tasks import (
     check_anlage4,
     check_anlage5,
     check_anlage6,
+    check_anlage2_functions,
     generate_gutachten,
     get_prompt,
     ANLAGE1_QUESTIONS,
@@ -1249,6 +1250,21 @@ def projekt_status_update(request, pk):
     except ValueError:
         pass
     return redirect("projekt_detail", pk=projekt.pk)
+
+
+@login_required
+@require_http_methods(["POST"])
+def projekt_functions_check(request, pk):
+    """Löst die Einzelprüfung der Anlage-2-Funktionen aus."""
+    model = request.POST.get("model")
+    try:
+        check_anlage2_functions(pk, model_name=model)
+    except RuntimeError:
+        return JsonResponse({"error": "Missing LLM credentials from environment."}, status=500)
+    except Exception:
+        logger.exception("LLM Fehler")
+        return JsonResponse({"status": "error"}, status=502)
+    return JsonResponse({"status": "ok"})
 
 
 @login_required


### PR DESCRIPTION
## Summary
- add new models `Anlage2Function` and `Anlage2FunctionResult`
- implement `check_anlage2_functions` task
- provide management command and endpoint for function checks
- register new models in admin
- extend tests for new features and command
- create migration with default prompt

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68482334c630832b8c897e391b7808bf