### PR TITLE
Add global system prompt support

### DIFF
--- a/core/llm_utils.py
+++ b/core/llm_utils.py
@@ -24,11 +24,21 @@ def query_llm(
     prompt: str, model_name: str | None = None, model_type: str = "default"
 ) -> str:
     """Sende eine Anfrage an ein LLM und gib die Antwort zurück."""
-    from .models import LLMConfig
+    from .models import LLMConfig, Prompt
 
     correlation_id = str(uuid.uuid4())
     if model_name is None:
         model_name = LLMConfig.get_default(model_type)
+
+    # System-Prompt laden und mitgeben
+    obj = Prompt.objects.filter(name="llm_system_persona").first()
+    if obj:
+        system_prompt = obj.text
+    else:
+        system_prompt = (
+            "Bitte beantworte die folgende Frage direkt und sachlich."
+        )
+    prompt = f"{system_prompt}\n\n---\n\n{prompt}"
 
     if not settings.GOOGLE_API_KEY and not settings.OPENAI_API_KEY:
         logger.error(

--- a/core/migrations/0014_default_prompts.py
+++ b/core/migrations/0014_default_prompts.py
@@ -21,6 +21,9 @@ class Migration(migrations.Migration):
             "generate_overall_gutachten": (
                 "Erstelle ein zusammenfassendes Gutachten f\u00fcr das Projekt '{project_title}'. Ber\u00fccksichtige alle folgenden Software-Komponenten und deren Analyseergebnisse: {context_data}. Fasse die Ergebnisse zusammen, bewerte das Gesamtprojekt und gib eine Abschlussempfehlung ab. Strukturiere das Gutachten mit klaren \u00dcberschriften und formatiere es mit Markdown (z.B. \u00dcberschriften, Fett- und Kursivdruck, Listen und Tabellen)."
             ),
+            "llm_system_persona": (
+                "Du bist ein Fachexperte f\u00fcr die Pr\u00fcfung von IT-Systemen im Kontext von Betriebsvereinbarungen bei Telef\u00f3nica Deutschland. Deine Antworten sind stets sachlich, pr\u00e4zise und direkt. Vermeide jegliche konversationelle Einleitungen oder F\u00fcllw\u00f6rter wie 'Gerne, hier ist...' oder 'Absolut, ...'. Du sprichst den Anwender mit 'Du' an. Deine einzige Aufgabe ist es, die folgende Anweisung auszuf\u00fchren."
+            ),
         }
         for i in range(1, 7):
             prompts[f"check_anlage{i}"] = (


### PR DESCRIPTION
## Summary
- hinterlege neuen Prompt `llm_system_persona` in den Default-Prompts
- lade System-Prompt in `query_llm` und stelle ihn jeder Anfrage voran

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6852b9694268832bb7b73ee9ff8d987a