### PR TITLE
Fix software name usage in initial LLM check

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -833,13 +833,11 @@ def worker_verify_feature(
     return data
 
 
-def worker_run_initial_check(project_id: int, software_name: str) -> dict[str, object]:
+def worker_run_initial_check(knowledge_id: int) -> dict[str, object]:
     """Führt eine zweistufige LLM-Abfrage zu einer Software durch."""
 
-    projekt = BVProject.objects.get(pk=project_id)
-    sk, _ = SoftwareKnowledge.objects.get_or_create(
-        projekt=projekt, software_name=software_name
-    )
+    sk = SoftwareKnowledge.objects.get(pk=knowledge_id)
+    software_name = sk.software_name
 
     result = {"is_known_by_llm": False, "description": ""}
     try:

--- a/core/views.py
+++ b/core/views.py
@@ -2517,10 +2517,13 @@ def ajax_start_initial_checks(request, project_id):
     names = [s.strip() for s in projekt.software_typen.split(',') if s.strip()]
     tasks = []
     for name in names:
+        sk, _ = SoftwareKnowledge.objects.get_or_create(
+            projekt=projekt,
+            software_name=name,
+        )
         tid = async_task(
             "core.llm_tasks.worker_run_initial_check",
-            projekt.pk,
-            name,
+            sk.pk,
         )
         tasks.append({"software": name, "task_id": tid})
     return JsonResponse({"status": "queued", "tasks": tasks})


### PR DESCRIPTION
## Summary
- load SoftwareKnowledge object by ID in `worker_run_initial_check`
- create/get knowledge entries before starting tasks
- adjust tests to pass knowledge ID

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685324b3c458832bacdb1b28a03abca2