### PR TITLE
feat: interaktive Anlage2 Review

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -515,7 +515,13 @@ def check_anlage2(projekt_id: int, model_name: str | None = None) -> dict:
             None,
         )
         logger.debug("Tabellenzeile: %s", row)
-        if row and all(v is not None for k, v in row.items() if k != "funktion"):
+        def _val(item, key):
+            value = item.get(key)
+            if isinstance(value, dict) and "value" in value:
+                return value["value"]
+            return value
+
+        if row and _val(row, "technisch_verfuegbar") is not None and _val(row, "ki_beteiligung") is not None:
             vals = {
                 "technisch_verfuegbar": row.get("technisch_verfuegbar"),
                 "ki_beteiligung": row.get("ki_beteiligung"),
@@ -541,8 +547,8 @@ def check_anlage2(projekt_id: int, model_name: str | None = None) -> dict:
             projekt=projekt,
             funktion=func,
             defaults={
-                "technisch_verfuegbar": vals.get("technisch_verfuegbar"),
-                "ki_beteiligung": vals.get("ki_beteiligung"),
+                "technisch_verfuegbar": _val(vals, "technisch_verfuegbar"),
+                "ki_beteiligung": _val(vals, "ki_beteiligung"),
                 "raw_json": raw,
                 "source": source,
             },

--- a/core/templatetags/recording_extras.py
+++ b/core/templatetags/recording_extras.py
@@ -26,3 +26,11 @@ def checkbox(value: object) -> str:
     """Rendert ein deaktiviertes Kontrollkästchen."""
     checked = " checked" if value is True else ""
     return mark_safe(f"<input type='checkbox' disabled{checked}>")
+
+
+@register.filter
+def raw_item(data, key):
+    """Gibt ``data[key]`` zurück ohne weitere Verarbeitung."""
+    if isinstance(data, dict):
+        return data.get(key)
+    return None

--- a/core/tests.py
+++ b/core/tests.py
@@ -210,10 +210,10 @@ class DocxExtractTests(TestCase):
             [
                 {
                     "funktion": "Login",
-                    "technisch_verfuegbar": True,
-                    "einsatz_telefonica": False,
-                    "zur_lv_kontrolle": False,
-                    "ki_beteiligung": True,
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                    "einsatz_telefonica": {"value": False, "note": None},
+                    "zur_lv_kontrolle": {"value": False, "note": None},
+                    "ki_beteiligung": {"value": True, "note": None},
                 }
             ],
         )
@@ -257,7 +257,7 @@ class DocxExtractTests(TestCase):
         finally:
             Path(tmp.name).unlink(missing_ok=True)
 
-        self.assertTrue(data[0]["technisch_verfuegbar"])
+        self.assertTrue(data[0]["technisch_verfuegbar"]["value"])
 
     def test_parse_anlage2_table_alias_headers(self):
         cfg = Anlage2Config.get_instance()
@@ -304,10 +304,10 @@ class DocxExtractTests(TestCase):
             [
                 {
                     "funktion": "Login",
-                    "technisch_verfuegbar": True,
-                    "einsatz_telefonica": False,
-                    "zur_lv_kontrolle": False,
-                    "ki_beteiligung": True,
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                    "einsatz_telefonica": {"value": False, "note": None},
+                    "zur_lv_kontrolle": {"value": False, "note": None},
+                    "ki_beteiligung": {"value": True, "note": None},
                 }
             ],
         )
@@ -362,10 +362,10 @@ class DocxExtractTests(TestCase):
             [
                 {
                     "funktion": "Login",
-                    "technisch_verfuegbar": True,
-                    "einsatz_telefonica": False,
-                    "zur_lv_kontrolle": False,
-                    "ki_beteiligung": True,
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                    "einsatz_telefonica": {"value": False, "note": None},
+                    "zur_lv_kontrolle": {"value": False, "note": None},
+                    "ki_beteiligung": {"value": True, "note": None},
                 }
             ],
         )
