### PR TITLE
Implement review reset functionality

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -189,6 +189,11 @@ urlpatterns = [
         name="projekt_file_edit_json",
     ),
     path(
+        "work/anlage/<int:pk>/reset-all-reviews/",
+        views.ajax_reset_all_reviews,
+        name="ajax_reset_all_reviews",
+    ),
+    path(
         "work/anlage/<int:pk>/email/",
         views.anlage1_generate_email,
         name="anlage1_generate_email",

--- a/core/views.py
+++ b/core/views.py
@@ -2285,6 +2285,22 @@ def ajax_save_anlage2_review_item(request) -> JsonResponse:
 
 
 @login_required
+@require_POST
+def ajax_reset_all_reviews(request, pk: int) -> JsonResponse:
+    """L\u00f6scht alle manuellen und KI-Bewertungen f\u00fcr eine Anlage."""
+
+    project_file = get_object_or_404(BVProjectFile, pk=pk)
+    if project_file.anlage_nr != 2:
+        return JsonResponse({"error": "invalid"}, status=400)
+
+    Anlage2FunctionResult.objects.filter(projekt=project_file.projekt).delete()
+    project_file.verification_json = {}
+    project_file.save(update_fields=["verification_json"])
+
+    return JsonResponse({"status": "success"})
+
+
+@login_required
 def projekt_gap_analysis(request, pk):
     """Stellt die Gap-Analyse als Download bereit."""
     projekt = BVProject.objects.get(pk=pk)

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -226,41 +226,35 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (resetButton) {
         resetButton.addEventListener('click', function() {
-            if (!confirm('M\u00f6chten Sie wirklich alle manuellen Bewertungen auf die urspr\u00fcnglichen Analysewerte zur\u00fccksetzen?')) {
-                return;
-            }
+            if (confirm('Sind Sie sicher, dass Sie alle manuellen und KI-Bewertungen f\u00fcr diese Anlage unwiderruflich l\u00f6schen und auf den Zustand der Dokumenten-Analyse zur\u00fccksetzen wollen?')) {
 
-            const rows = document.querySelectorAll('tbody tr[data-parsed-status]');
+                const url = "{% url 'ajax_reset_all_reviews' project_file.id %}";
+                const csrftoken = getCookie('csrftoken');
 
-            rows.forEach(row => {
-                const parsedStatus = row.dataset.parsedStatus;
-                const parsedNotes = row.dataset.parsedNotes || "";
+                resetButton.disabled = true;
+                resetButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Zur\u00fccksetzen...';
 
-                const statusRadios = row.querySelectorAll('input[type="radio"][name*="-status"]');
-                const notesTextarea = row.querySelector('textarea[name*="-notes"]');
-
-                if (statusRadios.length > 0) {
-                    let aRadioWasSet = false;
-                    statusRadios.forEach(radio => {
-                        if (radio.value.toLowerCase() === parsedStatus.toLowerCase()) {
-                            radio.checked = true;
-                            aRadioWasSet = true;
-                        }
-                    });
-
-                    if (!aRadioWasSet) {
-                        statusRadios.forEach(radio => {
-                            radio.checked = false;
-                        });
+                fetch(url, {
+                    method: 'POST',
+                    headers: { 'X-CSRFToken': csrftoken }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.status === 'success') {
+                        window.location.reload();
+                    } else {
+                        alert('Ein Fehler ist aufgetreten.');
+                        resetButton.disabled = false;
+                        resetButton.textContent = 'Alle Bewertungen zur\u00fccksetzen';
                     }
-                }
-
-                if (notesTextarea) {
-                    notesTextarea.value = parsedNotes;
-                }
-            });
-
-            alert('Alle Bewertungen wurden zur\u00fcckgesetzt.');
+                })
+                .catch(error => {
+                    alert('Ein Netzwerkfehler ist aufgetreten.');
+                    console.error("Reset error:", error);
+                    resetButton.disabled = false;
+                    resetButton.textContent = 'Alle Bewertungen zur\u00fccksetzen';
+                });
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- add URL and backend view to delete all manual and AI reviews for an Anlage
- call new endpoint in projekt_file_anlage2_review template

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: FieldError during migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68547cdb4584832b84d06a993fd27650