### PR TITLE
feat: verwalte anlage2 spalten

### DIFF
--- a/core/migrations/0042_add_alias_headings.py
+++ b/core/migrations/0042_add_alias_headings.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+def add_headings(apps, schema_editor):
+    Config = apps.get_model('core', 'Anlage2Config')
+    Heading = apps.get_model('core', 'Anlage2ColumnHeading')
+    for cfg in Config.objects.all():
+        Heading.objects.get_or_create(
+            config=cfg,
+            field_name='einsatz_bei_telefonica',
+            text='einsatzweise bei telefónica: soll die funktion verwendet werden?'
+        )
+        Heading.objects.get_or_create(
+            config=cfg,
+            field_name='zur_lv_kontrolle',
+            text='einsatzweise bei telefónica: soll zur überwachung von leistung oder verhalten verwendet werden?'
+        )
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0041_anlage2columnheading'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_headings, migrations.RunPython.noop),
+    ]

--- a/core/tests.py
+++ b/core/tests.py
@@ -18,6 +18,7 @@ from .models import (
     Area,
     Anlage2Function,
     Anlage2Config,
+    Anlage2ColumnHeading,
     Anlage2SubQuestion,
     Anlage2FunctionResult,
 )
@@ -227,12 +228,29 @@ class DocxExtractTests(TestCase):
         self.assertTrue(data["Login"]["technisch_verfuegbar"])
 
     def test_parse_anlage2_table_alias_headers(self):
+        cfg = Anlage2Config.objects.create()
+        Anlage2ColumnHeading.objects.create(
+            config=cfg,
+            field_name="technisch_vorhanden",
+            text="Steht technisch zur Verfügung?",
+        )
+        Anlage2ColumnHeading.objects.create(
+            config=cfg,
+            field_name="einsatz_bei_telefonica",
+            text="einsatzweise bei telefónica: soll die funktion verwendet werden?",
+        )
+        Anlage2ColumnHeading.objects.create(
+            config=cfg,
+            field_name="zur_lv_kontrolle",
+            text="einsatzweise bei telefónica: soll zur überwachung von leistung oder verhalten verwendet werden?",
+        )
+
         doc = Document()
         table = doc.add_table(rows=2, cols=5)
         table.cell(0, 0).text = "Funktion"
         table.cell(0, 1).text = "Steht technisch zur Verfügung?"
-        table.cell(0, 2).text = "Einsatz bei Telefonica"
-        table.cell(0, 3).text = "Zur LV Kontrolle"
+        table.cell(0, 2).text = "einsatzweise bei Telefónica: soll die Funktion verwendet werden?"
+        table.cell(0, 3).text = "einsatzweise bei Telefónica: soll zur Überwachung von Leistung oder Verhalten verwendet werden?"
         table.cell(0, 4).text = "KI-Beteiligung"
 
         table.cell(1, 0).text = "Login"

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -9,24 +9,60 @@
             <tr class="border-b text-left">
                 <th class="py-2">Feld</th>
                 <th class="py-2">Bezeichnung</th>
+                <th class="py-2 text-center">Löschen</th>
             </tr>
         </thead>
         <tbody>
             <tr class="border-b text-sm">
                 <td class="py-1 font-semibold">Technisch vorhanden</td>
                 <td class="py-1"><input type="text" name="col_technisch_vorhanden" value="{{ config.col_technisch_vorhanden }}" class="border rounded p-2 w-full"></td>
+                <td></td>
             </tr>
             <tr class="border-b text-sm">
                 <td class="py-1 font-semibold">Einsatz bei Telefónica</td>
                 <td class="py-1"><input type="text" name="col_einsatz_bei_telefonica" value="{{ config.col_einsatz_bei_telefonica }}" class="border rounded p-2 w-full"></td>
+                <td></td>
             </tr>
             <tr class="border-b text-sm">
                 <td class="py-1 font-semibold">Zur LV-Kontrolle</td>
                 <td class="py-1"><input type="text" name="col_zur_lv_kontrolle" value="{{ config.col_zur_lv_kontrolle }}" class="border rounded p-2 w-full"></td>
+                <td></td>
             </tr>
             <tr class="border-b text-sm">
                 <td class="py-1 font-semibold">KI-Beteiligung</td>
                 <td class="py-1"><input type="text" name="col_ki_beteiligung" value="{{ config.col_ki_beteiligung }}" class="border rounded p-2 w-full"></td>
+                <td></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h2 class="text-xl font-semibold mt-6 mb-2">Aliasüberschriften</h2>
+    <table class="min-w-full mb-4">
+        <thead>
+            <tr class="border-b text-left">
+                <th class="py-2">Feld</th>
+                <th class="py-2">Text</th>
+                <th class="py-2 text-center">Entfernen</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for h in aliases %}
+            <tr class="border-b text-sm">
+                <td class="py-1">{{ h.get_field_name_display }}</td>
+                <td class="py-1">{{ h.text }}</td>
+                <td class="py-1 text-center"><input type="checkbox" name="delete{{ h.id }}"></td>
+            </tr>
+        {% endfor %}
+            <tr class="border-b text-sm">
+                <td class="py-1">
+                    <select name="new_field" class="border rounded p-2 w-full">
+                    {% for val, label in choices %}
+                        <option value="{{ val }}">{{ label }}</option>
+                    {% endfor %}
+                    </select>
+                </td>
+                <td class="py-1"><input type="text" name="new_text" class="border rounded p-2 w-full"></td>
+                <td></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- allow managing Anlage2 column header aliases in the admin view
- load aliases for parsing tables from database
- seed two new aliases via migration
- adjust tests for database driven aliases

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68499702d9b4832ba5b29420b693c8fe