### PR TITLE
Add debug logging for _analysis_to_initial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ media/
 *.sqlite3
 
 .env
+debug.txt


### PR DESCRIPTION
## Summary
- write Anlage 2 debug info to debug.txt
- log field renames and final result in `_analysis_to_initial`
- ignore generated debug file

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684aad0116f4832ba01a829b585ba37a