### PR TITLE
Add initial software check table

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1393,6 +1393,15 @@ def projekt_detail(request, pk):
     anh = projekt.anlagen.all()
     reviewed = anh.filter(analysis_json__isnull=False).count()
     is_admin = request.user.groups.filter(name="admin").exists()
+    software_list = [s.strip() for s in projekt.software_typen.split(',') if s.strip()]
+    knowledge_map = {k.software_name: k for k in projekt.softwareknowledge.all()}
+    knowledge_rows = []
+    checked = 0
+    for name in software_list:
+        entry = knowledge_map.get(name)
+        if entry and entry.last_checked:
+            checked += 1
+        knowledge_rows.append({"name": name, "entry": entry})
     context = {
         "projekt": projekt,
         "status_choices": ProjectStatus.objects.all(),
@@ -1400,6 +1409,9 @@ def projekt_detail(request, pk):
         "num_attachments": anh.count(),
         "num_reviewed": reviewed,
         "is_admin": is_admin,
+        "knowledge_rows": knowledge_rows,
+        "knowledge_checked": checked,
+        "total_software": len(software_list),
     }
     return render(request, "projekt_detail.html", context)
 
@@ -2050,17 +2062,31 @@ def _run_llm_check(name: str, additional: str | None = None) -> tuple[str, bool]
 def project_detail_api(request, pk):
     projekt = BVProject.objects.get(pk=pk)
     software_list = [s.strip() for s in projekt.software_typen.split(",") if s.strip()]
+    knowledge_map = {k.software_name: k for k in projekt.softwareknowledge.all()}
+    knowledge = []
+    checked = 0
+    for name in software_list:
+        entry = knowledge_map.get(name)
+        item = {
+            "software_name": name,
+            "id": entry.pk if entry else None,
+            "is_known_by_llm": entry.is_known_by_llm if entry else False,
+            "description": entry.description if entry else "",
+            "last_checked": bool(entry and entry.last_checked),
+        }
+        if item["last_checked"]:
+            checked += 1
+        knowledge.append(item)
+
     data = {
         "id": projekt.pk,
         "title": projekt.title,
         "beschreibung": projekt.beschreibung,
         "software_typen": projekt.software_typen,
         "software_list": software_list,
-        "ist_llm_geprueft": projekt.llm_geprueft,
-        "llm_validated": projekt.llm_validated,
-        "llm_initial_output": projekt.llm_initial_output,
-        "llm_initial_output_html": markdown.markdown(projekt.llm_initial_output),
-        "llm_initial_output_combined": projekt.llm_initial_output,
+        "knowledge": knowledge,
+        "checked": checked,
+        "total": len(software_list),
     }
     return JsonResponse(data)
 

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -73,7 +73,44 @@
     </tbody>
 </table>
 <a href="{% url 'projekt_file_upload' projekt.pk %}" class="bg-blue-600 text-white px-4 py-2 rounded">Anlage hochladen</a>
