### PR TITLE
Add admin JSON import/export for Anlage-2 functions

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -290,3 +290,17 @@ class Anlage2SubQuestionForm(forms.ModelForm):
             "zur_lv_kontrolle": forms.CheckboxInput(attrs={"class": "mr-2"}),
             "ki_beteiligung": forms.CheckboxInput(attrs={"class": "mr-2"}),
         }
+
+
+class Anlage2FunctionImportForm(forms.Form):
+    """Formular für den JSON-Import des Funktionskatalogs."""
+
+    json_file = forms.FileField(
+        label="JSON-Datei",
+        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
+    )
+    clear_first = forms.BooleanField(
+        required=False,
+        label="Datenbank vorher leeren",
+        widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
+    )

--- a/core/urls.py
+++ b/core/urls.py
@@ -76,6 +76,16 @@ urlpatterns = [
         name="anlage2_function_delete",
     ),
     path(
+        "projects-admin/anlage2/import/",
+        views.anlage2_function_import,
+        name="anlage2_function_import",
+    ),
+    path(
+        "projects-admin/anlage2/export/",
+        views.anlage2_function_export,
+        name="anlage2_function_export",
+    ),
+    path(
         "projects-admin/anlage2/<int:function_pk>/subquestion/new/",
         views.anlage2_subquestion_form,
         name="anlage2_subquestion_new",

--- a/templates/anlage2/function_import.html
+++ b/templates/anlage2/function_import.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}Funktionen importieren{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Funktionen importieren</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.json_file.label_tag }}<br>
+        {{ form.json_file }}
+        {{ form.json_file.errors }}
+    </div>
+    <div>
+        <label class="mr-2">{{ form.clear_first }} Datenbank vorher leeren</label>
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Importieren</button>
+</form>
+{% endblock %}

--- a/templates/anlage2/function_list.html
+++ b/templates/anlage2/function_list.html
@@ -2,7 +2,11 @@
 {% block title %}Anlage 2 Funktionen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen</h1>
-<a href="{% url 'anlage2_function_new' %}" class="inline-block mb-4 px-4 py-2 bg-blue-600 text-white rounded">Neue Funktion</a>
+<div class="mb-4 space-x-2">
+    <a href="{% url 'anlage2_function_new' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Neue Funktion</a>
+    <a href="{% url 'anlage2_function_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
+    <a href="{% url 'anlage2_function_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
+</div>
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">


### PR DESCRIPTION
## Summary
- add form `Anlage2FunctionImportForm`
- implement admin views for JSON import and export
- link import/export on the function list page
- wire up URLs for the new actions
- cover import/export with tests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68485c98386c832b98b5291932a1a57d