### PR TITLE
Update LLM prompt to return Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,4 +155,6 @@ In der Detailansicht eines Projekts befindet sich unterhalb der Anlagen\u00fcber
 2. Zuerst ermittelt das LLM, ob die angegebene Software bekannt ist. Nur wenn dies bejaht wird, folgt eine zweite Abfrage mit der Bitte um eine kurze Beschreibung, die anschlie\u00dfend in der Tabelle erscheint.
 3. Erkennt das Modell die Software nicht, zeigt die Zeile einen Hinweis mit dem Button **Kontext hinzuf\u00fcgen & erneut pr\u00fcfen**. Dar\u00fcber l\u00e4sst sich in einem Modal ein zus\u00e4tzlicher Beschreibungstext eingeben, der beim erneuten Durchlauf an das LLM \u00fcbermittelt wird.
 
+4. Die vom LLM erzeugten Beschreibungen sind in Markdown formatiert und können Überschriften, Listen, Tabellen oder **fett** formatierten Text enthalten.
+
 Der Fortschritt der Initial-Pr\u00fcfung wird oberhalb der Tabelle angezeigt. Nach Abschluss k\u00f6nnen die erzeugten Beschreibungen bearbeitet, exportiert oder gel\u00f6scht werden.

--- a/core/migrations/0069_update_initial_llm_prompt_markup.py
+++ b/core/migrations/0069_update_initial_llm_prompt_markup.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+
+PROMPT_KEY = "initial_llm_check"
+NEW_TEXT = (
+    "Erstelle eine kurze, technisch korrekte Beschreibung für die Software '{name}'. "
+    "Nutze Markdown mit Überschriften, Listen oder Fettdruck, um den Text zu strukturieren. "
+    "Erläutere, was sie tut und wie sie typischerweise eingesetzt wird."
+)
+
+
+def forwards_func(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    Prompt.objects.update_or_create(
+        name=PROMPT_KEY,
+        defaults={'text': NEW_TEXT},
+    )
+
+
+def backwards_func(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    obj = Prompt.objects.filter(name=PROMPT_KEY).first()
+    if obj:
+        obj.text = (
+            "Erstelle eine kurze, technisch korrekte Beschreibung für die Software '{name}'. "
+            "Erläutere, was sie tut und wie sie typischerweise eingesetzt wird."
+        )
+        obj.save(update_fields=['text'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0068_alter_bvproject_software_typen'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, backwards_func),
+    ]


### PR DESCRIPTION
## Summary
- update the `initial_llm_check` prompt to request Markdown formatting
- document that the generated descriptions may contain Markdown

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685b02c40ec0832b88a0560e5227f75b