### PR TITLE
Implement custom admin for project status

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -428,3 +428,18 @@ class EditJustificationForm(forms.Form):
         required=False,
         widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 4}),
     )
+
+
+class ProjectStatusForm(forms.ModelForm):
+    """Formular für einen Projektstatus."""
+
+    class Meta:
+        model = ProjectStatus
+        fields = ["name", "key", "ordering", "is_default", "is_done_status"]
+        widgets = {
+            "name": forms.TextInput(attrs={"class": "border rounded p-2"}),
+            "key": forms.TextInput(attrs={"class": "border rounded p-2"}),
+            "ordering": forms.NumberInput(attrs={"class": "border rounded p-2"}),
+            "is_default": forms.CheckboxInput(attrs={"class": "mr-2"}),
+            "is_done_status": forms.CheckboxInput(attrs={"class": "mr-2"}),
+        }

--- a/core/urls.py
+++ b/core/urls.py
@@ -42,7 +42,10 @@ urlpatterns = [
     path("recording/delete/<int:pk>/", views.recording_delete, name="recording_delete"),
     path("talkdiary-admin/", views.admin_talkdiary, name="admin_talkdiary"),
     path("projects-admin/", views.admin_projects, name="admin_projects"),
-    path("projects-admin/status/", views.admin_project_statuses, name="admin_project_statuses"),
+    path("projects-admin/statuses/", views.admin_project_statuses, name="admin_project_statuses"),
+    path("projects-admin/statuses/new/", views.admin_project_status_form, name="admin_project_status_new"),
+    path("projects-admin/statuses/<int:pk>/edit/", views.admin_project_status_form, name="admin_project_status_edit"),
+    path("projects-admin/statuses/<int:pk>/delete/", views.admin_project_status_delete, name="admin_project_status_delete"),
     path(
         "projects-admin/<int:pk>/delete/",
         views.admin_project_delete,

--- a/templates/admin_project_status_form.html
+++ b/templates/admin_project_status_form.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block title %}{% if status %}Status bearbeiten{% else %}Neuer Status{% endif %}{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">{% if status %}Status bearbeiten{% else %}Neuer Status{% endif %}</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.name.label_tag }}<br>
+        {{ form.name }}
+        {{ form.name.errors }}
+    </div>
+    <div>
+        {{ form.key.label_tag }}<br>
+        {{ form.key }}
+        {{ form.key.errors }}
+    </div>
+    <div>
+        {{ form.ordering.label_tag }}<br>
+        {{ form.ordering }}
+        {{ form.ordering.errors }}
+    </div>
+    <div>
+        <label>{{ form.is_default }} Standard</label>
+        {{ form.is_default.errors }}
+    </div>
+    <div>
+        <label>{{ form.is_done_status }} Abschlussstatus</label>
+        {{ form.is_done_status.errors }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+</form>
+{% endblock %}

--- a/templates/admin_project_statuses.html
+++ b/templates/admin_project_statuses.html
@@ -2,40 +2,40 @@
 {% block title %}Projektstatus{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Projektstatus</h1>
-<form method="post" class="space-y-4">
-    {% csrf_token %}
-    <table class="min-w-full">
-        <thead>
-            <tr class="border-b text-left">
-                <th class="py-2">Name</th>
-                <th class="py-2">Key</th>
-                <th class="py-2">Reihenfolge</th>
-                <th class="py-2 text-center">Standard</th>
-                <th class="py-2 text-center">Abschluss</th>
-                <th class="py-2 text-center">Löschen</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for s in statuses %}
-            <tr class="border-b text-sm">
-                <td class="py-1"><input type="text" name="name{{ s.id }}" value="{{ s.name }}" class="border rounded p-1 w-full"></td>
-                <td class="py-1"><input type="text" name="key{{ s.id }}" value="{{ s.key }}" class="border rounded p-1 w-full"></td>
-                <td class="py-1"><input type="number" name="ordering{{ s.id }}" value="{{ s.ordering }}" class="border rounded p-1 w-full"></td>
-                <td class="py-1 text-center"><input type="checkbox" name="is_default{{ s.id }}" {% if s.is_default %}checked{% endif %}></td>
-                <td class="py-1 text-center"><input type="checkbox" name="is_done_status{{ s.id }}" {% if s.is_done_status %}checked{% endif %}></td>
-                <td class="py-1 text-center"><input type="checkbox" name="delete{{ s.id }}"></td>
-            </tr>
-        {% endfor %}
-        <tr class="border-b text-sm">
-            <td class="py-1"><input type="text" name="new_name" class="border rounded p-1 w-full"></td>
-            <td class="py-1"><input type="text" name="new_key" class="border rounded p-1 w-full"></td>
-            <td class="py-1"><input type="number" name="new_ordering" class="border rounded p-1 w-full"></td>
-            <td class="py-1 text-center"><input type="checkbox" name="new_is_default"></td>
-            <td class="py-1 text-center"><input type="checkbox" name="new_is_done_status"></td>
-            <td class="py-1 text-center"></td>
+<a href="{% url 'admin_project_status_new' %}" class="inline-block mb-4 px-4 py-2 bg-blue-600 text-white rounded">Neuen Status hinzufügen</a>
+<table class="min-w-full">
+    <thead>
+        <tr class="border-b text-left">
+            <th class="py-2">Name</th>
+            <th class="py-2">Key</th>
+            <th class="py-2">Reihenfolge</th>
+            <th class="py-2 text-center">Standard</th>
+            <th class="py-2 text-center">Abschluss</th>
+            <th class="py-2 text-center">Bearbeiten</th>
+            <th class="py-2 text-center">Löschen</th>
         </tr>
-        </tbody>
-    </table>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
-</form>
+    </thead>
+    <tbody>
+    {% for s in statuses %}
+        <tr class="border-b text-sm">
+            <td class="py-1">{{ s.name }}</td>
+            <td class="py-1">{{ s.key }}</td>
+            <td class="py-1">{{ s.ordering }}</td>
+            <td class="py-1 text-center">{{ s.is_default|yesno:"Ja,Nein" }}</td>
+            <td class="py-1 text-center">{{ s.is_done_status|yesno:"Ja,Nein" }}</td>
+            <td class="py-1 text-center">
+                <a href="{% url 'admin_project_status_edit' s.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
+            </td>
+            <td class="py-1 text-center">
+                <form action="{% url 'admin_project_status_delete' s.id %}" method="post" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Status wirklich löschen?');">Löschen</button>
+                </form>
+            </td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="7" class="py-2">Keine Status vorhanden.</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
 {% endblock %}

--- a/templates/admin_projects.html
+++ b/templates/admin_projects.html
@@ -7,7 +7,7 @@
 <a href="{% url 'admin_anlage1' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 1 Fragen</a>
 <a href="{% url 'anlage2_function_list' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 2 Funktionen</a>
 <a href="{% url 'anlage2_config' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 2 Konfiguration</a>
-<a href="{% url 'admin_project_statuses' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Projektstatus</a>
+<a href="{% url 'admin_project_statuses' %}" class="btn btn-secondary inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Projekt-Status verwalten</a>
 
 <form method="get" action="{% url 'admin_projects' %}" class="mb-4">
     <div class="row g-3 align-items-center">


### PR DESCRIPTION
## Summary
- add `ProjectStatusForm`
- define URLs for listing, creating, editing and deleting project status entries
- implement corresponding views
- redesign project status templates for CRUD operations
- link to status management from admin dashboard

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684f49054810832bae3799d0ccbd47ac