### PR TITLE
Improve table parser note handling

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -70,7 +70,7 @@
                     {% endif %}
                 </td>
                 {% else %}
-                {% with val=row.analysis|get_item:field %}
+                {% with val=row.analysis|get_item:field note=row.analysis|raw_item:field|get_item:'note' %}
                 <td class="border px-2 text-center">
                     {% if val == True %}
                         <span class="status-badge status-ja">✓ Vorhanden</span>
@@ -79,6 +79,7 @@
                     {% else %}
                         <span class="status-badge status-unbekannt">? Unbekannt</span>
                     {% endif %}
+                    {% if note %}<i class="fa fa-info-circle ms-1" data-bs-toggle="tooltip" title="{{ note }}"></i>{% endif %}
                 </td>
                 {% endwith %}
                 {% endif %}


### PR DESCRIPTION
## Summary
- extend cell parsing to capture notes after *Ja* or *Nein*
- show parsed note as tooltip in Anlage 2 review
- cover note extraction with a new test

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6858f2f2a50c832bb4e7050751992887