### PR TITLE
Introduce ProjectStatus model

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -9,6 +9,7 @@ from .models import (
     Area,
     Anlage2Function,
     Anlage2FunctionResult,
+    ProjectStatus,
 )
 
 
@@ -63,3 +64,9 @@ class Anlage2FunctionResultAdmin(admin.ModelAdmin):
         "technisch_verfuegbar",
         "ki_beteiligung",
     )
+
+
+@admin.register(ProjectStatus)
+class ProjectStatusAdmin(admin.ModelAdmin):
+    list_display = ("name", "key", "ordering", "is_default", "is_done_status")
+    list_editable = ("key", "ordering", "is_default", "is_done_status")

--- a/core/forms.py
+++ b/core/forms.py
@@ -5,6 +5,7 @@ from .models import (
     Recording,
     BVProject,
     BVProjectFile,
+    ProjectStatus,
     Anlage1Question,
     Anlage2Function,
     Anlage2SubQuestion,
@@ -143,6 +144,8 @@ class BVProjectForm(DocxValidationMixin, forms.ModelForm):
             self.fields["software_type"].queryset = SoftwareType.objects.all()
         if not self.instance or not self.instance.pk:
             self.fields.pop("status", None)
+        else:
+            self.fields["status"].queryset = ProjectStatus.objects.all()
         if self.data:
             self.software_list = [
                 s.strip() for s in self.data.getlist("software") if s.strip()

--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -20,6 +20,7 @@ from .models import (
     Anlage2Function,
     Anlage2SubQuestion,
     Anlage2FunctionResult,
+    ProjectStatus,
 )
 from .llm_utils import query_llm
 from .docx_utils import (
@@ -303,7 +304,7 @@ def classify_system(projekt_id: int, model_name: str | None = None) -> dict:
         data = {"raw": reply}
     data = _add_editable_flags(data)
     projekt.classification_json = data
-    projekt.status = BVProject.STATUS_CLASSIFIED
+    projekt.status = ProjectStatus.objects.get(key="CLASSIFIED")
     projekt.save(update_fields=["classification_json", "status"])
     return data
 
@@ -333,7 +334,7 @@ def generate_gutachten(
         old_path.unlink(missing_ok=True)
     doc.save(path)
     projekt.gutachten_file.name = f"gutachten/{fname}"
-    projekt.status = BVProject.STATUS_GUTACHTEN_OK
+    projekt.status = ProjectStatus.objects.get(key="GUTACHTEN_OK")
     projekt.save(update_fields=["gutachten_file", "status"])
     return path
 

--- a/core/migrations/0052_migrate_project_status.py
+++ b/core/migrations/0052_migrate_project_status.py
@@ -1,0 +1,92 @@
+from django.db import migrations, models
+
+
+# Neue Status-Tabelle einführen und bestehende Daten migrieren
+
+
+def create_statuses(apps, schema_editor):
+    ProjectStatus = apps.get_model('core', 'ProjectStatus')
+    statuses = [
+        ('NEW', 'Neu', True, False),
+        ('CLASSIFIED', 'Klassifiziert', False, False),
+        ('GUTACHTEN_OK', 'Gutachten OK', False, False),
+        ('GUTACHTEN_FREIGEGEBEN', 'Gutachten freigegeben', False, False),
+        ('IN_PRUEFUNG_ANLAGE_X', 'In Prüfung Anlage X', False, False),
+        ('FB_IN_PRUEFUNG', 'FB in Prüfung', False, False),
+        ('ENDGEPRUEFT', 'Endgeprüft', False, True),
+    ]
+    for idx, (key, name, is_default, is_done) in enumerate(statuses, start=1):
+        ProjectStatus.objects.create(
+            name=name,
+            key=key,
+            ordering=idx,
+            is_default=is_default,
+            is_done_status=is_done,
+        )
+
+
+def migrate_data(apps, schema_editor):
+    ProjectStatus = apps.get_model('core', 'ProjectStatus')
+    BVProject = apps.get_model('core', 'BVProject')
+    History = apps.get_model('core', 'BVProjectStatusHistory')
+    status_map = {s.key: s for s in ProjectStatus.objects.all()}
+    for projekt in BVProject.objects.all():
+        if isinstance(projekt.status, str):
+            projekt.status = status_map.get(projekt.status)
+            projekt.save(update_fields=['status'])
+    for entry in History.objects.all():
+        if isinstance(entry.status, str):
+            entry.status = status_map.get(entry.status)
+            entry.save(update_fields=['status'])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0051_merge_20250613_2352'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ProjectStatus',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100)),
+                ('key', models.CharField(max_length=50, unique=True)),
+                ('ordering', models.PositiveIntegerField(default=0)),
+                ('is_default', models.BooleanField(default=False)),
+                ('is_done_status', models.BooleanField(default=False)),
+            ],
+            options={'ordering': ['ordering', 'name']},
+        ),
+        migrations.AddField(
+            model_name='bvproject',
+            name='status_new',
+            field=models.ForeignKey(blank=True, null=True, on_delete=models.PROTECT, related_name='projects', to='core.projectstatus'),
+        ),
+        migrations.AddField(
+            model_name='bvprojectstatushistory',
+            name='status_new',
+            field=models.ForeignKey(blank=True, null=True, on_delete=models.PROTECT, to='core.projectstatus'),
+        ),
+        migrations.RunPython(create_statuses, migrations.RunPython.noop),
+        migrations.RunPython(migrate_data, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name='bvproject',
+            name='status',
+        ),
+        migrations.RemoveField(
+            model_name='bvprojectstatushistory',
+            name='status',
+        ),
+        migrations.RenameField(
+            model_name='bvproject',
+            old_name='status_new',
+            new_name='status',
+        ),
+        migrations.RenameField(
+            model_name='bvprojectstatushistory',
+            old_name='status_new',
+            new_name='status',
+        ),
+    ]
+

