### PR TITLE
Render LLM responses as Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ python manage.py showmigrations
 
 lässt sich prüfen, ob alle Migrationen angewendet wurden.
 
+## Markdown-Verarbeitung
+
+Alle Antworten der LLMs enthalten Markdown. Im Web werden sie mit
+`markdown.markdown()` zu HTML umgewandelt. In der Kommandozeile übernimmt
+`rich` die Darstellung über `rich.markdown.Markdown`.
+
 ### Gutachten verwalten
 
 1. Öffne `/work/projekte/<pk>/gutachten/` und ersetze `<pk>` durch die ID des Projekts. Dort lässt sich mithilfe eines LLM ein Gutachten erzeugen.

--- a/core/cli_utils.py
+++ b/core/cli_utils.py
@@ -1,0 +1,9 @@
+from rich.console import Console
+from rich.markdown import Markdown
+
+_console = Console()
+
+
+def print_markdown(text: str) -> None:
+    """Gibt Markdown-Text formatiert auf der Konsole aus."""
+    _console.print(Markdown(text))

--- a/core/management/commands/analyse_anlage2.py
+++ b/core/management/commands/analyse_anlage2.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import analyse_anlage2
+from core.cli_utils import print_markdown
+import json
 
 class Command(BaseCommand):
     """Analysiert Anlage 2 eines BVProjects."""
@@ -10,4 +12,5 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         data = analyse_anlage2(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(data)))
+        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        print_markdown(text)

--- a/core/management/commands/check_anlage1.py
+++ b/core/management/commands/check_anlage1.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import check_anlage1
+from core.cli_utils import print_markdown
+import json
 
 class Command(BaseCommand):
     """Prüft Anlage 1 eines BVProjects."""
@@ -10,4 +12,5 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         data = check_anlage1(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(data)))
+        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        print_markdown(text)

--- a/core/management/commands/check_anlage2.py
+++ b/core/management/commands/check_anlage2.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import check_anlage2
+from core.cli_utils import print_markdown
+import json
 
 class Command(BaseCommand):
     """Pr\u00fcft Anlage 2 eines BVProjects."""
@@ -10,4 +12,5 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         data = check_anlage2(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(data)))
+        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        print_markdown(text)

--- a/core/management/commands/check_anlage2_functions.py
+++ b/core/management/commands/check_anlage2_functions.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import check_anlage2_functions
+from core.cli_utils import print_markdown
+import json
 
 
 class Command(BaseCommand):
@@ -11,4 +13,5 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         data = check_anlage2_functions(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(data)))
+        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        print_markdown(text)

--- a/core/management/commands/check_anlage3.py
+++ b/core/management/commands/check_anlage3.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import check_anlage3
+from core.cli_utils import print_markdown
+import json
 
 class Command(BaseCommand):
     """Pr\u00fcft Anlage 3 eines BVProjects."""
@@ -10,4 +12,5 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         data = check_anlage3(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(data)))
+        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        print_markdown(text)

--- a/core/management/commands/check_anlage4.py
+++ b/core/management/commands/check_anlage4.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import check_anlage4
+from core.cli_utils import print_markdown
+import json
 
 class Command(BaseCommand):
     """Pr\u00fcft Anlage 4 eines BVProjects."""
@@ -10,4 +12,5 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         data = check_anlage4(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(data)))
+        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        print_markdown(text)

--- a/core/management/commands/check_anlage5.py
+++ b/core/management/commands/check_anlage5.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import check_anlage5
+from core.cli_utils import print_markdown
+import json
 
 class Command(BaseCommand):
     """Pr\u00fcft Anlage 5 eines BVProjects."""
@@ -10,4 +12,5 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         data = check_anlage5(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(data)))
+        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        print_markdown(text)

--- a/core/management/commands/check_anlage6.py
+++ b/core/management/commands/check_anlage6.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import check_anlage6
+from core.cli_utils import print_markdown
+import json
 
 class Command(BaseCommand):
     """Pr\u00fcft Anlage 6 eines BVProjects."""
@@ -10,4 +12,5 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         data = check_anlage6(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(data)))
+        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        print_markdown(text)

--- a/core/management/commands/classify_system.py
+++ b/core/management/commands/classify_system.py
@@ -1,5 +1,7 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import classify_system
+from core.cli_utils import print_markdown
+import json
 
 class Command(BaseCommand):
     """Führt die Systemklassifizierung für ein BVProject aus."""
