### PR TITLE
Update README with function catalog administration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,8 @@ zusätzliche Inline-Tabelle, über die sich die verfügbaren Tiles wie
 Das Django-Admin wurde optisch überarbeitet. Eine Seitenleiste listet alle
 Modelle übersichtlich auf und bietet eine Suchleiste. Die neue Datei
 `static/css/admin.css` steuert das Layout.
+
+### Funktionskatalog verwalten
+
+Administratorinnen und Administratoren erreichen die Übersicht aller Anlage‑2-Funktionen unter `/projects-admin/anlage2/`. Dort lassen sich neue Einträge anlegen, vorhandene Funktionen bearbeiten und auch wieder löschen. Über den Button **Importieren** kann eine JSON-Datei hochgeladen werden, die den Funktionskatalog enthält. Ist `/projects-admin/anlage2/import/` aufrufbar, bietet das Formular zudem die Option, die Datenbank vor dem Import zu leeren. Mit **Exportieren** wird der aktuelle Katalog als JSON unter `/projects-admin/anlage2/export/` heruntergeladen. Der Zugriff auf alle genannten URLs erfordert Mitgliedschaft in der Gruppe `admin`.
+


### PR DESCRIPTION
## Summary
- document how admins can import, edit and export Anlage-2 functions

## Testing
- `python manage.py makemigrations --check` *(fails: Couldn't import Django)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684860a0e4d0832bbe71b7677a9f150f