### PR TITLE
feat: erweitere markdownify um Markdown-Erweiterungen

### DIFF
--- a/core/templatetags/recording_extras.py
+++ b/core/templatetags/recording_extras.py
@@ -43,5 +43,13 @@ def markdownify(text: str) -> str:
     """Wandelt Markdown-Text in sicheres HTML um."""
     if not text:
         return ""
-    html = markdown.markdown(text)
+
+    # Aktivierte Markdown-Erweiterungen
+    extensions = [
+        "extra",      # Tabellen, Code-Blöcke und mehr
+        "admonition", # Hinweis-Boxen mit !!! note
+        "toc",        # Inhaltsverzeichnis per [TOC]
+    ]
+
+    html = markdown.markdown(text, extensions=extensions)
     return mark_safe(html)


### PR DESCRIPTION
## Summary
- erweitere den Markdown-Filter um `extra`, `toc` und `admonition`

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684dde9b2b68832b9cae9cea0f788c10