### PR TITLE
Implement Justification detail page

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -433,6 +433,16 @@ class EditJustificationForm(forms.Form):
     )
 
 
+class JustificationForm(forms.Form):
+    """Formular zum Bearbeiten eines KI-Begründungstextes."""
+
+    justification = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": 15}),
+        label="KI-Begründung bearbeiten",
+        required=False,
+    )
+
+
 class KnowledgeDescriptionForm(forms.ModelForm):
     """Formular zum Bearbeiten der Beschreibung einer Software."""
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -139,6 +139,16 @@ urlpatterns = [
         name="anlage2_feature_verify",
     ),
     path(
+        "work/anlage/file/<int:file_id>/justification/<path:function_key>/",
+        views.justification_detail_edit,
+        name="justification_detail_edit",
+    ),
+    path(
+        "work/anlage/file/<int:file_id>/justification/<path:function_key>/delete/",
+        views.justification_delete,
+        name="justification_delete",
+    ),
+    path(
         "work/anlage/<int:pk>/edit-ki-justification/",
         views.edit_ki_justification,
         name="edit_ki_justification",

--- a/templates/justification_detail.html
+++ b/templates/justification_detail.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}Begründung{% endblock %}
+{% block content %}
+<h3 class="text-xl font-semibold mb-4">Begründung für: {{ function_name }}</h3>
+<div class="mb-4 p-2 border rounded bg-gray-50">
+    {{ justification_html|safe }}
+</div>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.justification.label_tag }}
+    {{ form.justification }}
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    <a href="{% url 'justification_delete' project_file.id function_name %}" class="bg-red-600 text-white px-4 py-2 rounded ml-2">Begründung löschen</a>
+</form>
+{% endblock %}
+

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -37,14 +37,11 @@
                     <button class="btn btn-sm btn-light toggle-button mr-2" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
                     {% endif %}
                     {{ row.name }}
-                    {% if row.ki_begruendung_html %}
-                    <button type="button" class="btn btn-sm btn-outline-info open-justification-modal ms-2"
-                            data-bs-toggle="modal"
-                            data-bs-target="#justificationModal"
-                            data-function-name="{{ row.name }}"
-                            data-justification-html="{{ row.ki_begruendung_html|escape }}">
-                        ⓘ Begründung anzeigen
-                    </button>
+                    {% if row.ki_begruendung %}
+                    <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
+                       class="btn btn-sm btn-outline-secondary ms-2">
+                        Begründung ansehen/bearbeiten
+                    </a>
                     {% endif %}
                     <span class="text-muted small source-indicator">(Quelle: {{ row.source_text }})</span>
                 </td>
@@ -58,7 +55,7 @@
                                 {% if row.sub %}data-subquestion-id="{{ row.sub_id }}"{% endif %}>KI-Prüfung starten</button></li>
                             {% if row.ki_begruendung %}
                             <li>
-                                <a class="dropdown-item" href="{% url 'edit_ki_justification' anlage.pk %}?{% if row.sub %}subquestion={{ row.sub_id }}{% else %}function={{ row.func_id }}{% endif %}">Begründung bearbeiten</a>
+                                <a class="dropdown-item" href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}">Begründung ansehen/bearbeiten</a>
                             </li>
                             {% endif %}
                         </ul>
@@ -93,18 +90,6 @@
         <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-black px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>
     </div>
 </form>
-<div class="modal fade" id="justificationModal" tabindex="-1" aria-labelledby="justificationModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-scrollable">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="justificationModalLabel">Begründung</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-      </div>
-    </div>
-  </div>
-</div>
 {% endblock %}
 {% block extra_js %}
 <script>
@@ -179,22 +164,5 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 });
-
-const justificationModal = document.getElementById('justificationModal');
-if (justificationModal) {
-    justificationModal.addEventListener('show.bs.modal', function (event) {
-        const button = event.relatedTarget;
-        const functionName = button.dataset.functionName;
-        const justificationHtml = new DOMParser()
-            .parseFromString(button.dataset.justificationHtml, 'text/html')
-            .documentElement.textContent;
-
-        const modalTitle = justificationModal.querySelector('.modal-title');
-        const modalBody = justificationModal.querySelector('.modal-body');
-
-        modalTitle.textContent = 'Begründung für: ' + functionName;
-        modalBody.innerHTML = justificationHtml;
-    });
-}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add simple JustificationForm
- wire up justification detail/edit/delete URLs and views
- add new template to view, edit and delete reasoning text
- link from the review table to the new page and remove tooltip logic

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68531ff5c07c832ba8e39e933db934bc