### PR TITLE
Add feature justification prompt

### DIFF
--- a/core/migrations/0050_add_feature_justification_prompt.py
+++ b/core/migrations/0050_add_feature_justification_prompt.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def create_prompt(apps, schema_editor):
+    Prompt = apps.get_model("core", "Prompt")
+    Prompt.objects.get_or_create(
+        name="anlage2_feature_justification",
+        defaults={
+            "text": (
+                "Du bist ein Experte f\u00fcr IT-Systeme und Software-Architektur. "
+                "Begr\u00fcnde in ein bis zwei S\u00e4tzen, ob und warum die Software "
+                "'{software_name}' typischerweise die Funktion oder Eigenschaft "
+                "'{function_name}' besitzt."
+            )
+        },
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0049_anlage2config_enforce_subquestion_override"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_prompt, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- add migration for feature justification prompt

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684c95cedc10832bba9eb005c5aeea3e