### PR TITLE
Implement Anlage2 function admin

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,6 +1,14 @@
 from django import forms
 from pathlib import Path
-from .models import Recording, BVProject, BVProjectFile, Anlage1Question, Area
+from .models import (
+    Recording,
+    BVProject,
+    BVProjectFile,
+    Anlage1Question,
+    Anlage2Function,
+    Anlage2SubQuestion,
+    Area,
+)
 from .llm_tasks import ANLAGE1_QUESTIONS
 
 
@@ -239,3 +247,46 @@ class Anlage1ReviewForm(forms.Form):
             out[key] = q_data
         return out
 
+
+
+class Anlage2FunctionForm(forms.ModelForm):
+    """Formular für eine Funktion aus Anlage 2."""
+
+    class Meta:
+        model = Anlage2Function
+        fields = [
+            "name",
+            "technisch_vorhanden",
+            "einsatz_bei_telefonica",
+            "zur_lv_kontrolle",
+            "ki_beteiligung",
+        ]
+        widgets = {
+            "name": forms.TextInput(attrs={"class": "border rounded p-2"}),
+            "technisch_vorhanden": forms.CheckboxInput(attrs={"class": "mr-2"}),
+            "einsatz_bei_telefonica": forms.CheckboxInput(attrs={"class": "mr-2"}),
+            "zur_lv_kontrolle": forms.CheckboxInput(attrs={"class": "mr-2"}),
+            "ki_beteiligung": forms.CheckboxInput(attrs={"class": "mr-2"}),
+        }
+
+
+class Anlage2SubQuestionForm(forms.ModelForm):
+    """Formular für eine Unterfrage zu Anlage 2."""
+
+    class Meta:
+        model = Anlage2SubQuestion
+        fields = [
+            "frage_text",
+            "technisch_vorhanden",
+            "einsatz_bei_telefonica",
+            "zur_lv_kontrolle",
+            "ki_beteiligung",
+        ]
+        labels = {"frage_text": "Frage"}
+        widgets = {
+            "frage_text": forms.Textarea(attrs={"class": "border rounded p-2", "rows": 3}),
+            "technisch_vorhanden": forms.CheckboxInput(attrs={"class": "mr-2"}),
+            "einsatz_bei_telefonica": forms.CheckboxInput(attrs={"class": "mr-2"}),
+            "zur_lv_kontrolle": forms.CheckboxInput(attrs={"class": "mr-2"}),
+            "ki_beteiligung": forms.CheckboxInput(attrs={"class": "mr-2"}),
+        }

