### PR TITLE
Implement dynamic detection phrase formsets

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -325,10 +325,9 @@ class Anlage2FunctionForm(forms.ModelForm):
 
     class Meta:
         model = Anlage2Function
-        fields = ["name", "detection_phrases"]
+        fields = ["name"]
         widgets = {
             "name": forms.TextInput(attrs={"class": "border rounded p-2"}),
-            "detection_phrases": Textarea(attrs={"rows": 10}),
         }
 
 
@@ -356,4 +355,14 @@ class Anlage2FunctionImportForm(forms.Form):
         required=False,
         label="Datenbank vorher leeren",
         widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
+    )
+
+
+class PhraseForm(forms.Form):
+    """Einzelnes Feld für eine Erkennungsphrase."""
+
+    phrase = forms.CharField(
+        label="",
+        required=False,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
     )

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -10,13 +10,43 @@
         {{ form.name }}
         {{ form.name.errors }}
     </div>
+    {% for prefix, label, formset in sections %}
     <div>
-        {{ form.detection_phrases.label_tag }}<br>
-        {{ form.detection_phrases }}
-        {{ form.detection_phrases.errors }}
+        <h3 class="font-semibold mt-4 mb-2">{{ label }}</h3>
+        <div id="{{ prefix }}-container">
+            {{ formset.management_form }}
+            {% for form in formset %}
+            <div class="flex items-center mb-1">
+                {{ form.phrase }}
+                <label class="ml-2 text-sm">{{ form.DELETE }} löschen</label>
+            </div>
+            {% endfor %}
+        </div>
+        <div id="{{ prefix }}-empty-form" style="display:none;">
+            <div class="flex items-center mb-1">
+                {{ formset.empty_form.phrase }}
+                <label class="ml-2 text-sm">{{ formset.empty_form.DELETE }} löschen</label>
+            </div>
+        </div>
+        <button type="button" class="add-form bg-gray-300 px-2 py-1 rounded" data-prefix="{{ prefix }}">+ Weitere Phrase hinzufügen</button>
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    {% endfor %}
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded mt-4">Speichern</button>
 </form>
+<script>
+function addForm(prefix){
+    const total=document.getElementById('id_'+prefix+'-TOTAL_FORMS');
+    const index=parseInt(total.value);
+    const empty=document.querySelector('#'+prefix+'-empty-form').cloneNode(true);
+    empty.style.display='';
+    empty.innerHTML=empty.innerHTML.replace(/__prefix__/g,index);
+    document.getElementById(prefix+'-container').appendChild(empty);
+    total.value=index+1;
+}
+document.querySelectorAll('.add-form').forEach(btn=>{
+    btn.addEventListener('click',()=>addForm(btn.dataset.prefix));
+});
+</script>
 {% if funktion %}
 <h2 class="text-xl font-semibold mt-8 mb-2">Unterfragen</h2>
 <a href="{% url 'anlage2_subquestion_new' funktion.id %}" class="inline-block mb-2 px-3 py-1 bg-green-600 text-white rounded">Neue Unterfrage</a>


### PR DESCRIPTION
## Summary
- add simple `PhraseForm` for single phrase fields
- remove detection phrase textarea from `Anlage2FunctionForm`
- use formsets in `anlage2_function_form` view
- update template to render phrase formsets with JS to add rows

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError in management command patches)*

------
https://chatgpt.com/codex/tasks/task_e_684b3d2dc698832b8bfb32da689dd0ad