### PR TITLE
feat: markdown rendering for knowledge table

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2189,6 +2189,18 @@ def project_detail_api(request, pk):
             "id": entry.pk if entry else None,
             "is_known_by_llm": entry.is_known_by_llm if entry else False,
             "description": entry.description if entry else "",
+            "description_html": markdown.markdown(
+                entry.description,
+                extensions=[
+                    "extra",
+                    "admonition",
+                    "toc",
+                    "tables",
+                    "codehilite",
+                ],
+            )
+            if entry and entry.description
+            else "",
             "last_checked": bool(entry and entry.last_checked),
         }
         if item["last_checked"]:

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -197,7 +197,7 @@ function renderKnowledge(data){
   const known=k.last_checked? (k.is_known_by_llm? 'Ja':'Nein') : '-';
   tbody.innerHTML+=`<tr class="border-t"><td class="px-2 py-1">${k.software_name}</td>`+
                     `<td class="px-2 py-1 text-center">${known}</td>`+
-                    `<td class="px-2 py-1">${k.description||''}</td>`+
+                    `<td class="px-2 py-1">${k.description_html||''}</td>`+
                     `<td class="px-2 py-1 text-center">${actions}</td></tr>`;
  });
  document.getElementById('knowledge-progress').textContent=`${data.checked} / ${data.total}`;


### PR DESCRIPTION
## Summary
- render knowledge description as Markdown server-side and pass HTML via project_detail_api
- display description HTML in the knowledge table

## Testing
- `python manage.py makemigrations --check` *(fails: No module named 'django')*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685b077866c0832b983c2eb60b25291d