### PR TITLE
Add multi-software support to BVProjectForm

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User, Group
 from django.urls import reverse
 from django.test import TestCase
+from django.http import QueryDict
 
 
 from django.apps import apps
@@ -154,12 +155,13 @@ class DocxExtractTests(TestCase):
 
 class BVProjectFormTests(TestCase):
     def test_project_form_docx_validation(self):
-        data = {
+        data = QueryDict(mutable=True)
+        data.update({
             "title": "",
             "beschreibung": "",
-            "software_typen": "A",
             "status": BVProject.STATUS_NEW,
-        }
+        })
+        data.setlist("software", ["A"])
         valid = BVProjectForm(data, {"docx_file": SimpleUploadedFile("t.docx", b"d")})
         self.assertTrue(valid.is_valid())
         invalid = BVProjectForm(data, {"docx_file": SimpleUploadedFile("t.txt", b"d")})
@@ -172,12 +174,13 @@ class BVProjectFormTests(TestCase):
         self.assertFalse(invalid.is_valid())
 
     def test_form_saves_title(self):
-        data = {
+        data = QueryDict(mutable=True)
+        data.update({
             "title": "Mein Projekt",
             "beschreibung": "",
-            "software_typen": "A",
             "status": BVProject.STATUS_NEW,
-        }
+        })
+        data.setlist("software", ["A"])
         form = BVProjectForm(data)
         self.assertTrue(form.is_valid())
         projekt = form.save()

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -16,7 +16,22 @@
         {{ form.beschreibung.errors }}
     </div>
     <div>
-        {{ form.software_typen.label_tag }}<br>
+        <label>Software</label><br>
+        <div id="software-container">
+        {% for name in form.software_list %}
+            <div class="software-item mb-2 flex items-center">
+                <input type="text" name="software" value="{{ name }}" class="border rounded p-2 mr-2">
+                <button type="button" class="remove-software text-red-600">-</button>
+            </div>
+        {% endfor %}
+        {% if not form.software_list %}
+            <div class="software-item mb-2 flex items-center">
+                <input type="text" name="software" class="border rounded p-2 mr-2">
+                <button type="button" class="remove-software text-red-600">-</button>
+            </div>
+        {% endif %}
+        </div>
+        <button type="button" id="add-software" class="bg-gray-300 px-2 py-1 rounded">+</button>
         {{ form.software_typen }}
         {{ form.software_typen.errors }}
     </div>
@@ -49,5 +64,7 @@
 <script>
 function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 document.querySelectorAll('.llm-check-btn').forEach(btn=>{btn.addEventListener('click',ev=>{ev.preventDefault();const m=document.querySelector('input[name="model_category"]:checked');const body=new URLSearchParams();if(m){body.append('model_category',m.value);}fetch(btn.dataset.url,{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body}).then(r=>r.json()).then(data=>{if(data.status==='ok'){alert('LLM-Prüfung abgeschlossen');btn.textContent='LLM-Prüfung wiederholen';}else{alert('Fehler bei der LLM-Prüfung');}}).catch(()=>alert('Fehler bei der LLM-Prüfung'));});});
+document.getElementById('add-software').addEventListener('click',()=>{const c=document.getElementById('software-container');const d=document.createElement('div');d.className='software-item mb-2 flex items-center';d.innerHTML='<input type="text" name="software" class="border rounded p-2 mr-2"><button type="button" class="remove-software text-red-600">-</button>';c.appendChild(d);});
+document.getElementById('software-container').addEventListener('click',e=>{if(e.target.classList.contains('remove-software')){e.target.parentElement.remove();}});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow BVProjectForm to process multiple `software` inputs
- hide underlying `software_typen` field
- add JS in projekt_form to dynamically add/remove software inputs
- adjust tests for new input format

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68482a9ebe44832bb72481e1201ef9dc