### PR TITLE
Implement autosave workflow for Anlage 2

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -900,6 +900,20 @@ def worker_verify_feature(
     pf.verification_json = verif
     pf.save(update_fields=["verification_json"])
 
+    if object_type == "function":
+        Anlage2FunctionResult.objects.filter(
+            projekt_id=project_id,
+            funktion_id=object_id,
+            source="manual",
+        ).delete()
+    elif object_type == "subquestion":
+        Anlage2FunctionResult.objects.filter(
+            projekt_id=project_id,
+            funktion_id=obj_to_check.funktion_id,
+            source="manual",
+            raw_json__subquestion_id=object_id,
+        ).delete()
+
     return verification_result
 
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -159,9 +159,9 @@ urlpatterns = [
         name="ajax_check_task_status",
     ),
     path(
-        "ajax/save-review-item/",
-        views.ajax_save_anlage2_review_item,
-        name="ajax_save_review_item",
+        "ajax/save-manual-review-item/",
+        views.ajax_save_manual_review_item,
+        name="ajax_save_manual_review_item",
     ),
     path(
         "ajax/start-gutachten/<int:project_id>/",

--- a/core/views.py
+++ b/core/views.py
@@ -2243,24 +2243,20 @@ def ajax_check_task_status(request, task_id: str) -> JsonResponse:
 
 @login_required
 @require_http_methods(["POST"])
-def ajax_save_anlage2_review_item(request) -> JsonResponse:
-    """Speichert eine einzelne Bewertung aus Anlage 2."""
-    try:
-        payload = json.loads(request.body.decode())
-    except json.JSONDecodeError:
-        return JsonResponse({"error": "invalid"}, status=400)
+def ajax_save_manual_review_item(request) -> JsonResponse:
+    """Speichert eine einzelne manuelle Bewertung."""
 
-    pf_id = payload.get("project_file_id")
-    func_id = payload.get("function_id")
-    sub_id = payload.get("subquestion_id")
-    status_val = payload.get("status")
-    if status_val in (True, "True", "true", 1):
+    pf_id = request.POST.get("project_file_id")
+    func_id = request.POST.get("function_id")
+    sub_id = request.POST.get("subquestion_id")
+    status_val = request.POST.get("status")
+    if status_val in (True, "True", "true", "1", 1):
         status = True
-    elif status_val in (False, "False", "false", 0):
+    elif status_val in (False, "False", "false", "0", 0):
         status = False
     else:
         status = None
-    notes = payload.get("notes")
+    notes = request.POST.get("notes")
 
     if pf_id is None or func_id is None:
         return JsonResponse({"error": "invalid"}, status=400)

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -95,7 +95,6 @@
         </tbody>
     </table>
     <div class="space-x-2 mt-2">
-        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
         <button type="reset" id="reset-fields" class="bg-gray-300 text-black px-4 py-2 rounded">Reset</button>
         <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-black px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>
     </div>
@@ -165,6 +164,46 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
     tooltipTriggerList.forEach(el => new bootstrap.Tooltip(el));
+
+    const formElem = document.querySelector('form[data-anlage-id]');
+    const saveUrl = "{% url 'ajax_save_manual_review_item' %}";
+
+    function showStatus(input, text) {
+        let span = input.parentElement.querySelector('.autosave-status');
+        if (!span) {
+            span = document.createElement('span');
+            span.className = 'autosave-status text-muted ms-1';
+            input.parentElement.appendChild(span);
+        }
+        span.textContent = text;
+        return span;
+    }
+
+    function autoSave(event) {
+        const el = event.target;
+        const row = el.closest('tr');
+        if (!row || !formElem) { return; }
+        const funcId = row.dataset.funcId;
+        const subId = row.dataset.subId;
+        const status = el.type === 'checkbox' ? el.checked : el.value;
+        const body = new FormData();
+        body.append('project_file_id', formElem.dataset.anlageId);
+        body.append('function_id', funcId);
+        if (subId) { body.append('subquestion_id', subId); }
+        body.append('status', status);
+        body.append('notes', '');
+
+        const indicator = showStatus(el, 'Speichere...');
+        fetch(saveUrl, { method: 'POST', headers: { 'X-CSRFToken': csrftoken }, body: body })
+            .then(r => r.json())
+            .then(() => { indicator.textContent = '✓ Gespeichert'; setTimeout(() => indicator.textContent = '', 1500); })
+            .catch(() => { indicator.textContent = '⚠️'; });
+    }
+
+    if (formElem) {
+        formElem.querySelectorAll('input[type="checkbox"]').forEach(inp => inp.addEventListener('change', autoSave));
+        formElem.querySelectorAll('input[type="text"], textarea').forEach(inp => inp.addEventListener('blur', autoSave));
+    }
 
     const filterCheckbox = document.getElementById('show-relevant-only-filter');
 
@@ -241,11 +280,18 @@ document.addEventListener('DOMContentLoaded', function() {
             })
             .then(data => {
                 if (data.status === 'queued' && data.task_id) {
-                    // Hier würde die Polling-Logik starten
-                    // Fürs Erste geben wir nur Erfolg aus und setzen den Knopf zurück
-                    console.log('Task gestartet mit ID:', data.task_id);
-                    clickedButton.innerHTML = '✓';
-                    setTimeout(() => { clickedButton.innerHTML = '🤖'; clickedButton.disabled = false; }, 2000);
+                    const tmpl = "{% url 'ajax_check_task_status' 'TASKID' %}";
+                    const pollUrl = tmpl.replace('TASKID', data.task_id);
+                    const iv = setInterval(() => {
+                        fetch(pollUrl)
+                            .then(r => r.json())
+                            .then(d => {
+                                if (d.status === 'SUCCESS' || d.status === 'FAIL') {
+                                    clearInterval(iv);
+                                    window.location.reload();
+                                }
+                            });
+                    }, 3000);
                 } else {
                     throw new Error('Task-Start vom Server nicht bestätigt.');
                 }


### PR DESCRIPTION
## Summary
- add new endpoint `ajax_save_manual_review_item`
- wire up url for autosave endpoint
- enable autosave UI logic and remove manual save button
- reload page when verification tasks finish
- delete manual results after a KI check

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(not run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68595e23c2f0832b9a1501472711dabb