### PR TITLE
Asynchroner Gutachten-Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Alle Antworten der LLMs enthalten Markdown. Im Web werden sie mit
 
 ### Gutachten verwalten
 
-1. Öffne `/work/projekte/<pk>/gutachten/` und ersetze `<pk>` durch die ID des Projekts. Dort lässt sich mithilfe eines LLM ein Gutachten erzeugen.
+1. Klicke in der Projekt-Detailansicht auf **Gutachten erstellen**. Der Hintergrund-Task startet sofort und nach Fertigstellung erscheint automatisch ein Link zum Dokument.
 2. Nach erfolgreicher Erstellung zeigt `/work/projekte/<pk>/gutachten/view/` den Text an und bietet einen Download-Link.
 3. Über `/work/projekte/<pk>/gutachten/edit/` kann der Text im Browser bearbeitet und erneut gespeichert werden.
 4. Ein POST-Request an `/work/projekte/<pk>/gutachten/delete/` entfernt das Dokument wieder aus dem Projekt.

--- a/core/tests.py
+++ b/core/tests.py
@@ -45,6 +45,7 @@ from .llm_tasks import (
     analyse_anlage2,
     check_anlage2_functions,
     worker_verify_feature,
+    worker_generate_gutachten,
     get_prompt,
     generate_gutachten,
     parse_anlage1_questions,
@@ -1339,10 +1340,8 @@ class Anlage2ReviewTests(TestCase):
         self.assertTrue(resp.context["form"].initial[field])
 
 
-class ProjektGutachtenViewTests(TestCase):
+class WorkerGenerateGutachtenTests(TestCase):
     def setUp(self):
-        self.user = User.objects.create_user("guser", password="pass")
-        self.client.login(username="guser", password="pass")
         self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         BVProjectFile.objects.create(
             projekt=self.projekt,
@@ -1351,15 +1350,13 @@ class ProjektGutachtenViewTests(TestCase):
             text_content="Text",
         )
 
-    def test_gutachten_view_creates_file(self):
-        url = reverse("projekt_gutachten", args=[self.projekt.pk])
-        with patch("core.views.query_llm", return_value="Gutachtentext"):
-            resp = self.client.post(url, {"prompt": "foo"})
-        self.assertRedirects(resp, reverse("projekt_detail", args=[self.projekt.pk]))
+    def test_worker_creates_file(self):
+        with patch("core.llm_tasks.query_llm", return_value="Text"):
+            path = worker_generate_gutachten(self.projekt.pk)
         self.projekt.refresh_from_db()
         self.assertTrue(self.projekt.gutachten_file.name)
         self.assertEqual(self.projekt.status, BVProject.STATUS_GUTACHTEN_OK)
-        Path(self.projekt.gutachten_file.path).unlink(missing_ok=True)
+        Path(path).unlink(missing_ok=True)
 
 
 class GutachtenEditDeleteTests(TestCase):
@@ -1924,11 +1921,6 @@ class ModelSelectionTests(TestCase):
             reverse("projekt_file_edit_json", args=[self.projekt.anlagen.first().pk]),
         )
 
-        gutachten_url = reverse("projekt_gutachten", args=[self.projekt.pk])
-        resp = self.client.get(gutachten_url)
-        self.assertContains(resp, "Standard")
-        self.assertContains(resp, "Gutachten")
-        self.assertContains(resp, "Anlagen")
 
     def test_functions_check_uses_model(self):
         url = reverse("projekt_functions_check", args=[self.projekt.pk])

--- a/core/urls.py
+++ b/core/urls.py
@@ -146,6 +146,11 @@ urlpatterns = [
         name="ajax_save_review_item",
     ),
     path(
+        "ajax/start-gutachten/<int:project_id>/",
+        views.ajax_start_gutachten_generation,
+        name="ajax_start_gutachten_generation",
+    ),
+    path(
         "work/projekte/<int:pk>/anlage/<int:nr>/check/",
         views.projekt_file_check,
         name="projekt_file_check",
@@ -179,11 +184,6 @@ urlpatterns = [
         "work/projekte/<int:pk>/summary/",
         views.projekt_management_summary,
         name="projekt_management_summary",
-    ),
-    path(
-        "work/projekte/<int:pk>/gutachten/",
-        views.projekt_gutachten,
-        name="projekt_gutachten",
     ),
     path(
         "work/projekte/<int:pk>/gutachten/view/",

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -32,7 +32,8 @@
             <button type="submit" class="text-red-700 underline">Löschen</button>
         </form>
     {% else %}
-        <a href="{% url 'projekt_gutachten' projekt.pk %}" class="text-blue-700 underline">Gutachten erstellen</a>
+        <button id="btn-generate-gutachten" class="text-blue-700 underline">Gutachten erstellen</button>
+        <span id="gutachten-status" class="ml-2"></span>
     {% endif %}
 </p>
 <p class="mb-4">
@@ -164,5 +165,34 @@ function sendCheck(payload){
 }
 
 document.addEventListener('DOMContentLoaded',loadLLM);
+
+document.addEventListener('DOMContentLoaded',function(){
+ const btn=document.getElementById('btn-generate-gutachten');
+ const status=document.getElementById('gutachten-status');
+ if(!btn) return;
+ btn.addEventListener('click',function(){
+  btn.disabled=true;
+  status.textContent='Gutachten wird erstellt... ⏳';
+  fetch('{% url "ajax_start_gutachten_generation" projekt.pk %}',{
+    method:'POST',
+    headers:{'X-CSRFToken':getCookie('csrftoken')}
+  }).then(r=>r.json()).then(data=>{
+    const tid=data.task_id;
+    const tmpl='{% url "ajax_check_task_status" "dummy" %}';
+    const iv=setInterval(()=>{
+      fetch(tmpl.replace('dummy',tid)).then(r=>r.json()).then(d=>{
+        if(d.status==='SUCCESS'){
+          clearInterval(iv);
+          location.reload();
+        }else if(d.status==='FAIL'){
+          clearInterval(iv);
+          status.textContent='Fehler bei der Erstellung';
+          btn.disabled=false;
+        }
+      });
+    },3000);
+  }).catch(()=>{status.textContent='Fehler beim Start';btn.disabled=false;});
+ });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Hintergrund-Task `worker_generate_gutachten` implementiert
- neue AJAX-View startet die Gutachten-Erzeugung
- Projektseite zeigt Button mit Statusanzeige und Polling
- Dokumentation angepasst
- Tests für neuen Worker

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684de09eaae0832bb7549ac13b0b48da