### PR TITLE
Add subquestion context verification test

### DIFF
--- a/core/migrations/0014_default_prompts.py
+++ b/core/migrations/0014_default_prompts.py
@@ -29,6 +29,6 @@ class Migration(migrations.Migration):
                 "Pr\u00fcfe die folgende Anlage auf Vollst\u00e4ndigkeit. Gib ein JSON mit 'ok' und 'hinweis' zur\u00fcck:\n\n"
             )
         for key, text in prompts.items():
-            Prompt.objects.get_or_create(key=key, defaults={"prompt_text": text})
+            Prompt.objects.get_or_create(name=key, defaults={"text": text})
 
     operations = [migrations.RunPython(create_prompts, migrations.RunPython.noop)]

--- a/core/tests.py
+++ b/core/tests.py
@@ -2175,6 +2175,16 @@ class FeatureVerificationTests(TestCase):
             },
         )
 
+    def test_subquestion_context_contains_question(self):
+        """Die Subquestion wird korrekt im Kontext übergeben."""
+        with patch(
+            "core.llm_tasks.query_llm",
+            side_effect=["Nein", "Nein"],
+        ) as mock_q:
+            worker_verify_feature(self.projekt.pk, "subquestion", self.sub.pk)
+        first_call_ctx = mock_q.call_args_list[0].args[1]
+        self.assertEqual(first_call_ctx["function_name"], self.sub.frage_text)
+
     def test_mixed_returns_none(self):
         with patch(
             "core.llm_tasks.query_llm",


### PR DESCRIPTION
## Summary
- add a test ensuring worker_verify_feature passes subquestion text in the LLM context
- fix 0014 migration to use current Prompt fields

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68557ae1d198832b984efc10e5b79fc3