### PR TITLE
Add header mapping validation

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -433,20 +433,10 @@ class DocxExtractTests(TestCase):
         doc.save(tmp.name)
         tmp.close()
         try:
-            data = parse_anlage2_table(Path(tmp.name))
+            with self.assertRaises(ValueError):
+                parse_anlage2_table(Path(tmp.name))
         finally:
             Path(tmp.name).unlink(missing_ok=True)
-
-        self.assertEqual(
-            data,
-            {
-                "Login": {
-                    "technisch_verfuegbar": True,
-                    "einsatz_telefonica": False,
-                    "zur_lv_kontrolle": False,
-                }
-            },
-        )
 
 
 class BVProjectFormTests(TestCase):


### PR DESCRIPTION
## Summary
- validate duplicate table headers in `_build_header_map`
- raise ValueError on duplicate header text
- adapt test for alias conflicts

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6849cb32546c832b95843f6028019217