-<div id="llm-section" class="mt-4"></div>
+
+<h2 class="text-xl font-semibold mt-4">Initial-Prüfung der Software-Komponenten</h2>
+<table id="knowledge-table" class="mb-4 w-full text-left">
+    <thead>
+        <tr>
+            <th class="px-2 py-1">Software</th>
+            <th class="px-2 py-1 text-center">Bekannt?</th>
+            <th class="px-2 py-1">Beschreibung</th>
+            <th class="px-2 py-1 text-center">Aktionen</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for row in knowledge_rows %}
+        <tr class="border-t" data-id="{{ row.entry.id|default:'' }}">
+            <td class="px-2 py-1">{{ row.name }}</td>
+            <td class="px-2 py-1 text-center">
+                {% if row.entry and row.entry.last_checked %}
+                    {% if row.entry.is_known_by_llm %}Ja{% else %}Nein{% endif %}
+                {% else %}-{% endif %}
+            </td>
+            <td class="px-2 py-1">{{ row.entry.description|default:"" }}</td>
+            <td class="px-2 py-1 text-center space-x-2">
+            {% if row.entry %}
+                <a href="{% url 'edit_knowledge_description' row.entry.id %}" class="text-blue-700 underline">Bearbeiten</a>
+                <form action="{% url 'delete_knowledge_entry' row.entry.id %}" method="post" class="inline">
+                    {% csrf_token %}
+                    <button type="submit" class="text-red-700 underline">Löschen</button>
+                </form>
+                {% if row.entry.description %}
+                <a href="{% url 'download_knowledge_as_word' row.entry.id %}" class="text-blue-700 underline">Export</a>
+                {% endif %}
+            {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+<button id="start-checks" class="bg-green-600 text-white px-4 py-2 rounded">Prüfung starten</button>
 </div>
 <div class="lg:w-1/3 mt-4 lg:mt-0">
   <div class="bg-gray-100 p-4 rounded">
@@ -83,6 +120,7 @@
     <p class="mt-1"><strong>Anlagen:</strong> {{ num_attachments }}</p>
     <p class="mt-1"><strong>Gutachten vorhanden:</strong> {% if projekt.gutachten_file %}Ja{% else %}Nein{% endif %}</p>
     <p class="mt-1"><strong>Geprüft:</strong> {{ num_reviewed }} / {{ num_attachments }}</p>
+    <p class="mt-1"><strong>Initial-Prüfung:</strong> <span id="knowledge-progress">{{ knowledge_checked }} / {{ total_software }}</span> Komponenten analysiert</p>
     <h4 class="font-semibold mt-2">Status-Historie</h4>
     <ul class="list-disc pl-5">
     {% for h in history %}
@@ -93,78 +131,71 @@
 </div>
 </div>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
+function getCookie(name){const m=document.cookie.match('(^|;)\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 
-function loadLLM(){
+function loadKnowledge(){
  fetch('{% url 'project_detail_api' projekt.pk %}')
   .then(r=>r.json())
-  .then(data=>renderLLM(data));
+  .then(data=>renderKnowledge(data));
 }
 
-function renderLLM(data){
- const sec=document.getElementById('llm-section');
- sec.innerHTML='';
- if(!data.ist_llm_geprueft && !data.llm_initial_output){
-   sec.innerHTML=`<button id="run" class="bg-green-600 text-white px-4 py-2 rounded">Run LLM Check (Initial)</button>`;
- }else if(data.ist_llm_geprueft && !data.llm_validated){
-   sec.innerHTML=`<div class="text-red-600 mb-2">Initial LLM check incomplete or technically incorrect.</div>
-   <textarea id="edit" class="border rounded w-full p-2 mb-2">${data.llm_initial_output||''}</textarea>
-   <input id="context" type="text" placeholder="Additional context" class="border rounded w-full p-2 mb-2 hidden">
-   <div class="space-x-2">
-     <button id="edit-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Edit Response & Recheck (Initial)</button>
-     <button id="ctx-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Add Additional Context & Recheck (Initial)</button>
-   </div>`;
- }else if(data.ist_llm_geprueft && data.llm_validated){
-  sec.innerHTML=`<button id="toggle" class="bg-green-600 text-white px-4 py-2 rounded mb-2">Show/Hide Initial LLM Response</button>
-  <div id="output" class="prose max-w-none bg-gray-100 p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
- }
- if(data.llm_initial_output){
-   sec.innerHTML += `<button id="recheck" class="bg-blue-600 text-white px-4 py-2 rounded mt-2">Recheck (Initial)</button>`;
- }
- attachHandlers();
+function renderKnowledge(data){
+ const tbody=document.querySelector('#knowledge-table tbody');
+ tbody.innerHTML='';
+ const editT='{% url "edit_knowledge_description" 9999 %}';
+ const delT='{% url "delete_knowledge_entry" 9999 %}';
+ const downT='{% url "download_knowledge_as_word" 9999 %}';
+ data.knowledge.forEach(k=>{
+  let actions='';
+  if(k.id){
+    actions=`<a href="${editT.replace('9999',k.id)}" class="text-blue-700 underline mr-2">Bearbeiten</a>`+
+            `<form action="${delT.replace('9999',k.id)}" method="post" class="inline mr-2">`+
+            `<input type="hidden" name="csrfmiddlewaretoken" value="${getCookie('csrftoken')}">`+
+            `<button type="submit" class="text-red-700 underline">Löschen</button></form>`;
+    if(k.description){
+      actions+=`<a href="${downT.replace('9999',k.id)}" class="text-blue-700 underline">Export</a>`;
+    }
+  }
+  const known=k.last_checked? (k.is_known_by_llm? 'Ja':'Nein') : '-';
+  tbody.innerHTML+=`<tr class="border-t"><td class="px-2 py-1">${k.software_name}</td>`+
+                    `<td class="px-2 py-1 text-center">${known}</td>`+
+                    `<td class="px-2 py-1">${k.description||''}</td>`+
+                    `<td class="px-2 py-1 text-center">${actions}</td></tr>`;
+ });
+ document.getElementById('knowledge-progress').textContent=`${data.checked} / ${data.total}`;
 }
 
-function attachHandlers(){
- const run=document.getElementById('run');
- if(run){run.addEventListener('click',()=>sendCheck({}));}
- const editBtn=document.getElementById('edit-btn');
- const ctxBtn=document.getElementById('ctx-btn');
- if(editBtn){
-   editBtn.addEventListener('click',()=>{
-     const text=document.getElementById('edit').value;
-     sendCheck({edited_initial_output:text});
-   });
- }
- if(ctxBtn){
-   const ctxInput=document.getElementById('context');
-   ctxBtn.addEventListener('click',()=>{
-     if(ctxInput.classList.contains('hidden')){ctxInput.classList.remove('hidden');return;}
-     if(ctxInput.value){sendCheck({additional_context:ctxInput.value});}
-   });
- }
- const toggle=document.getElementById('toggle');
- if(toggle){
-  toggle.addEventListener('click',()=>{
-    document.getElementById('output').classList.toggle('hidden');
-  });
-}
- const recheck=document.getElementById('recheck');
- if(recheck){recheck.addEventListener('click',()=>sendCheck({}));}
-}
-
-function sendCheck(payload){
- const sec=document.getElementById('llm-section');
+function startChecks(){
+ const btn=document.getElementById('start-checks');
+ btn.disabled=true;
  const spinner=document.createElement('span');
- spinner.textContent='...';
- sec.appendChild(spinner);
+ spinner.textContent=' ...';
+ btn.after(spinner);
  fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
    method:'POST',
-   headers:{'X-CSRFToken':getCookie('csrftoken')},
-   body:new URLSearchParams(payload)
- }).then(r=>r.json()).then(d=>{if(d.error){alert(d.error);} loadLLM();}).catch(()=>alert('LLM-Prüfung fehlgeschlagen')).finally(()=>spinner.remove());
+   headers:{'X-CSRFToken':getCookie('csrftoken')}
+ }).then(r=>r.json()).then(data=>{
+   const tasks=data.tasks||[];
+   const tmpl='{% url "ajax_check_task_status" "dummy" %}';
+   let done=0;
+   tasks.forEach(t=>{
+     const iv=setInterval(()=>{
+       fetch(tmpl.replace('dummy',t.task_id)).then(r=>r.json()).then(d=>{
+         if(d.status==='SUCCESS'||d.status==='FAIL'){
+            clearInterval(iv);done++;loadKnowledge();
+            if(done===tasks.length){spinner.remove();btn.disabled=false;}
+         }
+       });
+     },3000);
+   });
+ }).catch(()=>{alert('Fehler beim Start');spinner.remove();btn.disabled=false;});
 }
 
-document.addEventListener('DOMContentLoaded',loadLLM);
+document.addEventListener('DOMContentLoaded',loadKnowledge);
+document.addEventListener('DOMContentLoaded',function(){
+ const btn=document.getElementById('start-checks');
+ if(btn){btn.addEventListener('click',startChecks);}
+});
 
 document.addEventListener('DOMContentLoaded',function(){
  const btn=document.getElementById('btn-generate-gutachten');


### PR DESCRIPTION
## Summary
- remove legacy LLM section from project detail
- show new table for initial software checks
- display progress of these checks in the project info box
- start and poll checks via new JavaScript using `ajax_start_initial_checks`
- extend views with software knowledge data and JSON API

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684f4c735120832b80c0e6abb3a3e914