### PR TITLE
Fix Anzeige erkannter Anlage2-Einträge

### DIFF
--- a/core/templatetags/recording_extras.py
+++ b/core/templatetags/recording_extras.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from django import template
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -15,3 +16,10 @@ def get_item(data, key):
     if isinstance(data, dict):
         return data.get(key, "")
     return ""
+
+
+@register.filter
+def checkbox(value: object) -> str:
+    """Rendert ein deaktiviertes Kontrollkästchen."""
+    checked = " checked" if value is True else ""
+    return mark_safe(f"<input type='checkbox' disabled{checked}>")

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -22,7 +22,7 @@
             <tr>
                 <td class="border px-2 {% if row.sub %}pl-8{% endif %}">{{ row.name }}</td>
                 {% for field in fields %}
-                <td class="border px-2 text-center">{{ row.analysis|get_item:field }}</td>
+                <td class="border px-2 text-center">{{ row.analysis|get_item:field|checkbox }}</td>
                 {% endfor %}
                 {% for field in row.form_fields %}
                 <td class="border px-2 text-center">{{ field }}</td>


### PR DESCRIPTION
## Summary
- neue Template-Filter `checkbox` implementiert
- Checkboxen in Anlage 2 Review verwenden

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fehlschlagend)*

------
https://chatgpt.com/codex/tasks/task_e_6849ee65aa78832bac763bb568760c5d