--- a/core/views.py
+++ b/core/views.py
@@ -54,6 +54,7 @@ from .models import (
     Anlage2FunctionResult,
     Tile,
     Area,
+    ProjectStatus,
 )
 from .docx_utils import extract_text
 from .llm_utils import query_llm
@@ -907,14 +908,14 @@ def admin_projects(request):
 
     status_filter = request.GET.get("status", "")
     if status_filter:
-        projects = projects.filter(status=status_filter)
+        projects = projects.filter(status__key=status_filter)
 
     context = {
         "projects": projects,
         "form": BVProjectForm(),
         "search_query": search_query,
         "status_filter": status_filter,
-        "status_choices": BVProject.STATUS_CHOICES,
+        "status_choices": ProjectStatus.objects.all(),
     }
     return render(request, "admin_projects.html", context)
 
@@ -1336,14 +1337,14 @@ def projekt_list(request):
 
     status_filter = request.GET.get("status", "")
     if status_filter:
-        projekte = projekte.filter(status=status_filter)
+        projekte = projekte.filter(status__key=status_filter)
 
     context = {
         "projekte": projekte,
         "is_admin": request.user.groups.filter(name="admin").exists(),
         "search_query": search_query,
         "status_filter": status_filter,
-        "status_choices": BVProject.STATUS_CHOICES,
+        "status_choices": ProjectStatus.objects.all(),
     }
     return render(request, "projekt_list.html", context)
 
