### PR TITLE
Fix software type conversion migration

### DIFF
--- a/core/migrations/0067_convert_software_typen_to_json.py
+++ b/core/migrations/0067_convert_software_typen_to_json.py
@@ -1,4 +1,5 @@
 from django.db import migrations
+import json
 
 def forwards(apps, schema_editor):
     BVProject = apps.get_model('core', 'BVProject')
@@ -10,7 +11,7 @@ def forwards(apps, schema_editor):
             cleaned = [s.strip() for s in data if str(s).strip()]
         else:
             cleaned = []
-        projekt.software_typen = cleaned
+        projekt.software_typen = json.dumps(cleaned)
         projekt.save(update_fields=['software_typen'])
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
## Summary
- encode cleaned software types as JSON string in migration

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py test` *(fails: AttributeError: module 'core.management.commands' has no attribute 'check_anlage2')*

------
https://chatgpt.com/codex/tasks/task_e_685a9e0fb34c832b9509a206ce70d953