### PR TITLE
Refactor AI prompt migration

### DIFF
--- a/core/migrations/0014_default_prompts.py
+++ b/core/migrations/0014_default_prompts.py
@@ -21,12 +21,6 @@ class Migration(migrations.Migration):
             "generate_overall_gutachten": (
                 "Erstelle ein zusammenfassendes Gutachten f\u00fcr das Projekt '{project_title}'. Ber\u00fccksichtige alle folgenden Software-Komponenten und deren Analyseergebnisse: {context_data}. Fasse die Ergebnisse zusammen, bewerte das Gesamtprojekt und gib eine Abschlussempfehlung ab. Strukturiere das Gutachten mit klaren \u00dcberschriften und formatiere es mit Markdown (z.B. \u00dcberschriften, Fett- und Kursivdruck, Listen und Tabellen)."
             ),
-            "anlage2_ai_involvement_check": (
-                "Antworte ausschlie\u00dflich mit 'Ja' oder 'Nein'. Frage: Beinhaltet die Funktion '{function_name}' der Software '{software_name}' typischerweise eine KI-Komponente? Eine KI-Komponente liegt vor, wenn die Funktion unstrukturierte Daten (Text, Bild, Ton) verarbeitet, Sentiment-Analysen durchf\u00fchrt oder nicht-deterministische, probabilistische Ergebnisse liefert."
-            ),
-            "anlage2_ai_involvement_justification": (
-                "Gib eine kurze Begr\u00fcndung, warum die Funktion '{function_name}' der Software '{software_name}' eine KI-Komponente beinhaltet oder beinhalten kann, insbesondere im Hinblick auf die Verarbeitung unstrukturierter Daten oder nicht-deterministischer Ergebnisse."
-            ),
         }
         for i in range(1, 7):
             if i == 2:

--- a/core/migrations/0063_add_ai_involvement_prompts.py
+++ b/core/migrations/0063_add_ai_involvement_prompts.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+
+PROMPTS_TO_ADD = [
+    {
+        "name": "anlage2_ai_involvement_check",
+        "text": (
+            "Antworte ausschließlich mit 'Ja' oder 'Nein'. Frage: Beinhaltet die Funktion '{function_name}' der Software '{software_name}' typischerweise eine KI-Komponente? "
+            "Eine KI-Komponente liegt vor, wenn die Funktion unstrukturierte Daten (Text, Bild, Ton) verarbeitet, Sentiment-Analysen durchführt oder nicht-deterministische, probabilistische Ergebnisse liefert."
+        ),
+    },
+    {
+        "name": "anlage2_ai_involvement_justification",
+        "text": (
+            "Gib eine kurze Begründung, warum die Funktion '{function_name}' der Software '{software_name}' eine KI-Komponente beinhaltet oder beinhalten kann, insbesondere im Hinblick auf die Verarbeitung unstrukturierter Daten oder nicht-deterministischer Ergebnisse."
+        ),
+    },
+]
+
+def forwards_func(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    for prompt_data in PROMPTS_TO_ADD:
+        Prompt.objects.get_or_create(
+            name=prompt_data["name"],
+            defaults={"text": prompt_data["text"]},
+        )
+
+def reverse_func(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    names_to_delete = [p["name"] for p in PROMPTS_TO_ADD]
+    Prompt.objects.filter(name__in=names_to_delete).delete()
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0062_remove_check_anlage2_prompt'),
+    ]
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]


### PR DESCRIPTION
## Summary
- remove ai involvement prompts from old migration
- add migration to handle ai involvement prompts separately

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68540fa260e0832b91a698bb2d0900a6