### PR TITLE
Remove obsolete fields from project creation

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -35,7 +35,7 @@ def _parse_cell_value(text: str) -> dict[str, object]:
     (optionaler Zusatztext) zurück.
     """
     text = text.strip()
-    match = re.match(r"^(?i)(ja|nein)\b(.*)$", text)
+    match = re.match(r"^(ja|nein)\b(.*)$", text, flags=re.IGNORECASE)
     if match:
         value = match.group(1).lower() == "ja"
         rest = match.group(2).strip()

--- a/core/forms.py
+++ b/core/forms.py
@@ -113,11 +113,6 @@ class DocxValidationMixin:
 
 
 class BVProjectForm(DocxValidationMixin, forms.ModelForm):
-    docx_file = forms.FileField(
-        required=False,
-        label="DOCX-Datei",
-        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
-    )
     if SoftwareType:
         software_type = forms.ModelMultipleChoiceField(
             queryset=SoftwareType.objects.none(),
@@ -127,16 +122,14 @@ class BVProjectForm(DocxValidationMixin, forms.ModelForm):
         )
     class Meta:
         model = BVProject
-        fields = ["title", "beschreibung", "software_typen", "status"]
+        fields = ["title", "software_typen", "status"]
         labels = {
             "title": "Name",
-            "beschreibung": "Beschreibung",
             "software_typen": "Software-Typen",
             "status": "Status",
         }
         widgets = {
             "title": forms.TextInput(attrs={"class": "border rounded p-2"}),
-            "beschreibung": forms.Textarea(attrs={"class": "border rounded p-2"}),
             "software_typen": forms.HiddenInput(),
             "status": forms.Select(attrs={"class": "border rounded p-2"}),
         }

--- a/core/tests.py
+++ b/core/tests.py
@@ -499,14 +499,12 @@ class BVProjectFormTests(TestCase):
         data.update(
             {
                 "title": "",
-                "beschreibung": "",
             }
         )
         data.setlist("software", ["A"])
-        valid = BVProjectForm(data, {"docx_file": SimpleUploadedFile("t.docx", b"d")})
-        self.assertTrue(valid.is_valid())
-        invalid = BVProjectForm(data, {"docx_file": SimpleUploadedFile("t.txt", b"d")})
-        self.assertFalse(invalid.is_valid())
+        form = BVProjectForm(data)
+        self.assertTrue(form.is_valid())
+        self.assertNotIn("docx_file", form.fields)
 
     def test_upload_form_docx_validation(self):
         valid = BVProjectUploadForm(

--- a/core/views.py
+++ b/core/views.py
@@ -1516,17 +1516,6 @@ def projekt_create(request):
         if form.is_valid():
             projekt = form.save(commit=False)
             projekt.title = form.cleaned_data.get("title", "")
-            docx_file = form.cleaned_data.get("docx_file")
-            if docx_file:
-                from tempfile import NamedTemporaryFile
-
-                tmp = NamedTemporaryFile(delete=False, suffix=".docx")
-                for chunk in docx_file.chunks():
-                    tmp.write(chunk)
-                tmp.close()
-                text = extract_text(Path(tmp.name))
-                Path(tmp.name).unlink(missing_ok=True)
-                projekt.beschreibung = text
             projekt.save()
             return redirect("projekt_detail", pk=projekt.pk)
     else:

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -11,11 +11,6 @@
         {{ form.title.errors }}
     </div>
     <div>
-        {{ form.beschreibung.label_tag }}<br>
-        {{ form.beschreibung }}
-        {{ form.beschreibung.errors }}
-    </div>
-    <div>
         <label>Software</label><br>
         <div id="software-container">
         {% for name in form.software_list %}
@@ -42,11 +37,6 @@
         {{ form.status.errors }}
     </div>
     {% endif %}
-    <div>
-        {{ form.docx_file.label_tag }}<br>
-        {{ form.docx_file }}
-        {{ form.docx_file.errors }}
-    </div>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
     {% if projekt %}
     <div class="mt-4">


### PR DESCRIPTION
## Summary
- simplify project creation by removing description and docx upload
- adjust BVProjectForm accordingly
- remove handling of docx upload in view
- clean project form template
- update tests and regex helper

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68599d187664832bbf66444a5a364126