### PR TITLE
Handle string input for software types

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from pathlib import Path
+import json
 
 
 def recording_upload_path(instance, filename):
@@ -88,6 +89,16 @@ class BVProject(models.Model):
     def save(self, *args, **kwargs):
         """Speichert das Projekt und setzt den Titel aus den Software-Namen."""
         if self.software_typen:
+            if isinstance(self.software_typen, str):
+                raw = self.software_typen
+                try:
+                    parsed = json.loads(raw)
+                except json.JSONDecodeError:
+                    parsed = raw.split(",")
+                if isinstance(parsed, str):
+                    parsed = [parsed]
+                self.software_typen = parsed
+
             cleaned_list = [
                 s.strip()
                 for s in self.software_typen

--- a/core/tests.py
+++ b/core/tests.py
@@ -573,6 +573,18 @@ class BVProjectModelTests(TestCase):
         )
         self.assertEqual(projekt.title, "X")
 
+    def test_software_typen_string_json(self):
+        projekt = BVProject.objects.create(
+            software_typen='["A", "B", " "]', beschreibung="x"
+        )
+        self.assertListEqual(projekt.software_typen, ["A", "B"])
+
+    def test_software_typen_string_commas(self):
+        projekt = BVProject.objects.create(
+            software_typen="A, B ,C", beschreibung="x"
+        )
+        self.assertListEqual(projekt.software_typen, ["A", "B", "C"])
+
 
 class WorkflowTests(TestCase):
     def test_default_status(self):


### PR DESCRIPTION
## Summary
- handle string-based `software_typen` values in `BVProject.save`
- accept JSON or comma-separated strings
- test saving projects with string values

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685af9291380832b85bddf3ad304531d