### PR TITLE
Fix dynamic software inputs

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -128,13 +128,17 @@ class BVProjectForm(DocxValidationMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Feldtyp überschreiben, damit einfache Textwerte akzeptiert werden
+        self.fields["software_typen"] = forms.CharField(
+            required=False, widget=forms.HiddenInput()
+        )
         if not self.instance or not self.instance.pk:
             self.fields.pop("status", None)
         else:
             self.fields["status"].queryset = ProjectStatus.objects.all()
         if self.data:
             self.software_list = [
-                s.strip() for s in self.data.getlist("software") if s.strip()
+                s.strip() for s in self.data.getlist("software_typen") if s.strip()
             ]
         else:
             raw = self.initial.get("software_typen")
@@ -147,7 +151,7 @@ class BVProjectForm(DocxValidationMixin, forms.ModelForm):
 
     def clean_software_typen(self) -> list[str]:
         """Bereinigt die Eingabe und stellt sicher, dass sie nicht leer ist."""
-        raw_list = self.data.getlist("software")
+        raw_list = self.data.getlist("software_typen")
         if raw_list:
             names = [s.strip() for s in raw_list if s.strip()]
         else:

--- a/core/tests.py
+++ b/core/tests.py
@@ -501,7 +501,7 @@ class BVProjectFormTests(TestCase):
                 "title": "",
             }
         )
-        data.setlist("software", ["A"])
+        data.setlist("software_typen", ["A"])
         form = BVProjectForm(data)
         self.assertTrue(form.is_valid())
         self.assertNotIn("docx_file", form.fields)

--- a/core/views.py
+++ b/core/views.py
@@ -1671,7 +1671,7 @@ def projekt_create(request):
             return redirect("projekt_detail", pk=projekt.pk)
     else:
         form = BVProjectForm()
-    return render(request, "projekt_form.html", {"form": form})
+    return render(request, "projekt_form.html", {"form": form, "software_typen_list": form.software_list})
 
 
 @login_required
@@ -1693,6 +1693,7 @@ def projekt_edit(request, pk):
         "projekt": projekt,
         "categories": LLMConfig.get_categories(),
         "category": "default",
+        "software_typen_list": form.software_list,
     }
     return render(request, "projekt_form.html", context)
 

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -14,17 +14,13 @@
         <label class="form-label">Software-Typen:</label>
 
         <div id="software-inputs-container">
-            <input type="text" name="software" class="form-control mb-2" value="{{ form.software_list.0 }}">
-            {% for software in form.software_list|slice:"1:" %}
-                <input type="text" name="software" class="form-control mb-2" value="{{ software }}">
+            {% for software_name in software_typen_list %}
+                <input type="text" name="software_typen" class="form-control mb-2" value="{{ software_name }}">
+            {% empty %}
+                <input type="text" name="software_typen" class="form-control mb-2">
             {% endfor %}
-            {% if not form.software_list %}
-                <input type="text" name="software" class="form-control mb-2">
-            {% endif %}
         </div>
         <button type="button" id="add-software-btn" class="btn btn-sm btn-secondary mt-1">+</button>
-        {{ form.software_typen }}
-        {{ form.software_typen.errors }}
 
     </div>
     {% if form.instance.pk %}
@@ -61,15 +57,21 @@ document.addEventListener('DOMContentLoaded', function() {
     const addSoftwareBtn = document.getElementById('add-software-btn');
     const container = document.getElementById('software-inputs-container');
 
+    // Prüfe, ob beide Elemente existieren, um Fehler zu vermeiden
     if (addSoftwareBtn && container) {
         addSoftwareBtn.addEventListener('click', function() {
-
+            // Erstelle ein neues Input-Element von Grund auf
             const newInput = document.createElement('input');
             newInput.type = 'text';
-            newInput.name = 'software';
+            newInput.name = 'software_typen';
             newInput.className = 'form-control mb-2';
+            newInput.placeholder = 'Weiterer Software-Typ';
 
+            // Füge das neue Input-Element zum Container hinzu
             container.appendChild(newInput);
+
+            // Optional: Setze den Fokus direkt auf das neue Feld
+            newInput.focus();
         });
     }
 });


### PR DESCRIPTION
## Summary
- replace unstable JS for adding software inputs
- simplify form field logic for software types
- update tests for new parameter name
- pass software list from views

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685a94ce9d20832b8b672b20ef39735a