### PR TITLE
Add persistent sidebar layout

### DIFF
--- a/templates/account.html
+++ b/templates/account.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 
 {% block title %}Konto{% endblock %}
 

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -1,36 +1,9 @@
 {% extends 'base.html' %}
+
+{% block sidebar %}
+    {% include 'partials/admin_sidebar.html' %}
+{% endblock %}
+
 {% block content %}
-<div class="flex">
-    <aside class="w-64 bg-gray-100 p-4 border-r">
-        <nav class="space-y-4 text-sm">
-            <ul class="space-y-1">
-                <li class="font-semibold text-gray-700">Projekte</li>
-                <ul class="ml-4 space-y-1">
-                    <li><a href="{% url 'admin_projects' %}" class="text-blue-700 hover:underline">Projekte</a></li>
-                </ul>
-                <li class="font-semibold text-gray-700 mt-4">Anlagen</li>
-                <ul class="ml-4 space-y-1">
-                    <li><a href="{% url 'admin_anlage1' %}" class="text-blue-700 hover:underline">Anlage 1 Fragen</a></li>
-                    <li><a href="{% url 'anlage2_function_list' %}" class="text-blue-700 hover:underline">Anlage 2 Funktionen</a></li>
-                    <li><a href="{% url 'anlage2_config' %}" class="text-blue-700 hover:underline">Anlage 2 Konfiguration</a></li>
-                </ul>
-                <li class="font-semibold text-gray-700 mt-4">System-Konfiguration</li>
-                <ul class="ml-4 space-y-1">
-                    <li><a href="{% url 'admin_prompts' %}" class="text-blue-700 hover:underline">Prompts</a></li>
-                    <li><a href="{% url 'admin_llm_roles' %}" class="text-blue-700 hover:underline">LLM-Rollen</a></li>
-                    <li><a href="{% url 'admin_models' %}" class="text-blue-700 hover:underline">LLM-Modelle</a></li>
-                    <li><a href="{% url 'admin_project_statuses' %}" class="text-blue-700 hover:underline">Projekt-Status</a></li>
-                </ul>
-                <li class="font-semibold text-gray-700 mt-4">Systemverwaltung</li>
-                <ul class="ml-4 space-y-1">
-                    <li><a href="{% url 'admin:auth_user_changelist' %}" class="text-blue-700 hover:underline">Benutzer</a></li>
-                    <li><a href="{% url 'admin:auth_group_changelist' %}" class="text-blue-700 hover:underline">Gruppen</a></li>
-                </ul>
-            </ul>
-        </nav>
-    </aside>
-    <div class="flex-1 p-4">
-        {% block admin_content %}{% endblock %}
-    </div>
-</div>
+    {% block admin_content %}{% endblock %}
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,18 +34,23 @@
         </div>
     </header>
 
-    <main class="flex-1 container mx-auto p-4">
-        {% if messages %}
-        <div class="mb-4 space-y-2">
-            {% for message in messages %}
-            <div class="p-2 rounded bg-blue-100 text-blue-800 {{ message.tags }}">
-                {{ message }}
+    <div class="main-container flex flex-1">
+        <aside class="sidebar bg-gray-100 p-4 w-64">
+            {% block sidebar %}{% endblock %}
+        </aside>
+        <main class="main-content flex-grow p-4">
+            {% if messages %}
+            <div class="mb-4 space-y-2">
+                {% for message in messages %}
+                <div class="p-2 rounded bg-blue-100 text-blue-800 {{ message.tags }}">
+                    {{ message }}
+                </div>
+                {% endfor %}
             </div>
-            {% endfor %}
-        </div>
-        {% endif %}
-        {% block content %}{% endblock %}
-    </main>
+            {% endif %}
+            {% block content %}{% endblock %}
+        </main>
+    </div>
 
     <footer class="bg-gray-100 text-center py-4">
         <p>&copy; 2024 Noesis Assistant</p>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% load recording_extras %}
 {% block title %}Dashboard{% endblock %}
 {% block content %}

