### PR TITLE
Fix Anlage2 filter

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -35,6 +35,11 @@
     display: none;
 }
 
+/* Zeilen, die durch den Filter versteckt werden */
+.filter-hidden {
+    display: none;
+}
+
 /* Status-Badges für Projektübersichten */
 .status-badge-new,
 .status-badge-classified {

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -7,7 +7,7 @@
     {% csrf_token %}
     <div class="filter-controls mb-2">
         <label>
-            <input type="checkbox" id="show-relevant-only-filter" class="mr-2">
+            <input type="checkbox" id="show-relevant-only-filter" class="form-check-input mr-2">
             Nur als "vorhanden" markierte Funktionen anzeigen
         </label>
         <button type="button" id="btn-verify-all" class="bg-green-600 text-white px-2 py-1 rounded ml-4">Alle Funktionen prüfen 🤖</button>
@@ -169,34 +169,21 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (filterCheckbox) {
         filterCheckbox.addEventListener('change', function() {
-            const isChecked = this.checked;
+            const showOnlyAvailable = this.checked;
             // Wähle alle Zeilen aus, die gefiltert werden können
-            const allFunctionRows = document.querySelectorAll('tbody tr[data-parsed-status]');
+            const allRows = document.querySelectorAll('tbody tr[data-parsed-status]');
 
-            allFunctionRows.forEach(row => {
-                // Die übergeordnete Hauptfunktion muss immer sichtbar bleiben,
-                // damit man die Unterfragen wieder einblenden kann. Wir filtern nur die Unterfragen.
-                const isSubquestionRow = row.classList.contains('subquestion-row');
+            allRows.forEach(row => {
+                const isAvailable = row.dataset.parsedStatus === 'True';
 
-                if (isChecked) {
-                    // Wenn Checkbox aktiv ist: Zeige nur Zeilen, deren Status 'True' ist.
-                    const status = row.dataset.parsedStatus;
-                    if (status && status.toLowerCase() === 'true') {
-                        row.style.display = '';
+                if (showOnlyAvailable) {
+                    if (isAvailable) {
+                        row.classList.remove('filter-hidden');
                     } else {
-                        // Verstecke die Zeile, wenn sie eine Unterfrage ist und der Status nicht passt
-                        if (isSubquestionRow) {
-                            row.style.display = 'none';
-                        }
+                        row.classList.add('filter-hidden');
                     }
                 } else {
-                    // Wenn Checkbox inaktiv ist: Zeige alle Zeilen wieder an,
-                    // aber respektiere den eingeklappten Zustand.
-                    if (isSubquestionRow && row.classList.contains('hidden-row')) {
-                        row.style.display = 'none';
-                    } else {
-                        row.style.display = '';
-                    }
+                    row.classList.remove('filter-hidden');
                 }
             });
         });


### PR DESCRIPTION
## Summary
- add `.filter-hidden` CSS class
- ensure filter checkbox uses `form-check-input` styling
- simplify filter logic to avoid accordion conflicts

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: FieldError: Cannot resolve keyword 'key' into field)*

------
https://chatgpt.com/codex/tasks/task_e_68548f8e9e44832bb7c512233da97b73