### PR TITLE
Implement new knowledge views

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -11,6 +11,7 @@ from .models import (
     Anlage2SubQuestion,
     Anlage2Config,
     Anlage2GlobalPhrase,
+    SoftwareKnowledge,
     Area,
 )
 
@@ -428,3 +429,15 @@ class EditJustificationForm(forms.Form):
         required=False,
         widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 4}),
     )
+
+class KnowledgeDescriptionForm(forms.ModelForm):
+    """Formular zum Bearbeiten der Beschreibung einer Software."""
+
+    class Meta:
+        model = SoftwareKnowledge
+        fields = ["description"]
+        labels = {"description": "Beschreibung"}
+        widgets = {
+            "description": forms.Textarea(attrs={"class": "border rounded p-2", "rows": 5})
+        }
+

--- a/core/urls.py
+++ b/core/urls.py
@@ -213,9 +213,24 @@ urlpatterns = [
     ),
     path("projects/<int:pk>/", views.project_detail_api, name="project_detail_api"),
     path(
-        "projects/<int:pk>/llm-check/",
-        views.project_llm_check,
-        name="project_llm_check",
+        "ajax/start-initial-checks/<int:project_id>/",
+        views.ajax_start_initial_checks,
+        name="ajax_start_initial_checks",
+    ),
+    path(
+        "knowledge/<int:knowledge_id>/edit/",
+        views.edit_knowledge_description,
+        name="edit_knowledge_description",
+    ),
+    path(
+        "knowledge/<int:knowledge_id>/delete/",
+        views.delete_knowledge_entry,
+        name="delete_knowledge_entry",
+    ),
+    path(
+        "knowledge/<int:knowledge_id>/download/",
+        views.download_knowledge_as_word,
+        name="download_knowledge_as_word",
     ),
     path(
         "login/", auth_views.LoginView.as_view(template_name="login.html"), name="login"

--- a/templates/edit_knowledge_description.html
+++ b/templates/edit_knowledge_description.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block title %}Beschreibung bearbeiten{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Beschreibung bearbeiten</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.description.label_tag }}
+    {{ form.description }}
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+</form>
+{% endblock %}

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -157,7 +157,7 @@ function sendCheck(payload){
  const spinner=document.createElement('span');
  spinner.textContent='...';
  sec.appendChild(spinner);
- fetch('{% url 'project_llm_check' projekt.pk %}',{
+ fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
    method:'POST',
    headers:{'X-CSRFToken':getCookie('csrftoken')},
    body:new URLSearchParams(payload)


### PR DESCRIPTION
## Summary
- start LLM initial checks asynchronously
- allow editing and deleting of software knowledge
- add download as Word for knowledge description
- clean urls and template
- remove obsolete project_llm_check view

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(failed: AttributeError: module 'core.management.commands' has no attribute 'check_anlage2')*

------
https://chatgpt.com/codex/tasks/task_e_684f48ea2770832b85dd5e895e97c7aa