### PR TITLE
Improve Anlage2 table parsing

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -207,14 +207,15 @@ class DocxExtractTests(TestCase):
 
         self.assertEqual(
             data,
-            {
-                "Login": {
+            [
+                {
+                    "funktion": "Login",
                     "technisch_verfuegbar": True,
                     "einsatz_telefonica": False,
                     "zur_lv_kontrolle": False,
                     "ki_beteiligung": True,
                 }
-            },
+            ],
         )
 
     def test_parse_anlage2_table_multiple_headers(self):
@@ -256,7 +257,7 @@ class DocxExtractTests(TestCase):
         finally:
             Path(tmp.name).unlink(missing_ok=True)
 
-        self.assertTrue(data["Login"]["technisch_verfuegbar"])
+        self.assertTrue(data[0]["technisch_verfuegbar"])
 
     def test_parse_anlage2_table_alias_headers(self):
         cfg = Anlage2Config.get_instance()
@@ -300,14 +301,15 @@ class DocxExtractTests(TestCase):
 
         self.assertEqual(
             data,
-            {
-                "Login": {
+            [
+                {
+                    "funktion": "Login",
                     "technisch_verfuegbar": True,
                     "einsatz_telefonica": False,
                     "zur_lv_kontrolle": False,
                     "ki_beteiligung": True,
                 }
-            },
+            ],
         )
 
 
@@ -357,14 +359,15 @@ class DocxExtractTests(TestCase):
 
         self.assertEqual(
             data,
-            {
-                "Login": {
+            [
+                {
+                    "funktion": "Login",
                     "technisch_verfuegbar": True,
                     "einsatz_telefonica": False,
                     "zur_lv_kontrolle": False,
                     "ki_beteiligung": True,
                 }
-            },
+            ],
         )
 
     def test_parse_anlage2_table_alias_conflict(self):

--- a/core/views.py
+++ b/core/views.py
@@ -132,6 +132,8 @@ def _analysis_to_initial(anlage: BVProjectFile) -> dict:
     rev_map = {v: k for k, v in FIELD_RENAME.items()}
 
     items = data.get("functions")
+    if isinstance(items, dict) and "value" in items:
+        items = items["value"]
     if items is None:
         table_funcs = data.get("table_functions")
         if isinstance(table_funcs, dict):
@@ -1453,6 +1455,8 @@ def projekt_file_edit_json(request, pk):
         funcs = []
         if anlage.analysis_json:
             funcs = anlage.analysis_json.get("functions")
+            if isinstance(funcs, dict) and "value" in funcs:
+                funcs = funcs["value"]
             if funcs is None:
                 table = anlage.analysis_json.get("table_functions")
                 if isinstance(table, dict):


### PR DESCRIPTION
## Summary
- handle hierarchical cells when parsing Anlage 2 table
- update usage in LLM tasks and view
- adjust tests for new table format
- drop outdated debug comments

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684af3004cfc832bb69e3a6c24776d09