### PR TITLE
Fix exception handling in file upload

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1125,8 +1125,9 @@ def projekt_file_upload(request, pk):
             else:
                 try:
                     content = uploaded.read().decode("utf-8")
-                except Exception:
-                    pass
+                except UnicodeDecodeError as exc:
+                    logger.error("Datei konnte nicht als UTF-8 dekodiert werden: %s", exc)
+                    return HttpResponseBadRequest("Ungültiges Dateiformat")
             obj = form.save(commit=False)
             obj.projekt = projekt
             obj.text_content = content


### PR DESCRIPTION
## Summary
- handle Unicode decode errors in `projekt_file_upload` view

## Testing
- `python manage.py makemigrations --check` *(fails: No module named 'django')*
- `python manage.py test` *(fails: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6849c9a066d4832b832689073343bc2a