### PR TITLE
Enable Markdown rendering in templates

### DIFF
--- a/core/templatetags/recording_extras.py
+++ b/core/templatetags/recording_extras.py
@@ -38,7 +38,7 @@ def raw_item(data, key):
     return None
 
 
-@register.filter
+@register.filter(name="markdownify")
 def markdownify(text: str) -> str:
     """Wandelt Markdown-Text in sicheres HTML um."""
     if not text:

--- a/core/views.py
+++ b/core/views.py
@@ -669,11 +669,9 @@ def talkdiary_detail(request, pk):
         if md_path.exists():
             md_text = md_path.read_text(encoding="utf-8")
 
-    html = markdown.markdown(md_text)
-
     context = {
         "recording": rec,
-        "transcript_html": html,
+        "transcript_text": md_text,
     }
     return render(request, "talkdiary_detail.html", context)
 
@@ -2291,10 +2289,9 @@ def gutachten_view(request, pk):
     if not path.exists():
         raise Http404
     text = extract_text(path)
-    html = markdown.markdown(text)
     context = {
         "projekt": projekt,
-        "text_html": html,
+        "text": text,
         "categories": LLMConfig.get_categories(),
         "category": "gutachten",
     }

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -1,8 +1,9 @@
 {% extends 'base.html' %}
+{% load recording_extras %}
 {% block title %}Gutachten anzeigen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>
-<div class="prose max-w-none bg-gray-100 p-2 rounded">{{ text_html|safe }}</div>
+<div class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
 <p class="mt-4">
     <a href="{% url 'gutachten_edit' projekt.pk %}" class="text-blue-700 underline">Bearbeiten</a>
     |

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load recording_extras %}
 {% block title %}Projekt {{ projekt.title }}{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">{{ projekt.title }}
@@ -9,7 +10,7 @@
 <div class="lg:flex lg:space-x-4">
 <div class="lg:w-2/3">
 <p class="mb-2"><strong>Aktueller Status:</strong> {{ projekt.get_status_display }}</p>
-<p class="mb-2"><strong>Beschreibung:</strong> {{ projekt.beschreibung }}</p>
+<p class="mb-2"><strong>Beschreibung:</strong> {{ projekt.beschreibung|markdownify }}</p>
 <p class="mb-2"><strong>Software-Typen:</strong> {{ projekt.software_typen }}</p>
 <form method="post" action="{% url 'projekt_status_update' projekt.pk %}" class="mb-4">
     {% csrf_token %}

--- a/templates/talkdiary_detail.html
+++ b/templates/talkdiary_detail.html
@@ -6,6 +6,6 @@
 <p class="text-sm text-gray-600 mb-4">{{ recording.created_at|date:'d.m.Y H:i' }} - {{ recording.bereich }}</p>
 <audio controls src="{{ recording.audio_file.url }}" class="mb-4 w-full"></audio>
 <div class="prose max-w-none">
-    {{ transcript_html|safe }}
+    {{ transcript_text|markdownify }}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `markdownify` filter registration
- pass raw text for transcripts and use filter in `talkdiary_detail`
- pass raw text for Gutachten and convert via filter
- format project description with Markdown
- load extra tags where needed

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684dc7aa129c832b8f8355d0a4690420