### PR TITLE
feat: manueller LLM-Check für Anlage 2

### DIFF
--- a/core/migrations/0038_bvproject_gutachten_function_note.py
+++ b/core/migrations/0038_bvproject_gutachten_function_note.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0037_add_source_to_functionresult"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="bvproject",
+            name="gutachten_function_note",
+            field=models.TextField(blank=True, verbose_name="LLM-Hinweis Gutachten"),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -80,6 +80,9 @@ class BVProject(models.Model):
     llm_geprueft_am = models.DateTimeField("LLM geprüft am", null=True, blank=True)
     classification_json = models.JSONField("Klassifizierung", null=True, blank=True)
     gutachten_file = models.FileField("Gutachten", upload_to="gutachten", blank=True)
+    gutachten_function_note = models.TextField(
+        "LLM-Hinweis Gutachten", blank=True
+    )
 
     class Meta:
         ordering = ["-created_at"]

--- a/core/urls.py
+++ b/core/urls.py
@@ -175,6 +175,11 @@ urlpatterns = [
         views.gutachten_delete,
         name="gutachten_delete",
     ),
+    path(
+        "work/projekte/<int:pk>/gutachten/llm-check/",
+        views.gutachten_llm_check,
+        name="gutachten_llm_check",
+    ),
     path("projects/<int:pk>/", views.project_detail_api, name="project_detail_api"),
     path(
         "projects/<int:pk>/llm-check/",

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -8,4 +8,21 @@
     |
     <a href="{{ projekt.gutachten_file.url }}" class="text-blue-700 underline">Download</a>
 </p>
+{% if projekt.gutachten_function_note %}
+<div class="mt-4">
+    <label class="font-semibold">LLM-Vorschlag:</label>
+    <textarea class="border rounded w-full p-2" rows="6" readonly>{{ projekt.gutachten_function_note }}</textarea>
+</div>
+{% endif %}
+<form method="post" action="{% url 'gutachten_llm_check' projekt.pk %}" class="mt-4">
+    {% csrf_token %}
+    <label class="font-semibold">LLM-Modell:</label>
+    {% for key, data in categories.items %}
+        <label class="ml-2">
+            <input type="radio" name="model_category" value="{{ key }}" {% if key == category %}checked{% endif %}>
+            {{ data.label }}
+        </label>
+    {% endfor %}
+    <button type="submit" class="bg-purple-600 text-white px-4 py-2 rounded ml-2">LLM-Funktionscheck</button>
+</form>
 {% endblock %}

--- a/templates/projekt_file_check_result.html
+++ b/templates/projekt_file_check_result.html
@@ -11,6 +11,9 @@
         </label>
     {% endfor %}
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded ml-2">Neu prüfen</button>
+    {% if anlage.anlage_nr == 2 %}
+    <button type="submit" name="llm" value="1" class="bg-purple-600 text-white px-4 py-2 rounded ml-2">LLM-Check</button>
+    {% endif %}
 </form>
 <form method="post" class="space-y-4">
     {% csrf_token %}


### PR DESCRIPTION
## Summary
- führe bei GET nur eine Parser-Analyse der Anlage 2 aus
- füge neuen LLM-Check-Button hinzu
- ermögliche LLM-Ausführung über Parameter `llm`
- teste neues Verhalten
- prüfe Gutachten mit LLM auf weitere Funktionen

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68489bfc148c832ba7d45ad040d2c8fb