### PR TITLE
Fix project description handling

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -122,14 +122,16 @@ class BVProjectForm(DocxValidationMixin, forms.ModelForm):
         )
     class Meta:
         model = BVProject
-        fields = ["title", "software_typen", "status"]
+        fields = ["title", "beschreibung", "software_typen", "status"]
         labels = {
             "title": "Name",
+            "beschreibung": "Beschreibung",
             "software_typen": "Software-Typen",
             "status": "Status",
         }
         widgets = {
             "title": forms.TextInput(attrs={"class": "border rounded p-2"}),
+            "beschreibung": forms.Textarea(attrs={"class": "border rounded p-2", "rows": 5}),
             "software_typen": forms.HiddenInput(),
             "status": forms.Select(attrs={"class": "border rounded p-2"}),
         }

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -30,6 +30,13 @@
         {{ form.software_typen }}
         {{ form.software_typen.errors }}
     </div>
+    {% if form.instance.pk %}
+    <div class="mb-3">
+        <label for="{{ form.beschreibung.id_for_label }}" class="form-label">Beschreibung:</label>
+        {{ form.beschreibung }}
+        <div class="form-text">Eine kurze, aussagekräftige Notiz zum Projekt.</div>
+    </div>
+    {% endif %}
     {% if 'status' in form.fields %}
     <div>
         {{ form.status.label_tag }}<br>


### PR DESCRIPTION
## Summary
- allow editing description when updating a project
- show description field only on the edit form

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6859a1e897b4832b80c94e52602f0e63