### PR TITLE
feat: erweitere header-normalisierung

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -38,7 +38,10 @@ def _normalize_header_text(text: str) -> str:
     text = text.replace("\n", " ")
     text = re.sub(r"ja\s*/\s*nein", "", text, flags=re.I)
     text = text.strip().lower()
-    text = re.sub(r"\s+", " ", text)
+    # Fragezeichen und Doppelpunkte am Ende entfernen
+    text = re.sub(r"[?:]+$", "", text).strip()
+    # Mehrere Leerzeichen und Tabulatoren vereinheitlichen
+    text = re.sub(r"[ \t]+", " ", text)
     return text
 
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -22,7 +22,7 @@ from .models import (
     Anlage2SubQuestion,
     Anlage2FunctionResult,
 )
-from .docx_utils import extract_text, parse_anlage2_table
+from .docx_utils import extract_text, parse_anlage2_table, _normalize_header_text
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from docx import Document
@@ -150,6 +150,17 @@ class DocxExtractTests(TestCase):
         finally:
             Path(tmp.name).unlink(missing_ok=True)
         self.assertIn("Das ist ein Test", text)
+
+    def test_normalize_header_text_variants(self):
+        cases = {
+            "Technisch vorhanden?": "technisch vorhanden",
+            "Technisch vorhanden:" : "technisch vorhanden",
+            "Technisch   vorhanden": "technisch vorhanden",
+            "Technisch\tvorhanden": "technisch vorhanden",
+            " Verf\u00fcgbar?\t": "verf\u00fcgbar",
+        }
+        for raw, expected in cases.items():
+            self.assertEqual(_normalize_header_text(raw), expected)
 
     def test_parse_anlage2_table(self):
         doc = Document()


### PR DESCRIPTION
## Summary
- erweitere `_normalize_header_text` um Entfernung von `?` und `:` am Ende
- vereinheitliche Tabulatoren und Mehrfachleerzeichen
- teste verschiedene Header-Schreibweisen

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6849b003b2d8832b97dae6902f990fa1