### PR TITLE
Implement background verification using Django-Q

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ python manage.py showmigrations
 
 lässt sich prüfen, ob alle Migrationen angewendet wurden.
 
+## Hintergrund-Tasks
+
+Für langlaufende Aktionen nutzt die Anwendung **Django‑Q**. Neben dem
+``runserver``-Prozess muss deshalb ein weiterer Worker laufen:
+
+```bash
+python manage.py qcluster
+```
+
+Ohne diesen Prozess werden keine Hintergrundaufgaben ausgeführt.
+
 ## Markdown-Verarbeitung
 
 Alle Antworten der LLMs enthalten Markdown. Im Web werden sie mit

--- a/core/urls.py
+++ b/core/urls.py
@@ -131,6 +131,11 @@ urlpatterns = [
         name="anlage2_feature_verify",
     ),
     path(
+        "ajax/task-status/<str:task_id>/",
+        views.ajax_check_task_status,
+        name="ajax_check_task_status",
+    ),
+    path(
         "ajax/save-review-item/",
         views.ajax_save_anlage2_review_item,
         name="ajax_save_review_item",

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "core",
+    "django_q",
 ]
 
 MIDDLEWARE = [
@@ -206,4 +207,18 @@ LOGGING = {
             "propagate": False,
         },
     },
+}
+
+# Django-Q Konfiguration
+Q_CLUSTER = {
+    'name': 'noesis_q',
+    'workers': 4,
+    'recycle': 500,
+    'timeout': 60,
+    'compress': True,
+    'save_limit': 250,
+    'queue_limit': 500,
+    'cpu_affinity': 1,
+    'label': 'Django Q',
+    'orm': 'default',
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ python-dotenv
 python-docx
 Pillow
 rich
+django-q

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -97,30 +97,50 @@ document.getElementById('reset-fields').addEventListener('click', () => {
 
 function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 const verifyUrl = '{% url "anlage2_feature_verify" anlage.pk %}';
+const statusUrlTemplate = '{% url "ajax_check_task_status" "dummy" %}';
+function startLoading(btn){btn.dataset.origText=btn.textContent;btn.textContent='⏳';}
+function stopLoading(btn){if(btn.dataset.origText){btn.textContent=btn.dataset.origText;}}
 
 function triggerVerify(button){
     const fd=new FormData();
-    if(button.dataset.functionId){fd.append('function',button.dataset.functionId);} 
-    if(button.dataset.subId){fd.append('subquestion',button.dataset.subId);} 
+    if(button.dataset.functionId){fd.append('function',button.dataset.functionId);}
+    if(button.dataset.subId){fd.append('subquestion',button.dataset.subId);}
+    startLoading(button);
     return fetch(verifyUrl,{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body:fd})
-        .then(resp=>{
-            if(!resp.ok){alert('Fehler bei der Prüfung');throw new Error('verify');}
-            return resp.json();
-        })
+        .then(resp=>resp.ok?resp.json():Promise.reject())
         .then(data=>{
-            console.log(data);
-            const row=button.closest('tr');
-            if(!row) return data;
-            const newStatus=data.technisch_verfuegbar;
-            const statusRadios=row.querySelectorAll('input[type="radio"][name*="-status"]');
-            statusRadios.forEach(radio=>{
-                if(radio.value===String(newStatus)){
-                    radio.checked=true;
-                }
+            const taskId=data.task_id;
+            return new Promise((resolve,reject)=>{
+                const intervalId=setInterval(()=>checkStatus(taskId,intervalId,button,resolve,reject),3000);
             });
-            return data;
         })
-        .catch(()=>null);
+        .catch(()=>{stopLoading(button);alert('Fehler bei der Prüfung');});
+}
+
+function checkStatus(taskId,intervalId,button,resolve,reject){
+    fetch(statusUrlTemplate.replace('dummy',taskId))
+        .then(r=>r.ok?r.json():Promise.reject())
+        .then(data=>{
+            if(data.status==='SUCCESS'){
+                clearInterval(intervalId);
+                updateRow(button,data.result.technisch_verfuegbar);
+                stopLoading(button);
+                resolve(data.result);
+            }else if(data.status==='FAIL'){
+                clearInterval(intervalId);
+                stopLoading(button);
+                alert('Fehler bei der Prüfung');
+                reject();
+            }
+        })
+        .catch(()=>{clearInterval(intervalId);stopLoading(button);reject();});
+}
+
+function updateRow(button,newStatus){
+    const row=button.closest('tr');
+    if(!row) return;
+    const statusRadios=row.querySelectorAll('input[type="radio"][name*="-status"]');
+    statusRadios.forEach(radio=>{if(radio.value===String(newStatus)){radio.checked=true;}});
 }
 
 document.querySelectorAll('.verify-btn').forEach(btn=>{
@@ -176,7 +196,7 @@ document.getElementById('verify-all').addEventListener('click',async()=>{
     const funcBtns=Array.from(document.querySelectorAll('.verify-btn[data-function-id]'));
     for(const fb of funcBtns){
         const result=await triggerVerify(fb);
-        if(result&&result.technisch_vorhanden===true){
+        if(result&&result.technisch_verfuegbar===true){
             const subs=Array.from(document.querySelectorAll(`.verify-btn[data-parent='${fb.dataset.functionId}']`));
             for(const sb of subs){await triggerVerify(sb);}
         }


### PR DESCRIPTION
## Summary
- add `django-q` to requirements
- configure `django_q` in settings and set up `Q_CLUSTER`
- refactor feature verification worker to run asynchronously
- store verification results directly on project files
- launch async task from view and add status endpoint
- update JavaScript to poll task status
- document new background process requirement

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684c37a42dbc832b8b0468cf529fb992