### PR TITLE
Add search and filter to admin project list

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -795,7 +795,8 @@ def admin_talkdiary(request):
 @login_required
 @admin_required
 def admin_projects(request):
-    projects = list(BVProject.objects.all().order_by("-created_at"))
+    """Verwaltet die Projektliste mit Such- und Filterfunktionen."""
+    projects = BVProject.objects.all().order_by("-created_at")
 
     if request.method == "POST":
         # Fall 1: Der globale Knopf zum Löschen markierter Projekte wurde gedrückt
@@ -829,7 +830,22 @@ def admin_projects(request):
 
         return redirect("admin_projects")
 
-    context = {"projects": projects}
+    # GET-Logik: Suche und Filter
+    search_query = request.GET.get("q", "")
+    if search_query:
+        projects = projects.filter(title__icontains=search_query)
+
+    status_filter = request.GET.get("status", "")
+    if status_filter:
+        projects = projects.filter(status=status_filter)
+
+    context = {
+        "projects": projects,
+        "form": BVProjectForm(),
+        "search_query": search_query,
+        "status_filter": status_filter,
+        "status_choices": BVProject.STATUS_CHOICES,
+    }
     return render(request, "admin_projects.html", context)
 
 

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -4,3 +4,29 @@
 .admin-content { @apply flex-1 p-4; }
 .admin-search input { @apply w-full border rounded px-2 py-1 mb-4; }
 .admin-nav a { @apply block py-1 text-blue-700 hover:underline; }
+
+/* Status Badges für Projektübersicht */
+.status-badge-new {
+    background-color: #0d6efd;
+    color: white;
+}
+.status-badge-classified {
+    background-color: #0d6efd;
+    color: white;
+}
+.status-badge-in_pruefung_anlage_x,
+.status-badge-fb_in_pruefung {
+    background-color: #ffc107;
+    color: black;
+}
+.status-badge-gutachten_ok,
+.status-badge-gutachten_freigegeben,
+.status-badge-endgeprueft {
+    background-color: #198754;
+    color: white;
+}
+.status-badge-error {
+    background-color: #dc3545;
+    color: white;
+}
+

--- a/templates/admin_projects.html
+++ b/templates/admin_projects.html
@@ -7,6 +7,27 @@
 <a href="{% url 'admin_anlage1' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 1 Fragen</a>
 <a href="{% url 'anlage2_function_list' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 2 Funktionen</a>
 <a href="{% url 'anlage2_config' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 2 Konfiguration</a>
+
+<form method="get" action="{% url 'admin_projects' %}" class="mb-4">
+    <div class="row g-3 align-items-center">
+        <div class="col-md-6">
+            <label for="search-input" class="visually-hidden">Suche nach Titel</label>
+            <input type="text" id="search-input" name="q" class="form-control" placeholder="Suche nach Titel..." value="{{ search_query }}">
+        </div>
+        <div class="col-md-4">
+            <label for="status-filter" class="visually-hidden">Nach Status filtern</label>
+            <select id="status-filter" name="status" class="form-select">
+                <option value="">Alle Status</option>
+                {% for value, display in status_choices %}
+                    <option value="{{ value }}" {% if value == status_filter %}selected{% endif %}>{{ display }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-2">
+            <button type="submit" class="btn btn-primary w-100">Filtern</button>
+        </div>
+    </div>
+</form>
 <form method="post">
     {% csrf_token %}
     <table class="min-w-full">
@@ -27,7 +48,9 @@
                 <td class="py-1">{{ p.title }}</td>
                 <td class="py-1">{{ p.beschreibung|truncatechars:50 }}</td>
                 <td class="py-1">{{ p.software_typen }}</td>
-                <td class="py-1">{{ p.get_status_display }}</td>
+                <td class="py-1">
+                    <span class="status-badge status-badge-{{ p.status|lower }}">{{ p.get_status_display }}</span>
+                </td>
                 <td class="py-1">{{ p.llm_geprueft|yesno:'Ja,Nein' }}</td>
                 <td class="py-1 text-center">
                     <a href="{% url 'projekt_edit' p.pk %}" class="px-2 py-1 bg-blue-600 text-white rounded mr-2">Bearbeiten</a>


### PR DESCRIPTION
## Summary
- extend `admin_projects` view for search and status filtering
- add search bar and status dropdown in project list template
- show colored status badges
- style badges in admin stylesheet

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'docx')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_684c24632774832ba6ff9e58be6a4207