@@ -10,4 +12,5 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         data = classify_system(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(data)))
+        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
+        print_markdown(text)

--- a/core/management/commands/generate_gutachten.py
+++ b/core/management/commands/generate_gutachten.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 from core.llm_tasks import generate_gutachten
+from core.cli_utils import print_markdown
 
 class Command(BaseCommand):
     """Erzeugt ein Gutachten für ein BVProject."""
@@ -10,4 +11,4 @@ class Command(BaseCommand):
 
     def handle(self, projekt_id, model=None, **options):
         path = generate_gutachten(projekt_id, model_name=model)
-        self.stdout.write(self.style.SUCCESS(str(path)))
+        print_markdown(str(path))

--- a/core/views.py
+++ b/core/views.py
@@ -1240,6 +1240,7 @@ def project_detail_api(request, pk):
         "ist_llm_geprueft": projekt.llm_geprueft,
         "llm_validated": projekt.llm_validated,
         "llm_initial_output": projekt.llm_initial_output,
+        "llm_initial_output_html": markdown.markdown(projekt.llm_initial_output),
         "llm_initial_output_combined": projekt.llm_initial_output,
     }
     return JsonResponse(data)
@@ -1265,6 +1266,7 @@ def project_llm_check(request, pk):
             "ist_llm_geprueft": projekt.llm_geprueft,
             "llm_validated": valid,
             "llm_initial_output": projekt.llm_initial_output,
+            "llm_initial_output_html": markdown.markdown(projekt.llm_initial_output),
         }
         if not valid:
             resp["error"] = msg
@@ -1325,6 +1327,7 @@ def project_llm_check(request, pk):
         "ist_llm_geprueft": True,
         "llm_validated": validated_all,
         "llm_initial_output": projekt.llm_initial_output,
+        "llm_initial_output_html": markdown.markdown(projekt.llm_initial_output),
     }
     return JsonResponse(resp)
 
@@ -1424,7 +1427,12 @@ def gutachten_view(request, pk):
     if not path.exists():
         raise Http404
     text = extract_text(path)
-    return render(request, "gutachten_view.html", {"projekt": projekt, "text": text})
+    html = markdown.markdown(text)
+    return render(
+        request,
+        "gutachten_view.html",
+        {"projekt": projekt, "text_html": html},
+    )
 
 
 @login_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ google-generativeai
 python-dotenv
 python-docx
 Pillow
+rich

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -2,7 +2,7 @@
 {% block title %}Gutachten anzeigen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>
-<pre class="whitespace-pre-wrap bg-gray-100 p-2 rounded">{{ text }}</pre>
+<div class="prose max-w-none bg-gray-100 p-2 rounded">{{ text_html|safe }}</div>
 <p class="mt-4">
     <a href="{% url 'gutachten_edit' projekt.pk %}" class="text-blue-700 underline">Bearbeiten</a>
     |

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -113,8 +113,8 @@ function renderLLM(data){
      <button id="ctx-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Add Additional Context & Recheck (Initial)</button>
    </div>`;
  }else if(data.ist_llm_geprueft && data.llm_validated){
-   sec.innerHTML=`<button id="toggle" class="bg-green-600 text-white px-4 py-2 rounded mb-2">Show/Hide Initial LLM Response</button>
-   <pre id="output" class="whitespace-pre-wrap bg-gray-100 p-2 rounded hidden">${data.llm_initial_output}</pre>`;
+  sec.innerHTML=`<button id="toggle" class="bg-green-600 text-white px-4 py-2 rounded mb-2">Show/Hide Initial LLM Response</button>
+  <div id="output" class="prose max-w-none bg-gray-100 p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
  }
  if(data.llm_initial_output){
    sec.innerHTML += `<button id="recheck" class="bg-blue-600 text-white px-4 py-2 rounded mt-2">Recheck (Initial)</button>`;


### PR DESCRIPTION
## Summary
- render gutachten and project LLM output as HTML via `markdown.markdown`
- pretty-print CLI outputs with `rich.markdown.Markdown`
- document Markdown handling in the README
- add rich to requirements

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68484347d6d8832b8d2f7c2c14b77c92