### PR TITLE
Adjust header alias handling

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -97,7 +97,7 @@ def _build_header_map(cfg: Anlage2Config | None) -> dict[str, str]:
         for header in headers:
             _add_mapping(header, canonical)
 
-    global_aliases = list(Anlage2ColumnHeading.objects.all())
+    global_aliases = list(cfg.headers.all()) if cfg else []
     for h in global_aliases:
         canonical = field_map.get(h.field_name)
         if canonical:
@@ -108,7 +108,7 @@ def _build_header_map(cfg: Anlage2Config | None) -> dict[str, str]:
                 _add_mapping(norm, canonical)
 
     logger.debug(
-        "Globale Alias-Überschriften: %s",
+        "Alias-Überschriften: %s",
         [str(h) for h in global_aliases],
     )
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -407,14 +407,13 @@ class DocxExtractTests(TestCase):
         )
 
     def test_parse_anlage2_table_alias_conflict(self):
-        cfg1 = Anlage2Config.objects.create()
-        cfg2 = Anlage2Config.objects.create()
+        cfg = Anlage2Config.objects.create()
         conflict = "Konflikt"
         Anlage2ColumnHeading.objects.create(
-            config=cfg1, field_name="technisch_vorhanden", text=conflict
+            config=cfg, field_name="technisch_vorhanden", text=conflict
         )
         Anlage2ColumnHeading.objects.create(
-            config=cfg2, field_name="einsatz_bei_telefonica", text=conflict
+            config=cfg, field_name="einsatz_bei_telefonica", text=conflict
         )
 
         doc = Document()


### PR DESCRIPTION
## Summary
- use per-config alias headers only
- adapt log message
- update test for alias conflict

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError in command tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849d2e6d084832babfbbc81eb07afda