### PR TITLE
Add header debug info in parse_anlage2_table

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -128,9 +128,8 @@ def parse_anlage2_table(path: Path) -> dict[str, dict[str, bool | None]]:
             for h in headers_raw
         ]
         logger.debug(
-            f"Tabelle {table_idx}: Roh-Header = {headers_raw}"
+            f"Tabelle {table_idx}: Roh-Header = {headers_raw}, Normiert = {headers}"
         )
-        logger.debug(f"Tabelle {table_idx}: Normalisierte Header = {headers}")
         try:
             idx_func = headers.index("funktion")
             idx_tech = headers.index("technisch vorhanden")

--- a/core/tests.py
+++ b/core/tests.py
@@ -170,7 +170,26 @@ class DocxExtractTests(TestCase):
         doc.save(tmp.name)
         tmp.close()
         try:
-            data = parse_anlage2_table(Path(tmp.name))
+            with patch("core.docx_utils.logging.getLogger") as mock_get_logger:
+                mock_logger = mock_get_logger.return_value
+                data = parse_anlage2_table(Path(tmp.name))
+                expected_raw = [
+                    "Funktion",
+                    "Technisch vorhanden",
+                    "Einsatz bei Telefónica",
+                    "Zur LV-Kontrolle",
+                    "KI-Beteiligung",
+                ]
+                expected_norm = [
+                    "funktion",
+                    "technisch vorhanden",
+                    "einsatz bei telefónica",
+                    "zur lv-kontrolle",
+                    "ki-beteiligung",
+                ]
+                mock_logger.debug.assert_any_call(
+                    f"Tabelle 0: Roh-Header = {expected_raw}, Normiert = {expected_norm}"
+                )
         finally:
             Path(tmp.name).unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary
- improve header logging in `parse_anlage2_table`
- extend unit test to verify new log message

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6849ad98bb3c832b831f834f9d875773