### PR TITLE
Add Markdown-based Gutachten export

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -191,6 +191,11 @@ urlpatterns = [
         name="gutachten_view",
     ),
     path(
+        "work/projekte/<int:pk>/gutachten/download/",
+        views.gutachten_download,
+        name="gutachten_download",
+    ),
+    path(
         "work/projekte/<int:pk>/gutachten/edit/",
         views.gutachten_edit,
         name="gutachten_edit",

--- a/core/views.py
+++ b/core/views.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseBadRequest, Http404, HttpResponse
+from django.http import (
+    HttpResponseBadRequest,
+    Http404,
+    HttpResponse,
+)
 from django.core.files.storage import default_storage
 from django.contrib import messages
 from django.http import JsonResponse, FileResponse
@@ -80,6 +84,7 @@ import copy
 import time
 
 import markdown
+import pypandoc
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -2296,6 +2301,46 @@ def gutachten_view(request, pk):
         "category": "gutachten",
     }
     return render(request, "gutachten_view.html", context)
+
+
+@login_required
+def gutachten_download(request, pk):
+    """Stellt das Gutachten als formatiertes DOCX bereit."""
+    projekt = BVProject.objects.get(pk=pk)
+    if not projekt.gutachten_file:
+        raise Http404
+
+    path = Path(settings.MEDIA_ROOT) / projekt.gutachten_file.name
+    if not path.exists():
+        raise Http404
+
+    markdown_text = extract_text(path)
+    extensions = ["extra", "admonition", "toc"]
+    html_content = markdown.markdown(markdown_text, extensions=extensions)
+
+    try:
+        docx_output = pypandoc.convert_text(
+            html_content,
+            "docx",
+            format="html",
+            outputfile=None,
+        )
+
+        response = HttpResponse(
+            docx_output,
+            content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+        response[
+            "Content-Disposition"
+        ] = f'attachment; filename="Gutachten_{projekt.title}.docx"'
+        return response
+    except (IOError, OSError) as e:
+        logger.error(f"Pandoc-Fehler beim Erstellen des Gutachtens: {e}")
+        messages.error(
+            request,
+            "Fehler beim Erstellen des Word-Dokuments. Ist Pandoc auf dem Server installiert?",
+        )
+        return redirect("projekt_detail", pk=projekt.pk)
 
 
 @login_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-docx
 Pillow
 rich
 django-q2>=1.8.0
+pypandoc

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -7,7 +7,7 @@
 <p class="mt-4">
     <a href="{% url 'gutachten_edit' projekt.pk %}" class="text-blue-700 underline">Bearbeiten</a>
     |
-    <a href="{{ projekt.gutachten_file.url }}" class="text-blue-700 underline">Download</a>
+    <a href="{% url 'gutachten_download' projekt.pk %}" class="text-blue-700 underline">Download</a>
 </p>
 {% if projekt.gutachten_function_note %}
 <div class="mt-4">

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -26,7 +26,7 @@
     {% if projekt.gutachten_file %}
         <a href="{% url 'gutachten_view' projekt.pk %}" class="text-blue-700 underline">Gutachten anzeigen</a> |
         <a href="{% url 'gutachten_edit' projekt.pk %}" class="text-blue-700 underline">Bearbeiten</a> |
-        <a href="{{ projekt.gutachten_file.url }}" class="text-blue-700 underline">Download</a>
+        <a href="{% url 'gutachten_download' projekt.pk %}" class="text-blue-700 underline">Download</a>
         <form method="post" action="{% url 'gutachten_delete' projekt.pk %}" class="inline-block ml-2">
             {% csrf_token %}
             <button type="submit" class="text-red-700 underline">Löschen</button>

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -18,7 +18,7 @@
 </form>
 {% if projekt.gutachten_file %}
 <p class="mt-4">
-    <a href="{{ projekt.gutachten_file.url }}" class="text-blue-700 underline">Gutachten herunterladen</a>
+    <a href="{% url 'gutachten_download' projekt.pk %}" class="text-blue-700 underline">Gutachten herunterladen</a>
 </p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- install `pypandoc`
- provide `/gutachten/download/` endpoint
- convert stored Gutachten text from Markdown to DOCX via pandoc
- link download buttons to the new endpoint

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684de2c21918832bbc6a0db234a7cbb3