### PR TITLE
Implement editable initial LLM prompt

### DIFF
--- a/core/migrations/0035_initial_llm_prompt.py
+++ b/core/migrations/0035_initial_llm_prompt.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+
+def create_prompt(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    Prompt.objects.get_or_create(
+        name='initial_llm_check',
+        defaults={
+            'text': (
+                'Do you know software {name}? Provide a short, technically correct '
+                'description of what it does and how it is typically used.'
+            )
+        },
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0034_anlage2_functions'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_prompt, migrations.RunPython.noop),
+    ]

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -2,38 +2,57 @@
 {% block title %}Admin Prompts{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Admin Prompts</h1>
-<table class="min-w-full">
-    <thead>
-        <tr class="border-b text-left">
-            <th class="py-2">Name</th>
-            <th class="py-2">Text</th>
-            <th class="py-2 text-center">Aktion</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for p in prompts %}
-        <tr class="border-b align-top text-sm">
-            <td class="py-1 font-semibold">{{ p.name }}</td>
-            <td class="py-1">
-                <form method="post" class="space-y-2">
-                    {% csrf_token %}
-                    <input type="hidden" name="pk" value="{{ p.id }}">
-                    <textarea name="text" rows="4" class="border rounded p-2 w-full">{{ p.text }}</textarea>
-                    <button name="action" value="save" class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
-                </form>
-            </td>
-            <td class="py-1 text-center">
-                <form method="post" class="inline">
-                    {% csrf_token %}
-                    <input type="hidden" name="pk" value="{{ p.id }}">
-                    <input type="hidden" name="action" value="delete">
-                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Prompt wirklich löschen?');">Löschen</button>
-                </form>
-            </td>
-        </tr>
-    {% empty %}
-        <tr><td colspan="3" class="py-2">Keine Prompts</td></tr>
+<div class="mb-4 space-x-2">
+    {% for key, label, items in grouped %}
+        <button class="tab-btn px-3 py-1 bg-blue-600 text-white rounded" data-tab="{{ key }}">{{ label }}</button>
     {% endfor %}
-    </tbody>
-</table>
+</div>
+
+{% for key, label, items in grouped %}
+<div id="tab-{{ key }}" class="tab-content {% if not forloop.first %}hidden{% endif %}">
+    <table class="min-w-full mb-6">
+        <thead>
+            <tr class="border-b text-left">
+                <th class="py-2">Name</th>
+                <th class="py-2">Text</th>
+                <th class="py-2 text-center">Aktion</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for p in items %}
+            <tr class="border-b align-top text-sm">
+                <td class="py-1 font-semibold">{{ p.name }}</td>
+                <td class="py-1">
+                    <form method="post" class="space-y-2">
+                        {% csrf_token %}
+                        <input type="hidden" name="pk" value="{{ p.id }}">
+                        <textarea name="text" rows="4" class="border rounded p-2 w-full">{{ p.text }}</textarea>
+                        <button name="action" value="save" class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
+                    </form>
+                </td>
+                <td class="py-1 text-center">
+                    <form method="post" class="inline">
+                        {% csrf_token %}
+                        <input type="hidden" name="pk" value="{{ p.id }}">
+                        <input type="hidden" name="action" value="delete">
+                        <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Prompt wirklich löschen?');">Löschen</button>
+                    </form>
+                </td>
+            </tr>
+        {% empty %}
+            <tr><td colspan="3" class="py-2">Keine Prompts</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endfor %}
+
+<script>
+document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-content').forEach(sec => sec.classList.add('hidden'));
+        document.getElementById('tab-' + btn.dataset.tab).classList.remove('hidden');
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add migration for `initial_llm_check` prompt
- allow `_run_llm_check` to fetch editable prompt
- group prompts by type with tabs in admin view

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68482bb71538832bb82de111b8f88365