--- a/templates/edit_ki_justification.html
+++ b/templates/edit_ki_justification.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}KI-Begründung bearbeiten{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">KI-Begründung bearbeiten</h1>

--- a/templates/edit_knowledge_description.html
+++ b/templates/edit_knowledge_description.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Beschreibung bearbeiten{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Beschreibung bearbeiten</h1>

--- a/templates/gutachten_edit.html
+++ b/templates/gutachten_edit.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Gutachten bearbeiten{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }} bearbeiten</h1>

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% load recording_extras %}
 {% block title %}Gutachten anzeigen{% endblock %}
 {% block content %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 
 {% block title %}Startseite - Noesis Assistant{% endblock %}
 

--- a/templates/justification_detail.html
+++ b/templates/justification_detail.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Begründung{% endblock %}
 {% block content %}
 <h3 class="text-xl font-semibold mb-4">Begründung für: {{ function_name }}</h3>

--- a/templates/partials/admin_sidebar.html
+++ b/templates/partials/admin_sidebar.html
@@ -1,0 +1,26 @@
+<nav class="space-y-4 text-sm">
+    <ul class="space-y-1">
+        <li class="font-semibold text-gray-700">Projekte</li>
+        <ul class="ml-4 space-y-1">
+            <li><a href="{% url 'admin_projects' %}" class="text-blue-700 hover:underline">Projekte</a></li>
+        </ul>
+        <li class="font-semibold text-gray-700 mt-4">Anlagen</li>
+        <ul class="ml-4 space-y-1">
+            <li><a href="{% url 'admin_anlage1' %}" class="text-blue-700 hover:underline">Anlage 1 Fragen</a></li>
+            <li><a href="{% url 'anlage2_function_list' %}" class="text-blue-700 hover:underline">Anlage 2 Funktionen</a></li>
+            <li><a href="{% url 'anlage2_config' %}" class="text-blue-700 hover:underline">Anlage 2 Konfiguration</a></li>
+        </ul>
+        <li class="font-semibold text-gray-700 mt-4">System-Konfiguration</li>
+        <ul class="ml-4 space-y-1">
+            <li><a href="{% url 'admin_prompts' %}" class="text-blue-700 hover:underline">Prompts</a></li>
+            <li><a href="{% url 'admin_llm_roles' %}" class="text-blue-700 hover:underline">LLM-Rollen</a></li>
+            <li><a href="{% url 'admin_models' %}" class="text-blue-700 hover:underline">LLM-Modelle</a></li>
+            <li><a href="{% url 'admin_project_statuses' %}" class="text-blue-700 hover:underline">Projekt-Status</a></li>
+        </ul>
+        <li class="font-semibold text-gray-700 mt-4">Systemverwaltung</li>
+        <ul class="ml-4 space-y-1">
+            <li><a href="{% url 'admin:auth_user_changelist' %}" class="text-blue-700 hover:underline">Benutzer</a></li>
+            <li><a href="{% url 'admin:auth_group_changelist' %}" class="text-blue-700 hover:underline">Gruppen</a></li>
+        </ul>
+    </ul>
+</nav>

--- a/templates/partials/user_sidebar.html
+++ b/templates/partials/user_sidebar.html
@@ -1,0 +1,6 @@
+<nav class="space-y-2">
+    <ul class="space-y-1">
+        <li><a href="{% url 'dashboard' %}" class="block py-2 px-4 hover:bg-gray-200">Dashboard</a></li>
+        <li><a href="{% url 'projekt_list' %}" class="block py-2 px-4 hover:bg-gray-200">Projekte</a></li>
+    </ul>
+</nav>

--- a/templates/personal.html
+++ b/templates/personal.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 
 {% block title %}Persönlicher Bereich{% endblock %}
 

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% load recording_extras %}
 {% block title %}Projekt {{ projekt.title }}{% endblock %}
 {% block content %}

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Anlage 1 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen prüfen</h1>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% load recording_extras %}
 {% block title %}Anlage 2 Review{% endblock %}
 {% block content %}

--- a/templates/projekt_file_check_result.html
+++ b/templates/projekt_file_check_result.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Pr\u00fcfergebnis{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Pr\u00fcfergebnis f\u00fcr Anlage {{ anlage.anlage_nr }}</h1>

--- a/templates/projekt_file_form.html
+++ b/templates/projekt_file_form.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Anlage hochladen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage hochladen f\u00fcr {{ projekt.title }}</h1>

--- a/templates/projekt_file_json_form.html
+++ b/templates/projekt_file_json_form.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Analyse bearbeiten{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Analyse f\u00fcr Anlage {{ anlage.anlage_nr }} bearbeiten</h1>

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}{% if projekt %}Projekt bearbeiten{% else %}Neues Projekt{% endif %}{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">{% if projekt %}Projekt bearbeiten{% else %}Neues Projekt{% endif %}</h1>

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Gutachten erstellen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>

--- a/templates/projekt_list.html
+++ b/templates/projekt_list.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Projektverwaltung{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Projektverwaltung</h1>

--- a/templates/projekt_upload.html
+++ b/templates/projekt_upload.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Projekt aus DOCX{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Projekt aus DOCX erstellen</h1>

--- a/templates/recording.html
+++ b/templates/recording.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% load static %}
 {% block title %}Aufnahme {{ bereich|capfirst }}{% endblock %}
 

--- a/templates/talkdiary.html
+++ b/templates/talkdiary.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% load recording_extras %}
 {% block title %}TalkDiary {{ bereich|capfirst }}{% endblock %}
 {% block content %}

--- a/templates/talkdiary_detail.html
+++ b/templates/talkdiary_detail.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% load recording_extras %}
 {% block title %}Transcript{% endblock %}
 {% block content %}

--- a/templates/upload_recording.html
+++ b/templates/upload_recording.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Upload{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Audio hochladen</h1>

--- a/templates/upload_transcript.html
+++ b/templates/upload_transcript.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 {% block title %}Transcript hochladen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Transcript hochladen</h1>

--- a/templates/work.html
+++ b/templates/work.html
@@ -1,4 +1,7 @@
 {% extends 'base.html' %}
+{% block sidebar %}
+    {% include 'partials/user_sidebar.html' %}
+{% endblock %}
 
 {% block title %}Arbeitsassistent{% endblock %}
 


### PR DESCRIPTION
## Summary
- refactor `base.html` for two-column layout with sidebar block
- move admin navigation to a reusable partial
- add user sidebar partial with dashboard and project links
- load the proper sidebar in user and admin templates

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6859a6b051f0832b856a6731b1871678