### PR TITLE
Add KI justification editor

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -415,3 +415,13 @@ class Anlage2ConfigForm(forms.ModelForm):
         widgets = {
             "enforce_subquestion_override": forms.CheckboxInput(attrs={"class": "mr-2"}),
         }
+
+
+class EditJustificationForm(forms.Form):
+    """Formular zum Bearbeiten einer KI-Begründung."""
+
+    justification = forms.CharField(
+        label="Begründung",
+        required=False,
+        widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 4}),
+    )

--- a/core/tests.py
+++ b/core/tests.py
@@ -2162,6 +2162,26 @@ class FeatureVerificationTests(TestCase):
         self.assertEqual(result["ki_begruendung"], "")
 
 
+class EditJustificationViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("editor", password="pass")
+        self.client.login(username="editor", password="pass")
+        self.projekt = BVProject.objects.create(software_typen="X", beschreibung="x")
+        self.file = BVProjectFile.objects.create(
+            projekt=self.projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("a.txt", b"data"),
+            verification_json={"Login": {"technisch_verfuegbar": True, "ki_begruendung": "Alt"}},
+        )
+
+    def test_post_updates_justification(self):
+        url = reverse("edit_ki_justification", args=[self.file.pk, "Login"])
+        resp = self.client.post(url, {"justification": "Neu"})
+        self.assertRedirects(resp, reverse("projekt_file_edit_json", args=[self.file.pk]))
+        self.file.refresh_from_db()
+        self.assertEqual(self.file.verification_json["Login"]["ki_begruendung"], "Neu")
+
+
 
 
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -161,6 +161,11 @@ urlpatterns = [
         name="projekt_file_edit_json",
     ),
     path(
+        "work/anlage/<int:pk>/edit-justification/<str:function_key>/",
+        views.edit_ki_justification,
+        name="edit_ki_justification",
+    ),
+    path(
         "work/anlage/<int:pk>/email/",
         views.anlage1_generate_email,
         name="anlage1_generate_email",

--- a/templates/edit_justification.html
+++ b/templates/edit_justification.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Begründung bearbeiten{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Begründung bearbeiten</h1>
+<p class="mb-2">{{ function_key }}</p>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.justification.label_tag }}<br>
+    {{ form.justification }}
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+</form>
+{% endblock %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -48,7 +48,11 @@
                         <button class="btn btn-sm btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">🤖</button>
                         <ul class="dropdown-menu">
                             <li><button type="button" class="dropdown-item verify-btn" {% if row.sub %}data-sub-id="{{ row.sub_id }}" data-parent="{{ row.func_id }}"{% else %}data-function-id="{{ row.func_id }}"{% endif %}>KI-Prüfung starten</button></li>
-                            <li><button type="button" class="dropdown-item">Begründung bearbeiten</button></li>
+                            {% if row.ki_begruendung %}
+                            <li>
+                                <a class="dropdown-item" href="{% url 'edit_ki_justification' anlage.pk row.verif_key %}">Begründung bearbeiten</a>
+                            </li>
+                            {% endif %}
                         </ul>
                     </div>
                 </td>


### PR DESCRIPTION
## Summary
- allow editing KI justification via new EditJustificationForm
- implement `edit_ki_justification` view and route
- show "Begründung bearbeiten" link when justification exists
- add template for editing justifications
- test updating of justification

## Testing
- `python manage.py makemigrations --check` *(fails: conflicting migrations and missing Pillow)*
- `python manage.py test` *(fails: conflicting migrations)*

------
https://chatgpt.com/codex/tasks/task_e_684c9b4272c0832b91fb723e049f544f