@@ -1356,7 +1357,7 @@ def projekt_detail(request, pk):
     is_admin = request.user.groups.filter(name="admin").exists()
     context = {
         "projekt": projekt,
-        "status_choices": BVProject.STATUS_CHOICES,
+        "status_choices": ProjectStatus.objects.all(),
         "history": projekt.status_history.all(),
         "num_attachments": anh.count(),
         "num_reviewed": reviewed,

--- a/core/workflow.py
+++ b/core/workflow.py
@@ -1,16 +1,17 @@
-from .models import BVProject, BVProjectStatusHistory
+from .models import BVProject, BVProjectStatusHistory, ProjectStatus
 
 
 def set_project_status(projekt: BVProject, status: str) -> None:
     """Setzt den Status eines BVProject.
 
     :param projekt: Das zu aktualisierende Projekt
-    :param status: Neuer Status aus ``BVProject.STATUS_CHOICES``
+    :param status: Schlüssel des neuen Status
     :raises ValueError: Wenn der Status ungültig ist
     """
-    valid = [s[0] for s in BVProject.STATUS_CHOICES]
-    if status not in valid:
-        raise ValueError("Ungültiger Status")
-    projekt.status = status
+    try:
+        status_obj = ProjectStatus.objects.get(key=status)
+    except ProjectStatus.DoesNotExist as exc:
+        raise ValueError("Ungültiger Status") from exc
+    projekt.status = status_obj
     projekt.save(update_fields=["status"])
-    BVProjectStatusHistory.objects.create(projekt=projekt, status=status)
+    BVProjectStatusHistory.objects.create(projekt=projekt, status=status_obj)

--- a/templates/admin_projects.html
+++ b/templates/admin_projects.html
@@ -18,8 +18,8 @@
             <label for="status-filter" class="visually-hidden">Nach Status filtern</label>
             <select id="status-filter" name="status" class="form-select">
                 <option value="">Alle Status</option>
-                {% for value, display in status_choices %}
-                    <option value="{{ value }}" {% if value == status_filter %}selected{% endif %}>{{ display }}</option>
+                {% for s in status_choices %}
+                    <option value="{{ s.key }}" {% if s.key == status_filter %}selected{% endif %}>{{ s.name }}</option>
                 {% endfor %}
             </select>
         </div>
@@ -49,7 +49,7 @@
                 <td class="py-1">{{ p.beschreibung|truncatechars:50 }}</td>
                 <td class="py-1">{{ p.software_typen }}</td>
                 <td class="py-1">
-                    <span class="status-badge status-badge-{{ p.status|lower }}">{{ p.get_status_display }}</span>
+                    <span class="status-badge status-badge-{{ p.status.key|lower }}">{{ p.status.name }}</span>
                 </td>
                 <td class="py-1">{{ p.llm_geprueft|yesno:'Ja,Nein' }}</td>
                 <td class="py-1 text-center">

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -9,15 +9,15 @@
 </h1>
 <div class="lg:flex lg:space-x-4">
 <div class="lg:w-2/3">
-<p class="mb-2"><strong>Aktueller Status:</strong> {{ projekt.get_status_display }}</p>
+<p class="mb-2"><strong>Aktueller Status:</strong> {{ projekt.status.name }}</p>
 <p class="mb-2"><strong>Beschreibung:</strong> {{ projekt.beschreibung|markdownify }}</p>
 <p class="mb-2"><strong>Software-Typen:</strong> {{ projekt.software_typen }}</p>
 <form method="post" action="{% url 'projekt_status_update' projekt.pk %}" class="mb-4">
     {% csrf_token %}
     <label for="status" class="font-semibold">Status:</label>
     <select id="status" name="status" class="border rounded p-2">
-    {% for val,label in status_choices %}
-        <option value="{{ val }}" {% if projekt.status == val %}selected{% endif %}>{{ label }}</option>
+    {% for s in status_choices %}
+        <option value="{{ s.key }}" {% if projekt.status and projekt.status.key == s.key %}selected{% endif %}>{{ s.name }}</option>
     {% endfor %}
     </select>
     <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded ml-2">Aktualisieren</button>
@@ -86,7 +86,7 @@
     <h4 class="font-semibold mt-2">Status-Historie</h4>
     <ul class="list-disc pl-5">
     {% for h in history %}
-      <li>{{ h.get_status_display }} - {{ h.changed_at|date:"d.m.Y H:i" }}</li>
+      <li>{{ h.status.name }} - {{ h.changed_at|date:"d.m.Y H:i" }}</li>
     {% endfor %}
     </ul>
   </div>

--- a/templates/projekt_list.html
+++ b/templates/projekt_list.html
@@ -16,8 +16,8 @@
             <label for="status-filter" class="visually-hidden">Nach Status filtern</label>
             <select id="status-filter" name="status" class="form-select">
                 <option value="">Alle Status</option>
-                {% for value, display in status_choices %}
-                    <option value="{{ value }}" {% if value == status_filter %}selected{% endif %}>{{ display }}</option>
+                {% for s in status_choices %}
+                    <option value="{{ s.key }}" {% if s.key == status_filter %}selected{% endif %}>{{ s.name }}</option>
                 {% endfor %}
             </select>
         </div>
@@ -44,7 +44,7 @@
             <td class="py-1">{{ p.beschreibung|truncatechars:50 }}</td>
             <td class="py-1">{{ p.software_typen }}</td>
             <td class="py-1">
-                <span class="status-badge status-badge-{{ p.status|lower }}">{{ p.get_status_display }}</span>
+                <span class="status-badge status-badge-{{ p.status.key|lower }}">{{ p.status.name }}</span>
             </td>
             <td class="py-1">{{ p.llm_geprueft|yesno:'Ja,Nein' }}</td>
             <td class="py-1">


### PR DESCRIPTION
## Summary
- add `ProjectStatus` model and migrate existing status data
- update BVProject to use new foreign key
- adapt admin, forms, views and templates for new model
- revise workflow logic and llm tasks
- adjust tests for status objects

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f3662e7d0832b9d89e9e8509d1182