### PR TITLE
feat: add admin user permission management

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -15,7 +15,9 @@ from .models import (
     Area,
     LLMRole,
     Prompt,
+    Tile,
 )
+from django.contrib.auth.models import Group
 
 try:
     from .models import SoftwareType
@@ -501,4 +503,29 @@ class PromptForm(forms.ModelForm):
             display_name = f"{role.name} (Standard)" if role.is_default else role.name
             choices.append((role.pk, display_name))
         self.fields["role"].choices = choices
+
+
+class UserPermissionsForm(forms.Form):
+    """Formular zur Bearbeitung von Benutzerrechten."""
+
+    groups = forms.ModelMultipleChoiceField(
+        queryset=Group.objects.none(),
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+        label="Gruppen",
+    )
+    tiles = forms.ModelMultipleChoiceField(
+        queryset=Tile.objects.none(),
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+        label="Tiles",
+    )
+
+    def __init__(self, *args, user=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["groups"].queryset = Group.objects.all()
+        self.fields["tiles"].queryset = Tile.objects.all()
+        if user is not None:
+            self.fields["groups"].initial = user.groups.all()
+            self.fields["tiles"].initial = user.tiles.all()
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -62,6 +62,12 @@ urlpatterns = [
     ),
     path("projects-admin/prompts/", views.admin_prompts, name="admin_prompts"),
     path("projects-admin/models/", views.admin_models, name="admin_models"),
+    path("projects-admin/users/", views.admin_user_list, name="admin_user_list"),
+    path(
+        "projects-admin/users/<int:user_id>/permissions/",
+        views.admin_edit_user_permissions,
+        name="admin_edit_user_permissions",
+    ),
     path("projects-admin/anlage1/", views.admin_anlage1, name="admin_anlage1"),
     path(
         "projects-admin/anlage2/config/",

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -31,7 +31,7 @@
             </div>
              <div>
                 <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">Systemverwaltung</h3>
-                <a href="{% url 'admin:auth_user_changelist' %}">Benutzer</a>
+                <a href="{% url 'admin_user_list' %}">Benutzer</a>
                 <a href="{% url 'admin:auth_group_changelist' %}">Gruppen</a>
             </div>
         </nav>

--- a/templates/admin_user_list.html
+++ b/templates/admin_user_list.html
@@ -1,0 +1,31 @@
+{% extends 'admin/base_site.html' %}
+{% block title %}Benutzer{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Benutzer</h1>
+<table class="min-w-full">
+    <thead>
+        <tr class="border-b text-left">
+            <th class="py-2">Name</th>
+            <th class="py-2">E-Mail</th>
+            <th class="py-2">Gruppen</th>
+            <th class="py-2">Tiles</th>
+            <th class="py-2 text-center">Aktion</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for u in users %}
+        <tr class="border-b text-sm">
+            <td class="py-1">{{ u.get_full_name|default:u.username }}</td>
+            <td class="py-1">{{ u.email }}</td>
+            <td class="py-1">{{ u.groups.all|join:", " }}</td>
+            <td class="py-1">{{ u.tiles.all|join:", " }}</td>
+            <td class="py-1 text-center">
+                <a href="{% url 'admin_edit_user_permissions' u.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Berechtigungen bearbeiten</a>
+            </td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="5" class="py-2">Keine Benutzer vorhanden.</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/admin_user_permissions_form.html
+++ b/templates/admin_user_permissions_form.html
@@ -1,0 +1,20 @@
+{% extends 'admin/base_site.html' %}
+{% block title %}Berechtigungen bearbeiten{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Berechtigungen für {{ user_obj.username }}</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.groups.label_tag }}<br>
+        {{ form.groups }}
+        {{ form.groups.errors }}
+    </div>
+    <div>
+        {{ form.tiles.label_tag }}<br>
+        {{ form.tiles }}
+        {{ form.tiles.errors }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add user permission form
- list users and permissions in custom admin
- edit user permissions
- link to new list from admin navigation

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6859b8599f24832b8816dd694dcddc00