--- a/core/urls.py
+++ b/core/urls.py
@@ -55,6 +55,41 @@ urlpatterns = [
     path("projects-admin/prompts/", views.admin_prompts, name="admin_prompts"),
     path("projects-admin/models/", views.admin_models, name="admin_models"),
     path("projects-admin/anlage1/", views.admin_anlage1, name="admin_anlage1"),
+    path(
+        "projects-admin/anlage2/",
+        views.anlage2_function_list,
+        name="anlage2_function_list",
+    ),
+    path(
+        "projects-admin/anlage2/new/",
+        views.anlage2_function_form,
+        name="anlage2_function_new",
+    ),
+    path(
+        "projects-admin/anlage2/<int:pk>/edit/",
+        views.anlage2_function_form,
+        name="anlage2_function_edit",
+    ),
+    path(
+        "projects-admin/anlage2/<int:pk>/delete/",
+        views.anlage2_function_delete,
+        name="anlage2_function_delete",
+    ),
+    path(
+        "projects-admin/anlage2/<int:function_pk>/subquestion/new/",
+        views.anlage2_subquestion_form,
+        name="anlage2_subquestion_new",
+    ),
+    path(
+        "projects-admin/anlage2/subquestion/<int:pk>/edit/",
+        views.anlage2_subquestion_form,
+        name="anlage2_subquestion_edit",
+    ),
+    path(
+        "projects-admin/anlage2/subquestion/<int:pk>/delete/",
+        views.anlage2_subquestion_delete,
+        name="anlage2_subquestion_delete",
+    ),
     path("work/projekte/", views.projekt_list, name="projekt_list"),
     path("work/projekte/neu/", views.projekt_create, name="projekt_create"),
     path("work/projekte/<int:pk>/", views.projekt_detail, name="projekt_detail"),

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -1,0 +1,58 @@
+{% extends 'base.html' %}
+{% block title %}{% if funktion %}Funktion bearbeiten{% else %}Neue Funktion{% endif %}{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">{% if funktion %}Funktion bearbeiten{% else %}Neue Funktion{% endif %}</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.name.label_tag }}<br>
+        {{ form.name }}
+        {{ form.name.errors }}
+    </div>
+    <div>
+        <label class="mr-2">{{ form.technisch_vorhanden }} Technisch vorhanden</label>
+    </div>
+    <div>
+        <label class="mr-2">{{ form.einsatz_bei_telefonica }} Einsatz bei Telefónica</label>
+    </div>
+    <div>
+        <label class="mr-2">{{ form.zur_lv_kontrolle }} Zur LV-Kontrolle</label>
+    </div>
+    <div>
+        <label class="mr-2">{{ form.ki_beteiligung }} KI-Beteiligung</label>
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+</form>
+{% if funktion %}
+<h2 class="text-xl font-semibold mt-8 mb-2">Unterfragen</h2>
+<a href="{% url 'anlage2_subquestion_new' funktion.id %}" class="inline-block mb-2 px-3 py-1 bg-green-600 text-white rounded">Neue Unterfrage</a>
+<table class="min-w-full">
+    <thead>
+        <tr class="border-b text-left">
+            <th class="py-2">Frage</th>
+            <th class="py-2 text-center">Bearbeiten</th>
+            <th class="py-2 text-center">Löschen</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for q in subquestions %}
+        <tr class="border-b text-sm">
+            <td class="py-1">{{ q.frage_text|truncatechars:80 }}</td>
+            <td class="py-1 text-center">
+                <a href="{% url 'anlage2_subquestion_edit' q.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
+            </td>
+            <td class="py-1 text-center">
+                <form action="{% url 'anlage2_subquestion_delete' q.id %}" method="post" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Unterfrage wirklich löschen?');">Löschen</button>
+                </form>
+            </td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="3" class="py-2">Keine Unterfragen vorhanden.</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/templates/anlage2/function_list.html
+++ b/templates/anlage2/function_list.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block title %}Anlage 2 Funktionen{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen</h1>
+<a href="{% url 'anlage2_function_new' %}" class="inline-block mb-4 px-4 py-2 bg-blue-600 text-white rounded">Neue Funktion</a>
+<table class="min-w-full">
+    <thead>
+        <tr class="border-b text-left">
+            <th class="py-2">Name</th>
+            <th class="py-2 text-center">Bearbeiten</th>
+            <th class="py-2 text-center">Löschen</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for f in functions %}
+        <tr class="border-b text-sm">
+            <td class="py-1">{{ f.name }}</td>
+            <td class="py-1 text-center">
+                <a href="{% url 'anlage2_function_edit' f.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
+            </td>
+            <td class="py-1 text-center">
+                <form action="{% url 'anlage2_function_delete' f.id %}" method="post" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Funktion wirklich löschen?');">Löschen</button>
+                </form>
+            </td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="3" class="py-2">Keine Funktionen vorhanden.</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/anlage2/subquestion_form.html
+++ b/templates/anlage2/subquestion_form.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% block title %}{% if subquestion %}Unterfrage bearbeiten{% else %}Neue Unterfrage{% endif %}{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">{% if subquestion %}Unterfrage bearbeiten{% else %}Neue Unterfrage{% endif %}</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.frage_text.label_tag }}<br>
+        {{ form.frage_text }}
+        {{ form.frage_text.errors }}
+    </div>
+    <div>
+        <label class="mr-2">{{ form.technisch_vorhanden }} Technisch vorhanden</label>
+    </div>
+    <div>
+        <label class="mr-2">{{ form.einsatz_bei_telefonica }} Einsatz bei Telefónica</label>
+    </div>
+    <div>
+        <label class="mr-2">{{ form.zur_lv_kontrolle }} Zur LV-Kontrolle</label>
+    </div>
+    <div>
+        <label class="mr-2">{{ form.ki_beteiligung }} KI-Beteiligung</label>
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add forms for managing Anlage 2 functions and subquestions
- implement views and URL patterns for Anlage 2 admin pages
- create templates to list and edit functions and subquestions

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684859c69be4832bac6f38855893d9e9