### PR TITLE
Add missing link to LLM role admin

### DIFF
--- a/templates/admin_projects.html
+++ b/templates/admin_projects.html
@@ -8,6 +8,7 @@
 <a href="{% url 'anlage2_function_list' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 2 Funktionen</a>
 <a href="{% url 'anlage2_config' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Anlage 2 Konfiguration</a>
 <a href="{% url 'admin_project_statuses' %}" class="btn btn-secondary inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">Projekt-Status verwalten</a>
+<a href="{% url 'admin_llm_roles' %}" class="inline-block mb-4 px-4 py-2 bg-purple-600 text-white rounded ml-2">LLM-Rollen verwalten</a>
 
 <form method="get" action="{% url 'admin_projects' %}" class="mb-4">
     <div class="row g-3 align-items-center">


### PR DESCRIPTION
## Summary
- add navigation button to access the LLM role admin section from the project admin dashboard

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: django_q)*
- `python manage.py test` *(fails: ImportError: cannot import name 'baseconv')*

------
https://chatgpt.com/codex/tasks/task_e_6852c66aead8832bb7b1887b811d3854