@@ -630,8 +630,8 @@ class LLMTasksTests(TestCase):
             "functions": [
                 {
                     "funktion": "Login",
-                    "technisch_verfuegbar": True,
-                    "ki_beteiligung": True,
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                    "ki_beteiligung": {"value": True, "note": None},
                     "source": "parser",
                 }
             ],
@@ -1219,10 +1219,10 @@ class Anlage2ReviewTests(TestCase):
                 "functions": [
                     {
                         "funktion": "Login",
-                        "technisch_vorhanden": True,
-                        "einsatz_bei_telefonica": False,
-                        "zur_lv_kontrolle": False,
-                        "ki_beteiligung": True,
+                        "technisch_vorhanden": {"value": True, "note": None},
+                        "einsatz_bei_telefonica": {"value": False, "note": None},
+                        "zur_lv_kontrolle": {"value": False, "note": None},
+                        "ki_beteiligung": {"value": True, "note": None},
                     }
                 ]
             },
@@ -1259,9 +1259,9 @@ class Anlage2ReviewTests(TestCase):
             "functions": [
                 {
                     "funktion": "Login",
-                    "technisch_verfuegbar": True,
-                    "einsatz_telefonica": True,
-                    "zur_lv_kontrolle": True,
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                    "einsatz_telefonica": {"value": True, "note": None},
+                    "zur_lv_kontrolle": {"value": True, "note": None},
                 }
             ]
         }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -7,3 +7,20 @@
 .back-link {
     margin-right: 0.5rem;
 }
+
+.status-badge {
+    padding: 0.2em 0.6em;
+    border-radius: 1em;
+    font-size: 0.8em;
+    font-weight: bold;
+    color: white;
+}
+.status-ja {
+    background-color: #28a745;
+}
+.status-nein {
+    background-color: #dc3545;
+}
+.status-unbekannt {
+    background-color: #6c757d;
+}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -5,6 +5,12 @@
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen prüfen</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
+    <div class="filter-controls mb-2">
+        <label>
+            <input type="checkbox" id="show-relevant-only-filter" class="mr-2">
+            Nur als "vorhanden" markierte Funktionen anzeigen
+        </label>
+    </div>
     <table class="table-auto w-full border">
         <thead>
             <tr>
@@ -19,10 +25,20 @@
         </thead>
         <tbody>
         {% for row in rows %}
-            <tr>
+            <tr data-relevant="{{ row.analysis|get_item:'technisch_vorhanden'|yesno:'true,false,unknown' }}">
                 <td class="border px-2 {% if row.sub %}pl-8{% endif %}">{{ row.name }}</td>
                 {% for field in fields %}
-                <td class="border px-2 text-center">{{ row.analysis|get_item:field|checkbox }}</td>
+                {% with parsed=row.analysis|raw_item:field %}
+                <td class="border px-2 text-center">
+                    {% if parsed.value == True %}
+                        <span class="status-badge status-ja" title="{{ parsed.note|default:'Keine Zusatzinfo' }}">✓ Vorhanden</span>
+                    {% elif parsed.value == False %}
+                        <span class="status-badge status-nein">✗ Nicht vorhanden</span>
+                    {% else %}
+                        <span class="status-badge status-unbekannt">? Unbekannt</span>
+                    {% endif %}
+                </td>
+                {% endwith %}
                 {% endfor %}
                 {% for field in row.form_fields %}
                 <td class="border px-2 text-center">{{ field }}</td>
@@ -33,4 +49,17 @@
     </table>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded mt-2">Speichern</button>
 </form>
+<script>
+document.getElementById('show-relevant-only-filter').addEventListener('change', function() {
+    const rows = document.querySelectorAll('tbody tr');
+    rows.forEach(tr => {
+        const relevant = tr.dataset.relevant;
+        if (this.checked && relevant !== 'true') {
+            tr.style.display = 'none';
+        } else {
+            tr.style.display = '';
+        }
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- parse boolean cells with optional notes
- adapt parser docs and return type
- store parser notes for Anlage 2 checks
- add filter and colored status badges for Anlage 2 review
- expose parser notes via tooltip
- extend template tags with `raw_item`
- adjust CSS styling
- update tests for new parser format

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684b0b72ed94832b90028309e1a90cdc