### PR TITLE
Refaktoriere Initial-Check

### DIFF
--- a/core/migrations/0061_initial_check_prompts.py
+++ b/core/migrations/0061_initial_check_prompts.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+def add_initial_check_prompts(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    Prompt.objects.get_or_create(
+        name='initial_check_knowledge',
+        defaults={
+            'text': "Kennst du die Software '{name}'? Antworte ausschließlich mit einem einzigen Wort: 'Ja' oder 'Nein'.",
+            'use_system_role': False,
+        },
+    )
+    obj, _ = Prompt.objects.get_or_create(name='initial_llm_check')
+    obj.text = (
+        "Erstelle eine kurze, technisch korrekte Beschreibung für die Software '{name}'. "
+        "Erläutere, was sie tut und wie sie typischerweise eingesetzt wird."
+    )
+    obj.save(update_fields=['text'])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0060_prompt_use_system_role'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_initial_check_prompts, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- add migration for new `initial_check_knowledge` prompt and adjust `initial_llm_check`
- rewrite `worker_run_initial_check` with two-step logic

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: module import errors and one failing test)*

------
https://chatgpt.com/codex/tasks/task_e_6852fd8cd5d0832b9e43370fbcf35c61