### PR TITLE
Fix verify-all button functionality

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -111,6 +111,23 @@ function getCookie(name) {
 const csrftoken = getCookie('csrftoken');
 
 document.addEventListener('DOMContentLoaded', function() {
+    const verifyAllBtn = document.getElementById('btn-verify-all');
+
+    if (verifyAllBtn) {
+        verifyAllBtn.addEventListener('click', function() {
+            const singleVerifyButtons = document.querySelectorAll('.verify-single-feature-btn:not(:disabled)');
+
+            if (singleVerifyButtons.length > 0) {
+                if (confirm(`M\u00f6chten Sie wirklich ${singleVerifyButtons.length} KI-Pr\u00fcfungen starten?`)) {
+                    singleVerifyButtons.forEach(button => {
+                        button.click();
+                    });
+                }
+            } else {
+                alert('Keine ungepr\u00fcften Funktionen zum Starten vorhanden.');
+            }
+        });
+    }
     // Event-Listener für alle individuellen Prüf-Knöpfe
     document.querySelectorAll('.verify-single-feature-btn').forEach(button => {
         button.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- wire up the "Alle Funktionen prüfen" button

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68532a048e24832b86b87592a01fc51a