### PR TITLE
Improve auto-save status handling

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1997,7 +1997,13 @@ def ajax_save_anlage2_review_item(request) -> JsonResponse:
     pf_id = payload.get("project_file_id")
     func_id = payload.get("function_id")
     sub_id = payload.get("subquestion_id")
-    status = payload.get("status")
+    status_val = payload.get("status")
+    if status_val in (True, "True", "true", 1):
+        status = True
+    elif status_val in (False, "False", "false", 0):
+        status = False
+    else:
+        status = None
     notes = payload.get("notes")
 
     if pf_id is None or func_id is None:
@@ -2013,8 +2019,8 @@ def ajax_save_anlage2_review_item(request) -> JsonResponse:
         projekt=anlage.projekt,
         funktion=funktion,
         defaults={
-            "technisch_verfuegbar": None if status is None else bool(status),
-            "raw_json": {"notes": notes},
+            "technisch_verfuegbar": status,
+            "raw_json": {"notes": notes, "subquestion_id": sub_id},
             "source": "manual",
         },
     )


### PR DESCRIPTION
## Summary
- handle string booleans in `ajax_save_anlage2_review_item`
- include `subquestion_id` in saved JSON metadata

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684c32c5e480832b8e5035ada86de11a