### PR TITLE
Implement admin interface for project statuses

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -9,7 +9,6 @@ from .models import (
     Area,
     Anlage2Function,
     Anlage2FunctionResult,
-    ProjectStatus,
 )
 
 
@@ -66,7 +65,3 @@ class Anlage2FunctionResultAdmin(admin.ModelAdmin):
     )
 
 
-@admin.register(ProjectStatus)
-class ProjectStatusAdmin(admin.ModelAdmin):
-    list_display = ("name", "key", "ordering", "is_default", "is_done_status")
-    list_editable = ("key", "ordering", "is_default", "is_done_status")

--- a/core/urls.py
+++ b/core/urls.py
@@ -42,6 +42,7 @@ urlpatterns = [
     path("recording/delete/<int:pk>/", views.recording_delete, name="recording_delete"),
     path("talkdiary-admin/", views.admin_talkdiary, name="admin_talkdiary"),
     path("projects-admin/", views.admin_projects, name="admin_projects"),
+    path("projects-admin/status/", views.admin_project_statuses, name="admin_project_statuses"),
     path(
         "projects-admin/<int:pk>/delete/",
         views.admin_project_delete,

--- a/core/views.py
+++ b/core/views.py
@@ -1120,6 +1120,38 @@ def admin_anlage1(request):
 
 @login_required
 @admin_required
+def admin_project_statuses(request):
+    """Verwaltet mögliche Projektstatus."""
+    statuses = list(ProjectStatus.objects.all().order_by("ordering", "name"))
+    if request.method == "POST":
+        for s in statuses:
+            if request.POST.get(f"delete{s.id}"):
+                s.delete()
+                continue
+            s.name = request.POST.get(f"name{s.id}", s.name)
+            s.key = request.POST.get(f"key{s.id}", s.key)
+            s.ordering = int(request.POST.get(f"ordering{s.id}", s.ordering) or 0)
+            s.is_default = bool(request.POST.get(f"is_default{s.id}"))
+            s.is_done_status = bool(request.POST.get(f"is_done_status{s.id}"))
+            s.save()
+        name = request.POST.get("new_name", "").strip()
+        key = request.POST.get("new_key", "").strip()
+        if name and key:
+            ordering = int(request.POST.get("new_ordering", "0") or 0)
+            ProjectStatus.objects.create(
+                name=name,
+                key=key,
+                ordering=ordering,
+                is_default=bool(request.POST.get("new_is_default")),
+                is_done_status=bool(request.POST.get("new_is_done_status")),
+            )
+        return redirect("admin_project_statuses")
+    context = {"statuses": statuses}
+    return render(request, "admin_project_statuses.html", context)
+
+
+@login_required
+@admin_required
 def anlage2_config(request):
     """Konfiguriert Überschriften und globale Phrasen für Anlage 2."""
     cfg = Anlage2Config.get_instance()

--- a/templates/admin_project_statuses.html
+++ b/templates/admin_project_statuses.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block title %}Projektstatus{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Projektstatus</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    <table class="min-w-full">
+        <thead>
+            <tr class="border-b text-left">
+                <th class="py-2">Name</th>
+                <th class="py-2">Key</th>
+                <th class="py-2">Reihenfolge</th>
+                <th class="py-2 text-center">Standard</th>
+                <th class="py-2 text-center">Abschluss</th>
+                <th class="py-2 text-center">Löschen</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for s in statuses %}
+            <tr class="border-b text-sm">
+                <td class="py-1"><input type="text" name="name{{ s.id }}" value="{{ s.name }}" class="border rounded p-1 w-full"></td>
+                <td class="py-1"><input type="text" name="key{{ s.id }}" value="{{ s.key }}" class="border rounded p-1 w-full"></td>
+                <td class="py-1"><input type="number" name="ordering{{ s.id }}" value="{{ s.ordering }}" class="border rounded p-1 w-full"></td>
+                <td class="py-1 text-center"><input type="checkbox" name="is_default{{ s.id }}" {% if s.is_default %}checked{% endif %}></td>
+                <td class="py-1 text-center"><input type="checkbox" name="is_done_status{{ s.id }}" {% if s.is_done_status %}checked{% endif %}></td>
+                <td class="py-1 text-center"><input type="checkbox" name="delete{{ s.id }}"></td>
+            </tr>
+        {% endfor %}
+        <tr class="border-b text-sm">
+            <td class="py-1"><input type="text" name="new_name" class="border rounded p-1 w-full"></td>
+            <td class="py-1"><input type="text" name="new_key" class="border rounded p-1 w-full"></td>
+            <td class="py-1"><input type="number" name="new_ordering" class="border rounded p-1 w-full"></td>
+            <td class="py-1 text-center"><input type="checkbox" name="new_is_default"></td>
+            <td class="py-1 text-center"><input type="checkbox" name="new_is_done_status"></td>
+            <td class="py-1 text-center"></td>
+        </tr>
+        </tbody>
+    </table>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+</form>
+{% endblock %}

--- a/templates/admin_projects.html
+++ b/templates/admin_projects.html
@@ -7,6 +7,7 @@
 <a href="{% url 'admin_anlage1' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 1 Fragen</a>
 <a href="{% url 'anlage2_function_list' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 2 Funktionen</a>
 <a href="{% url 'anlage2_config' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 2 Konfiguration</a>
+<a href="{% url 'admin_project_statuses' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Projektstatus</a>
 
 <form method="get" action="{% url 'admin_projects' %}" class="mb-4">
     <div class="row g-3 align-items-center">


### PR DESCRIPTION
## Summary
- add project status management view for project admin
- expose new view via URL and link from admin dashboard
- remove `ProjectStatus` from Django admin

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError in management command patches)*

------
https://chatgpt.com/codex/tasks/task_e_684f438cd0dc832ba17eb430eb1f1126