### PR TITLE
Integrate custom admin layout

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,7 +1,16 @@
-{% extends "admin/base.html" %}
-{% load static %}
+{% extends "admin_base.html" %}
+{% load i18n static %}
 
-{# Zusätzliche Inhalte für das Django-Admin lassen sich über admin_content einbinden #}
-{% block admin_content %}
-    {% block content %}{% endblock %}
+{% block title %}{{ title }} | {% trans 'NOESIS Admin' %}{% endblock %}
+
+{% block content %}
+    <div id="content-main">
+        {% block content_title %}{% if title %}<h1>{{ title }}</h1>{% endif %}{% endblock %}
+
+        {% block object-tools %}{% endblock %}
+
+        {{ content }}
+
+        {% block sidebar %}{% endblock %}
+    </div>
 {% endblock %}

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -21,6 +21,11 @@
                     <li><a href="{% url 'admin_models' %}" class="text-blue-700 hover:underline">LLM-Modelle</a></li>
                     <li><a href="{% url 'admin_project_statuses' %}" class="text-blue-700 hover:underline">Projekt-Status</a></li>
                 </ul>
+                <li class="font-semibold text-gray-700 mt-4">Systemverwaltung</li>
+                <ul class="ml-4 space-y-1">
+                    <li><a href="{% url 'admin:auth_user_changelist' %}" class="text-blue-700 hover:underline">Benutzer</a></li>
+                    <li><a href="{% url 'admin:auth_group_changelist' %}" class="text-blue-700 hover:underline">Gruppen</a></li>
+                </ul>
             </ul>
         </nav>
     </aside>


### PR DESCRIPTION
## Summary
- wrap Django admin with custom template
- link User and Group management in sidebar

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6852d89ffd00832b92e7ef0df6a57090