### PR TITLE
fix: Header in Anlage2-Tabelle flexibler

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -30,16 +30,29 @@ def parse_anlage2_table(path: Path) -> dict[str, dict[str, bool | None]]:
         return {}
 
     results: dict[str, dict[str, bool | None]] = {}
+
+    aliases = {
+        "steht technisch zur verfügung?": "technisch vorhanden",
+        "steht technisch zur verfuegung?": "technisch vorhanden",
+        "einsatz bei telefonica": "einsatz bei telefónica",
+        "einsatz bei telefonica?": "einsatz bei telefónica",
+        "zur lv kontrolle": "zur lv-kontrolle",
+        "zur lv kontrolle?": "zur lv-kontrolle",
+        "ki-beteiligung?": "ki-beteiligung",
+    }
+
     for table in doc.tables:
-        headers = [cell.text.strip().lower() for cell in table.rows[0].cells]
+        raw_headers = [cell.text.replace("\n", " ").replace("\r", " ") for cell in table.rows[0].cells]
+        headers = [" ".join(h.split()).lower() for h in raw_headers]
+        normalized = [aliases.get(h, h) for h in headers]
         try:
-            idx_func = headers.index("funktion")
-            idx_tech = headers.index("technisch vorhanden")
-            idx_tel = headers.index("einsatz bei telefónica")
-            idx_lv = headers.index("zur lv-kontrolle")
+            idx_func = normalized.index("funktion")
+            idx_tech = normalized.index("technisch vorhanden")
+            idx_tel = normalized.index("einsatz bei telefónica")
+            idx_lv = normalized.index("zur lv-kontrolle")
         except ValueError:
             continue
-        idx_ki = headers.index("ki-beteiligung") if "ki-beteiligung" in headers else None
+        idx_ki = normalized.index("ki-beteiligung") if "ki-beteiligung" in normalized else None
 
         for row in table.rows[1:]:
             func = row.cells[idx_func].text.strip()

--- a/core/tests.py
+++ b/core/tests.py
@@ -184,6 +184,41 @@ class DocxExtractTests(TestCase):
             },
         )
 
+    def test_parse_anlage2_table_alias_headers(self):
+        doc = Document()
+        table = doc.add_table(rows=2, cols=5)
+        table.cell(0, 0).text = "Funktion"
+        table.cell(0, 1).text = "Steht technisch zur Verfügung?"
+        table.cell(0, 2).text = "Einsatz bei Telefonica"
+        table.cell(0, 3).text = "Zur LV Kontrolle"
+        table.cell(0, 4).text = "KI-Beteiligung"
+
+        table.cell(1, 0).text = "Login"
+        table.cell(1, 1).text = "Ja"
+        table.cell(1, 2).text = "Nein"
+        table.cell(1, 3).text = "Nein"
+        table.cell(1, 4).text = "Ja"
+
+        tmp = NamedTemporaryFile(delete=False, suffix=".docx")
+        doc.save(tmp.name)
+        tmp.close()
+        try:
+            data = parse_anlage2_table(Path(tmp.name))
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+        self.assertEqual(
+            data,
+            {
+                "Login": {
+                    "technisch_verfuegbar": True,
+                    "einsatz_telefonica": False,
+                    "zur_lv_kontrolle": False,
+                    "ki_beteiligung": True,
+                }
+            },
+        )
+
 
 class BVProjectFormTests(TestCase):
     def test_project_form_docx_validation(self):

--- a/core/views.py
+++ b/core/views.py
@@ -1667,7 +1667,10 @@ def gutachten_llm_check(request, pk):
     category = request.POST.get("model_category")
     model = LLMConfig.get_default(category) if category else None
     try:
-        check_gutachten_functions(projekt.pk, model_name=model)
+        note = check_gutachten_functions(projekt.pk, model_name=model)
+        if note:
+            projekt.gutachten_function_note = note
+            projekt.save(update_fields=["gutachten_function_note"])
         messages.success(request, "Gutachten geprüft")
     except ValueError:
         messages.error(request, "Kein Gutachten vorhanden")


### PR DESCRIPTION
## Summary
- verbessere die Erkennung von Spaltenüberschriften in `parse_anlage2_table`
- akzeptiere alternative Header in den Tests
- speichere Rückgabewert von `check_gutachten_functions`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684938e28070832bb8a1301e4067c791