### PR TITLE
Handle missing BVProject in worker

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -350,7 +350,15 @@ def worker_generate_gutachten(project_id: int, software_type_id: int | None = No
     Gesamtgutachten f\u00fcr das Projekt.
     """
 
-    projekt = BVProject.objects.get(pk=project_id)
+    try:
+        projekt = BVProject.objects.get(pk=project_id)
+    except BVProject.DoesNotExist:
+        logger.warning(
+            "Task f\u00fcr Gutachten-Erstellung (Projekt-ID: %s) gestartet, "
+            "aber das Projekt existiert nicht mehr. Breche ab.",
+            project_id,
+        )
+        return ""
     model = LLMConfig.get_default("gutachten")
 
     prefix = get_prompt(


### PR DESCRIPTION
## Summary
- prevent crash if a project is removed before `worker_generate_gutachten` runs

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError: module 'core.management.commands' has no attribute 'check_anlage2')*

------
https://chatgpt.com/codex/tasks/task_e_6852b6f460cc832b9fa7d23440a1e5cc