### PR TITLE
Add explicit project title field

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -84,13 +84,15 @@ class BVProjectForm(DocxValidationMixin, forms.ModelForm):
     )
     class Meta:
         model = BVProject
-        fields = ["beschreibung", "software_typen", "status"]
+        fields = ["title", "beschreibung", "software_typen", "status"]
         labels = {
+            "title": "Name",
             "beschreibung": "Beschreibung",
             "software_typen": "Software-Typen (kommagetrennt)",
             "status": "Status",
         }
         widgets = {
+            "title": forms.TextInput(attrs={"class": "border rounded p-2"}),
             "beschreibung": forms.Textarea(attrs={"class": "border rounded p-2"}),
             "software_typen": forms.TextInput(attrs={"class": "border rounded p-2"}),
             "status": forms.Select(attrs={"class": "border rounded p-2"}),

--- a/core/models.py
+++ b/core/models.py
@@ -92,7 +92,8 @@ class BVProject(models.Model):
         if self.software_typen:
             cleaned = ", ".join([s.strip() for s in self.software_typen.split(",") if s.strip()])
             self.software_typen = cleaned
-            self.title = cleaned
+            if not self.title:
+                self.title = cleaned
         is_new = self._state.adding
         super().save(*args, **kwargs)
         if is_new:

--- a/core/tests.py
+++ b/core/tests.py
@@ -155,6 +155,7 @@ class DocxExtractTests(TestCase):
 class BVProjectFormTests(TestCase):
     def test_project_form_docx_validation(self):
         data = {
+            "title": "",
             "beschreibung": "",
             "software_typen": "A",
             "status": BVProject.STATUS_NEW,
@@ -169,6 +170,18 @@ class BVProjectFormTests(TestCase):
         self.assertTrue(valid.is_valid())
         invalid = BVProjectUploadForm({}, {"docx_file": SimpleUploadedFile("t.txt", b"d")})
         self.assertFalse(invalid.is_valid())
+
+    def test_form_saves_title(self):
+        data = {
+            "title": "Mein Projekt",
+            "beschreibung": "",
+            "software_typen": "A",
+            "status": BVProject.STATUS_NEW,
+        }
+        form = BVProjectForm(data)
+        self.assertTrue(form.is_valid())
+        projekt = form.save()
+        self.assertEqual(projekt.title, "Mein Projekt")
 
 class BVProjectFileTests(TestCase):
     def test_create_project_with_files(self):
@@ -211,6 +224,16 @@ class ProjektFileUploadTests(TestCase):
         file_obj = self.projekt.anlagen.first()
         self.assertIsNotNone(file_obj)
         self.assertIn("Docx Inhalt", file_obj.text_content)
+
+
+class BVProjectModelTests(TestCase):
+    def test_title_auto_set_from_software(self):
+        projekt = BVProject.objects.create(software_typen="A, B", beschreibung="x")
+        self.assertEqual(projekt.title, "A, B")
+
+    def test_title_preserved_when_set(self):
+        projekt = BVProject.objects.create(title="X", software_typen="A", beschreibung="x")
+        self.assertEqual(projekt.title, "X")
 
 
 class WorkflowTests(TestCase):

--- a/core/views.py
+++ b/core/views.py
@@ -807,6 +807,7 @@ def projekt_create(request):
         form = BVProjectForm(request.POST, request.FILES)
         if form.is_valid():
             projekt = form.save(commit=False)
+            projekt.title = form.cleaned_data.get("title", "")
             docx_file = form.cleaned_data.get("docx_file")
             if docx_file:
                 from tempfile import NamedTemporaryFile

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -6,6 +6,11 @@
     {% csrf_token %}
     {{ form.non_field_errors }}
     <div>
+        {{ form.title.label_tag }}<br>
+        {{ form.title }}
+        {{ form.title.errors }}
+    </div>
+    <div>
         {{ form.beschreibung.label_tag }}<br>
         {{ form.beschreibung }}
         {{ form.beschreibung.errors }}


### PR DESCRIPTION
## Summary
- extend BVProjectForm with `title` field and label "Name"
- keep user provided title in BVProject.save
- store title from form when creating projects
- show title field first in form template
- test form and model behaviour for title handling

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6848281b0fb8832bbfe61b8e6e9e3fa1