### PR TITLE
Fix header alias resolution

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -72,7 +72,8 @@ def _build_header_map(cfg: Anlage2Config | None) -> dict[str, str]:
     for h in Anlage2ColumnHeading.objects.all():
         canonical = field_map.get(h.field_name)
         if canonical:
-            mapping[_normalize_header_text(h.text)] = canonical
+            norm = _normalize_header_text(h.text)
+            mapping.setdefault(norm, canonical)
 
     return mapping
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -406,6 +406,48 @@ class DocxExtractTests(TestCase):
             },
         )
 
+    def test_parse_anlage2_table_alias_conflict(self):
+        cfg1 = Anlage2Config.objects.create()
+        cfg2 = Anlage2Config.objects.create()
+        conflict = "Konflikt"
+        Anlage2ColumnHeading.objects.create(
+            config=cfg1, field_name="technisch_vorhanden", text=conflict
+        )
+        Anlage2ColumnHeading.objects.create(
+            config=cfg2, field_name="einsatz_bei_telefonica", text=conflict
+        )
+
+        doc = Document()
+        table = doc.add_table(rows=2, cols=4)
+        table.cell(0, 0).text = "Funktion"
+        table.cell(0, 1).text = conflict
+        table.cell(0, 2).text = "Einsatz bei Telefónica"
+        table.cell(0, 3).text = "Zur LV-Kontrolle"
+
+        table.cell(1, 0).text = "Login"
+        table.cell(1, 1).text = "Ja"
+        table.cell(1, 2).text = "Nein"
+        table.cell(1, 3).text = "Nein"
+
+        tmp = NamedTemporaryFile(delete=False, suffix=".docx")
+        doc.save(tmp.name)
+        tmp.close()
+        try:
+            data = parse_anlage2_table(Path(tmp.name))
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+        self.assertEqual(
+            data,
+            {
+                "Login": {
+                    "technisch_verfuegbar": True,
+                    "einsatz_telefonica": False,
+                    "zur_lv_kontrolle": False,
+                }
+            },
+        )
+
 
 class BVProjectFormTests(TestCase):
     def test_project_form_docx_validation(self):


### PR DESCRIPTION
## Summary
- prevent global aliases from overriding local headings in `_build_header_map`
- test conflict scenario for `parse_anlage2_table`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6849b6b9eb3c832b9c413b774cd5c86a