### PR TITLE
Fix prompt field names in migration

### DIFF
--- a/core/migrations/0014_default_prompts.py
+++ b/core/migrations/0014_default_prompts.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
             prompts[f"check_anlage{i}"] = (
                 "Pr\u00fcfe die folgende Anlage auf Vollst\u00e4ndigkeit. Gib ein JSON mit 'ok' und 'hinweis' zur\u00fcck:\n\n"
             )
-        for name, text in prompts.items():
-            Prompt.objects.get_or_create(name=name, defaults={"text": text})
+        for key, text in prompts.items():
+            Prompt.objects.get_or_create(key=key, defaults={"prompt_text": text})
 
     operations = [migrations.RunPython(create_prompts, migrations.RunPython.noop)]


### PR DESCRIPTION
## Summary
- adjust default prompt migration to use `key` and `prompt_text`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: Cannot resolve keyword 'key' into field)*

------
https://chatgpt.com/codex/tasks/task_e_6853e916c28c832b9d4ca9b80fcbbf4c