### PR TITLE
Remove obsolete Anlage1 prompts

### DIFF
--- a/core/migrations/0023_anlage1config.py
+++ b/core/migrations/0023_anlage1config.py
@@ -36,27 +36,4 @@ class Migration(migrations.Migration):
                 "verbose_name": "Anlage1 Konfiguration",
             },
         ),
-        migrations.RunPython(
-            lambda apps, schema_editor: [
-                apps.get_model("core", "Prompt").objects.get_or_create(
-                    name=f"anlage1_q{i}",
-                    defaults={"text": text},
-                )
-                for i, text in enumerate(
-                    [
-                        "Frage 1: Extrahiere alle Unternehmen als Liste.",
-                        "Frage 2: Extrahiere alle Fachbereiche als Liste.",
-                        "Frage 3: Liste alle Hersteller und Produktnamen auf.",
-                        "Frage 4: Lege den Textblock als question4_raw ab.",
-                        "Frage 5: Fasse den Zweck des Systems in einem Satz.",
-                        "Frage 6: Extrahiere Web-URLs.",
-                        "Frage 7: Extrahiere ersetzte Systeme.",
-                        "Frage 8: Extrahiere Legacy-Funktionen.",
-                        "Frage 9: Lege den Text als question9_raw ab.",
-                    ],
-                    start=1,
-                )
-            ],
-            migrations.RunPython.noop,
-        ),
     ]

--- a/core/migrations/0059_remove_obsolete_anlage1_prompts.py
+++ b/core/migrations/0059_remove_obsolete_anlage1_prompts.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def forwards_func(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    Prompt.objects.filter(name__startswith='anlage1_q').delete()
+
+
+def reverse_func(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0058_llmrole_prompt_role'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]


### PR DESCRIPTION
## Summary
- clean up creation of `anlage1_q*` prompts from old migration
- add migration to delete those prompts from existing DBs

## Testing
- `python manage.py makemigrations --check` *(fails: django_q incompatible with Django 5.2)*
- `python manage.py test` *(fails: django_q incompatible with Django 5.2)*

------
https://chatgpt.com/codex/tasks/task_e_6852d5481630832bb8ae92efaec30b53