### PR TITLE
Add Anlage 2 review form

### DIFF
--- a/core/templatetags/recording_extras.py
+++ b/core/templatetags/recording_extras.py
@@ -7,3 +7,11 @@ register = template.Library()
 @register.filter
 def basename(value):
     return Path(value).name
+
+
+@register.filter
+def get_item(data, key):
+    """Gibt ``data[key]`` zur\u00fcck, falls vorhanden."""
+    if isinstance(data, dict):
+        return data.get(key, "")
+    return ""

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% load recording_extras %}
+{% block title %}Anlage 2 Review{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen prüfen</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    <table class="table-auto w-full border">
+        <thead>
+            <tr>
+                <th class="border px-2">Funktion</th>
+                {% for label in labels %}
+                <th class="border px-2">{{ label }} (Analyse)</th>
+                {% endfor %}
+                {% for label in labels %}
+                <th class="border px-2">{{ label }} (Review)</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+        {% for row in rows %}
+            <tr>
+                <td class="border px-2 {% if row.sub %}pl-8{% endif %}">{{ row.name }}</td>
+                {% for field in fields %}
+                <td class="border px-2 text-center">{{ row.analysis|get_item:field }}</td>
+                {% endfor %}
+                {% for field in row.form_fields %}
+                <td class="border px-2 text-center">{{ field }}</td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded mt-2">Speichern</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `Anlage2ReviewForm` to review functions and subquestions
- show new review table via `projekt_file_anlage2_review.html`
- hook form into `projekt_file_edit_json`
- extend template tags with `get_item`
- test GET/POST behaviour for Anlage 2

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684886abf278832ba6ee80e476cf7898