### PR TITLE
Add debugging output for Anlage2 view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ media/
 
 .env
 debug.txt
+debug.log


### PR DESCRIPTION
## Summary
- configure logger `anlage2_debug` to log to console and *debug.log*
- extend debug output for answers and rows in `projekt_file_edit_json`
- ignore `debug.log`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684ae0e8d9a8832bab6754b57c0c533f