### PR TITLE
feat: erweitere initial-check workflow

### DIFF
--- a/core/migrations/0014_default_prompts.py
+++ b/core/migrations/0014_default_prompts.py
@@ -21,6 +21,9 @@ class Migration(migrations.Migration):
             "generate_overall_gutachten": (
                 "Erstelle ein zusammenfassendes Gutachten f\u00fcr das Projekt '{project_title}'. Ber\u00fccksichtige alle folgenden Software-Komponenten und deren Analyseergebnisse: {context_data}. Fasse die Ergebnisse zusammen, bewerte das Gesamtprojekt und gib eine Abschlussempfehlung ab. Strukturiere das Gutachten mit klaren \u00dcberschriften und formatiere es mit Markdown (z.B. \u00dcberschriften, Fett- und Kursivdruck, Listen und Tabellen)."
             ),
+            "initial_check_knowledge_with_context": (
+                "Kennst du die Software '{name}'? Hier ist zus\u00e4tzlicher Kontext, um sie zu identifizieren: \"{user_context}\". Antworte ausschlie\u00dflich mit einem einzigen Wort: 'Ja' oder 'Nein'."
+            ),
         }
         for i in range(1, 7):
             if i == 2:

--- a/core/tests.py
+++ b/core/tests.py
@@ -2265,6 +2265,16 @@ class InitialCheckTests(TestCase):
         self.assertFalse(sk.is_known_by_llm)
         self.assertEqual(sk.description, "")
 
+    def test_context_is_passed_to_prompt(self):
+        with patch("core.llm_tasks.query_llm", return_value="Nein") as mock_q:
+            sk = SoftwareKnowledge.objects.create(
+                projekt=self.projekt,
+                software_name="A",
+            )
+            worker_run_initial_check(sk.pk, user_context="Hint")
+        prompt_text = mock_q.call_args[0][0].text
+        self.assertIn("Hint", prompt_text)
+
 
 
 class EditKIJustificationTests(TestCase):

--- a/core/urls.py
+++ b/core/urls.py
@@ -240,6 +240,11 @@ urlpatterns = [
         name="ajax_start_initial_checks",
     ),
     path(
+        "ajax/rerun-initial-check/",
+        views.ajax_rerun_initial_check_with_context,
+        name="ajax_rerun_initial_check_with_context",
+    ),
+    path(
         "knowledge/<int:knowledge_id>/edit/",
         views.edit_knowledge_description,
         name="edit_knowledge_description",

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -92,6 +92,11 @@
                 {% if row.entry.description %}
                 <a href="{% url 'download_knowledge_as_word' row.entry.id %}" class="text-blue-700 underline">Export</a>
                 {% endif %}
+                {% if row.entry.is_known_by_llm == False %}
+                <button type="button" class="btn btn-sm btn-warning retry-with-context-btn" data-bs-toggle="modal" data-bs-target="#contextModal" data-knowledge-id="{{ row.entry.id }}">
+                    Kontext hinzufügen & erneut prüfen
+                </button>
+                {% endif %}
             {% endif %}
             </td>
             <td class="px-2 py-1 text-center">
@@ -130,8 +135,26 @@
       <li>{{ h.status.name }} - {{ h.changed_at|date:"d.m.Y H:i" }}</li>
     {% endfor %}
     </ul>
-  </div>
 </div>
+</div>
+</div>
+
+<!-- Modal für zusätzlichen Kontext -->
+<div class="modal fade" id="contextModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Kontext hinzufügen</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <textarea id="contextText" class="form-control" rows="4"></textarea>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary send-context-btn">Senden</button>
+      </div>
+    </div>
+  </div>
 </div>
 <script>
 function getCookie(name){const m=document.cookie.match('(^|;)\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
@@ -212,8 +235,8 @@ function startChecks(){
      const iv=setInterval(()=>{
        fetch(tmpl.replace('dummy',t.task_id)).then(r=>r.json()).then(d=>{
          if(d.status==='SUCCESS'||d.status==='FAIL'){
-            clearInterval(iv);done++;loadKnowledge();
-            if(done===tasks.length){spinner.remove();btn.disabled=false;}
+            clearInterval(iv);done++;
+            if(done===tasks.length){window.location.reload();}
          }
        });
      },3000);
@@ -258,9 +281,42 @@ document.addEventListener('DOMContentLoaded',function(){
         }).catch(()=>{
           if(status){status.textContent='Fehler';}
           button.classList.remove('disabled');
-        });
+  });
+  });
+});
+
+document.addEventListener('DOMContentLoaded',function(){
+  let contextId=null;
+  document.querySelectorAll('.retry-with-context-btn').forEach(btn=>{
+    btn.addEventListener('click',function(){
+      contextId=this.dataset.knowledgeId;
+      document.getElementById('contextText').value='';
     });
   });
+  const sendBtn=document.querySelector('.send-context-btn');
+  if(sendBtn){
+    sendBtn.addEventListener('click',function(){
+      const text=document.getElementById('contextText').value;
+      const body=new FormData();
+      body.append('knowledge_id',contextId);
+      body.append('user_context',text);
+      fetch('{% url "ajax_rerun_initial_check_with_context" %}',{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body:body})
+        .then(r=>r.json()).then(data=>{
+          const tid=data.task_id;
+          const tmpl='{% url "ajax_check_task_status" "dummy" %}';
+          const iv=setInterval(()=>{
+            fetch(tmpl.replace('dummy',tid)).then(r=>r.json()).then(d=>{
+              if(d.status==='SUCCESS'||d.status==='FAIL'){
+                clearInterval(iv);window.location.reload();
+              }
+            });
+          },3000);
+        });
+      const modalEl=document.getElementById('contextModal');
+      bootstrap.Modal.getInstance(modalEl).hide();
+    });
+  }
+});
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add optional context prompt for initial checks
- provide AJAX view and URL for rerunning with context
- refresh page when initial tasks finish
- show retry button with context modal
- update tests for new worker behavior

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py test` *(fails: re.error in parse_anlage2_table)*

------
https://chatgpt.com/codex/tasks/task_e_68594ef862d0832b9fa851b17ac39e43