### PR TITLE
Add modal for KI justification

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -98,6 +98,7 @@ import time
 import markdown
 import pypandoc
 from django.conf import settings
+from .templatetags.recording_extras import markdownify
 
 logger = logging.getLogger(__name__)
 debug_logger = logging.getLogger("anlage2_debug")
@@ -1942,6 +1943,7 @@ def projekt_file_edit_json(request, pk):
                     }
                 )
             row_source = source_map.get((str(func.id), None, "technisch_vorhanden"))
+            begr_md = ki_map.get((str(func.id), None))
             rows.append(
                 {
                     "name": func.name,
@@ -1952,7 +1954,9 @@ def projekt_file_edit_json(request, pk):
                     "func_id": func.id,
                     "verif_key": func.name,
                     "source_text": row_source,
-                    "ki_begruendung": ki_map.get((str(func.id), None)),
+                    "ki_begruendung": begr_md,
+                    "ki_begruendung_md": begr_md,
+                    "ki_begruendung_html": markdownify(begr_md) if begr_md else "",
                 }
             )
             for sub in func.anlage2subquestion_set.all().order_by("id"):
@@ -1996,6 +2000,7 @@ def projekt_file_edit_json(request, pk):
                 row_source = source_map.get(
                     (str(func.id), str(sub.id), "technisch_vorhanden")
                 )
+                begr_md = ki_map.get((str(func.id), str(sub.id)))
                 rows.append(
                     {
                         "name": sub.frage_text,
@@ -2010,7 +2015,9 @@ def projekt_file_edit_json(request, pk):
                         "sub_id": sub.id,
                         "verif_key": lookup_key,
                         "source_text": row_source,
-                        "ki_begruendung": ki_map.get((str(func.id), str(sub.id))),
+                        "ki_begruendung": begr_md,
+                        "ki_begruendung_md": begr_md,
+                        "ki_begruendung_html": markdownify(begr_md) if begr_md else "",
                     }
                 )
         debug_logger.debug(

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -37,9 +37,14 @@
                     <button class="btn btn-sm btn-light toggle-button mr-2" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
                     {% endif %}
                     {{ row.name }}
-                    {% if row.ki_begruendung %}
-                    <span class="ms-2" data-bs-toggle="tooltip" data-bs-html="true"
-                          title="{{ row.ki_begruendung|markdownify }}">ⓘ</span>
+                    {% if row.ki_begruendung_html %}
+                    <button type="button" class="btn btn-sm btn-outline-info open-justification-modal ms-2"
+                            data-bs-toggle="modal"
+                            data-bs-target="#justificationModal"
+                            data-function-name="{{ row.name }}"
+                            data-justification-html="{{ row.ki_begruendung_html|escape }}">
+                        ⓘ Begründung
+                    </button>
                     {% endif %}
                     <span class="text-muted small">(Quelle: {{ row.source_text }})</span>
                 </td>
@@ -85,6 +90,18 @@
         <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-black px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>
     </div>
 </form>
+<div class="modal fade" id="justificationModal" tabindex="-1" aria-labelledby="justificationModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="justificationModalLabel">Begründung</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}
 {% block extra_js %}
 <script>
@@ -344,5 +361,19 @@ document.querySelector('tbody').addEventListener('blur', function(e) {
 document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
     new bootstrap.Tooltip(el, {html: true});
 });
+
+const justificationModal = document.getElementById('justificationModal');
+if (justificationModal) {
+    justificationModal.addEventListener('show.bs.modal', function (event) {
+        const button = event.relatedTarget;
+        const functionName = button.dataset.functionName;
+        const justificationHtml = new DOMParser().parseFromString(button.dataset.justificationHtml, 'text/html').documentElement.textContent;
+        const modalTitle = justificationModal.querySelector('.modal-title');
+        const modalBody = justificationModal.querySelector('.modal-body');
+
+        modalTitle.textContent = 'Begründung für: ' + functionName;
+        modalBody.innerHTML = justificationHtml;
+    });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- provide markdownify helper in views
- collect rendered KI justification in `projekt_file_anlage2_review`
- show justification in Bootstrap modal instead of table tooltip
- add JavaScript handler to populate the modal

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6852c221ebf8832bb3b358c66c9d7a85