### PR TITLE
Add Word export for knowledge entries

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1400,6 +1400,7 @@ def projekt_detail(request, pk):
         "num_attachments": anh.count(),
         "num_reviewed": reviewed,
         "is_admin": is_admin,
+        "knowledge_list": projekt.softwareknowledge.all(),
     }
     return render(request, "projekt_detail.html", context)
 
@@ -2434,7 +2435,8 @@ def download_knowledge_as_word(request, knowledge_id):
         raise Http404
     temp_file_path = os.path.join(tempfile.gettempdir(), f"knowledge_{knowledge_id}.docx")
     try:
-        html_content = markdown.markdown(knowledge.description, extensions=["extra", "admonition", "toc"])
+        extensions = ["extra", "admonition", "toc"]
+        html_content = markdown.markdown(knowledge.description, extensions=extensions)
         pypandoc.convert_text(
             html_content,
             "docx",

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -73,6 +73,43 @@
     </tbody>
 </table>
 <a href="{% url 'projekt_file_upload' projekt.pk %}" class="bg-blue-600 text-white px-4 py-2 rounded">Anlage hochladen</a>
+
+<h2 class="text-xl font-semibold mt-4">Software-Wissen</h2>
+<table class="mb-4 w-full text-left">
+    <thead>
+        <tr>
+            <th class="px-2 py-1">Software</th>
+            <th class="px-2 py-1">Beschreibung</th>
+            <th class="px-2 py-1 text-center">Bearbeiten</th>
+            <th class="px-2 py-1 text-center">Löschen</th>
+            <th class="px-2 py-1 text-center">Als Word exportieren</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for k in knowledge_list %}
+        <tr class="border-t">
+            <td class="px-2 py-1">{{ k.software_name }}</td>
+            <td class="px-2 py-1">{{ k.description|truncatechars:50 }}</td>
+            <td class="px-2 py-1 text-center">
+                <a href="{% url 'edit_knowledge_description' k.pk %}"
+                   class="bg-blue-600 text-white px-2 py-1 rounded">Bearbeiten</a>
+            </td>
+            <td class="px-2 py-1 text-center">
+                <form method="post" action="{% url 'delete_knowledge_entry' k.pk %}" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded" onclick="return confirm('Eintrag wirklich löschen?');">Löschen</button>
+                </form>
+            </td>
+            <td class="px-2 py-1 text-center">
+                <a href="{% url 'download_knowledge_as_word' k.pk %}"
+                   class="bg-green-600 text-white px-2 py-1 rounded">Als Word exportieren</a>
+            </td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="5">Keine Einträge vorhanden</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
 <div id="llm-section" class="mt-4"></div>
 </div>
 <div class="lg:w-1/3 mt-4 lg:mt-0">


### PR DESCRIPTION
## Summary
- convert software knowledge Markdown into DOCX via Pandoc
- list Software-Wissen entries on project detail page
- allow download of each entry as Word document

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f4c7ef134832bbb466e37a46bf2dc