### PR TITLE
Add DB-driven prompt for overall report

### DIFF
--- a/core/migrations/0014_default_prompts.py
+++ b/core/migrations/0014_default_prompts.py
@@ -18,6 +18,9 @@ class Migration(migrations.Migration):
             "generate_gutachten": (
                 "Erstelle ein kurzes Gutachten basierend auf diesen Unterlagen:\n\n"
             ),
+            "generate_overall_gutachten": (
+                "Erstelle ein zusammenfassendes Gutachten f\u00fcr das Projekt '{project_title}'. Ber\u00fccksichtige alle folgenden Software-Komponenten und deren Analyseergebnisse: {context_data}. Fasse die Ergebnisse zusammen, bewerte das Gesamtprojekt und gib eine Abschlussempfehlung ab. Strukturiere das Gutachten mit klaren \u00dcberschriften und formatiere es mit Markdown (z.B. \u00dcberschriften, Fett- und Kursivdruck, Listen und Tabellen)."
+            ),
         }
         for i in range(1, 7):
             prompts[f"check_anlage{i}"] = (


### PR DESCRIPTION
## Summary
- include a default prompt for overall reports in the migrations
- generate overall reports with a configurable prompt

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6851e8dd00dc832bbc08c51d05f81468