### PR TITLE
Add german import keys support

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1596,6 +1596,29 @@ class FunctionImportExportTests(TestCase):
         self.assertRedirects(resp, reverse("anlage2_function_list"))
         self.assertTrue(Anlage2Function.objects.filter(name="Login").exists())
 
+    def test_import_accepts_german_keys(self):
+        payload = json.dumps([
+            {
+                "funktion": "Anwesenheit",
+                "unterfragen": [
+                    {"frage": "Testfrage"}
+                ],
+            }
+        ])
+        file = SimpleUploadedFile("func_de.json", payload.encode("utf-8"))
+        url = reverse("anlage2_function_import")
+        resp = self.client.post(
+            url,
+            {"json_file": file, "clear_first": "on"},
+            format="multipart",
+        )
+        self.assertRedirects(resp, reverse("anlage2_function_list"))
+        self.assertTrue(Anlage2Function.objects.filter(name="Anwesenheit").exists())
+        self.assertEqual(
+            Anlage2SubQuestion.objects.filter(funktion__name="Anwesenheit").count(),
+            1,
+        )
+
 
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -874,7 +874,8 @@ def anlage2_function_import(request):
             Anlage2SubQuestion.objects.all().delete()
             Anlage2Function.objects.all().delete()
         for entry in items:
-            func, _ = Anlage2Function.objects.get_or_create(name=entry.get("name", ""))
+            name = entry.get("name") or entry.get("funktion") or ""
+            func, _ = Anlage2Function.objects.get_or_create(name=name)
             for field in [
                 "technisch_vorhanden",
                 "einsatz_bei_telefonica",
@@ -884,9 +885,10 @@ def anlage2_function_import(request):
                 if field in entry:
                     setattr(func, field, entry.get(field))
             func.save()
-            for sub in entry.get("subquestions", []):
+            subs = entry.get("subquestions") or entry.get("unterfragen") or []
+            for sub in subs:
                 if isinstance(sub, dict):
-                    text = sub.get("frage_text", "")
+                    text = sub.get("frage_text") or sub.get("frage") or ""
                     vals = sub
                 else:
                     text = str(sub)


### PR DESCRIPTION
## Summary
- allow Anlage2 JSON import to read german keys `funktion`, `unterfragen`, `frage`
- add tests for german import structure

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684865559940832b983162fdaf7a2ed2