### PR TITLE
Extend AI verification logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ bejaht wird, folgt Stufe 2 mit der Einschätzung, ob üblicherweise eine
 KI‑Beteiligung vorliegt. Beide Ergebnisse erscheinen anschließend direkt in der
 Tabelle, wobei die Begründung weiterhin über den Info‑Link abrufbar ist.
 
+Die Antwort auf die KI-Frage wird unter `ki_beteiligt` gespeichert. Gibt das
+Modell "Ja" zurück, folgt zudem eine kurze Erläuterung, die im Feld
+`ki_beteiligt_begruendung` landet.
+
 ### Edit-Ansicht für Analysedaten
 
 Über den Link **Analyse bearbeiten** gelangt man zu `/work/anlage/<pk>/edit-json/`.


### PR DESCRIPTION
## Summary
- check for KI involvement after verifying feature availability
- save KI involvement flags in verification JSON and README docs
- adjust tests for new verification fields

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6853dcb9d864832b82ce975b59812463