### PR TITLE
Add detection phrase support for Anlage 2 import/export

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1453,6 +1453,8 @@ def anlage2_function_import(request):
         for entry in items:
             name = entry.get("name") or entry.get("funktion") or ""
             func, _ = Anlage2Function.objects.get_or_create(name=name)
+            if "detection_phrases" in entry:
+                func.detection_phrases = entry.get("detection_phrases", {})
             func.save()
             subs = entry.get("subquestions") or entry.get("unterfragen") or []
             for sub in subs:
@@ -1465,6 +1467,7 @@ def anlage2_function_import(request):
                 Anlage2SubQuestion.objects.create(
                     funktion=func,
                     frage_text=text,
+                    detection_phrases=vals.get("detection_phrases", {}),
                 )
         messages.success(request, "Funktionskatalog importiert")
         return redirect("anlage2_function_list")
@@ -1479,10 +1482,14 @@ def anlage2_function_export(request):
     for f in Anlage2Function.objects.all().order_by("name"):
         item = {
             "name": f.name,
+            "detection_phrases": f.detection_phrases,
             "subquestions": [],
         }
         for q in f.anlage2subquestion_set.all().order_by("id"):
-            item["subquestions"].append({"frage_text": q.frage_text})
+            item["subquestions"].append({
+                "frage_text": q.frage_text,
+                "detection_phrases": q.detection_phrases,
+            })
         functions.append(item)
     content = json.dumps(functions, ensure_ascii=False, indent=2)
     resp = HttpResponse(content, content_type="application/json")


### PR DESCRIPTION
## Summary
- include `detection_phrases` in `anlage2_function_export`
- load `detection_phrases` when importing functions and subquestions

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: test_get_shows_table)*

------
https://chatgpt.com/codex/tasks/task_e_6859beb65b80832b9bc2af0127db701d