### PR TITLE
Fix reset-all reviews

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2293,9 +2293,12 @@ def ajax_reset_all_reviews(request, pk: int) -> JsonResponse:
     if project_file.anlage_nr != 2:
         return JsonResponse({"error": "invalid"}, status=400)
 
-    Anlage2FunctionResult.objects.filter(projekt=project_file.projekt).delete()
+    Anlage2FunctionResult.objects.filter(
+        projekt=project_file.projekt
+    ).exclude(source="parser").delete()
     project_file.verification_json = {}
-    project_file.save(update_fields=["verification_json"])
+    project_file.manual_analysis_json = None
+    project_file.save(update_fields=["verification_json", "manual_analysis_json"])
 
     return JsonResponse({"status": "success"})
 


### PR DESCRIPTION
## Summary
- avoid deleting parser results when resetting
- clear manual overrides so parsed data is shown

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6854822922a4832b8711e9b7e1248fee