### PR TITLE
Fix reset button in review page

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -101,7 +101,7 @@
     </table>
     <div class="space-x-2 mt-2">
         <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
-        <button type="button" id="reset-fields" class="bg-gray-300 text-black px-4 py-2 rounded">Reset</button>
+        <button type="reset" id="reset-fields" class="bg-gray-300 text-black px-4 py-2 rounded">Reset</button>
         <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-black px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>
     </div>
 </form>


### PR DESCRIPTION
## Summary
- ensure the reset button in `projekt_file_anlage2_review.html` uses the native `type="reset"`

## Testing
- `python manage.py makemigrations --check` *(fails: DJANGO_SECRET_KEY not set)*
- `python manage.py test` *(fails: DJANGO_SECRET_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_6854783aeafc832b8fcc18af5edda7d1