### PR TITLE
Hide status field when creating BVProjects

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -100,10 +100,16 @@ class BVProjectForm(DocxValidationMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not self.instance or not self.instance.pk:
+            self.fields.pop("status", None)
         if self.data:
-            self.software_list = [s.strip() for s in self.data.getlist("software") if s.strip()]
+            self.software_list = [
+                s.strip() for s in self.data.getlist("software") if s.strip()
+            ]
         else:
-            raw = self.initial.get("software_typen") or getattr(self.instance, "software_typen", "")
+            raw = self.initial.get("software_typen") or getattr(
+                self.instance, "software_typen", ""
+            )
             self.software_list = [s.strip() for s in raw.split(",") if s.strip()]
 
     def clean_software_typen(self) -> str:

--- a/core/tests.py
+++ b/core/tests.py
@@ -159,7 +159,6 @@ class BVProjectFormTests(TestCase):
         data.update({
             "title": "",
             "beschreibung": "",
-            "status": BVProject.STATUS_NEW,
         })
         data.setlist("software", ["A"])
         valid = BVProjectForm(data, {"docx_file": SimpleUploadedFile("t.docx", b"d")})
@@ -178,13 +177,13 @@ class BVProjectFormTests(TestCase):
         data.update({
             "title": "Mein Projekt",
             "beschreibung": "",
-            "status": BVProject.STATUS_NEW,
         })
         data.setlist("software", ["A"])
         form = BVProjectForm(data)
         self.assertTrue(form.is_valid())
         projekt = form.save()
         self.assertEqual(projekt.title, "Mein Projekt")
+        self.assertEqual(projekt.status, BVProject.STATUS_NEW)
 
 class BVProjectFileTests(TestCase):
     def test_create_project_with_files(self):

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -35,11 +35,13 @@
         {{ form.software_typen }}
         {{ form.software_typen.errors }}
     </div>
+    {% if 'status' in form.fields %}
     <div>
         {{ form.status.label_tag }}<br>
         {{ form.status }}
         {{ form.status.errors }}
     </div>
+    {% endif %}
     <div>
         {{ form.docx_file.label_tag }}<br>
         {{ form.docx_file }}


### PR DESCRIPTION
## Summary
- hide `status` field in `BVProjectForm` if no instance is provided
- wrap status section in template with condition
- adjust tests for new default behaviour

## Testing
- `python manage.py makemigrations --check` *(fails: No module named 'django')*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68482d69b3b4832b8b1c0b9ed2604b5c