### PR TITLE
Extend knowledge API

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2184,6 +2184,13 @@ def project_detail_api(request, pk):
     checked = 0
     for name in software_list:
         entry = knowledge_map.get(name)
+        gutachten_id = None
+        if entry:
+            try:
+                gutachten_id = entry.gutachten.id
+            except Gutachten.DoesNotExist:  # pragma: no cover - nicht vorhanden
+                pass
+
         item = {
             "software_name": name,
             "id": entry.pk if entry else None,
@@ -2202,6 +2209,7 @@ def project_detail_api(request, pk):
             if entry and entry.description
             else "",
             "last_checked": bool(entry and entry.last_checked),
+            "gutachten_id": gutachten_id,
         }
         if item["last_checked"]:
             checked += 1

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -185,10 +185,14 @@ function loadKnowledge(){
 function renderKnowledge(data){
  const tbody=document.querySelector('#knowledge-table tbody');
  tbody.innerHTML='';
- const editT='{% url "edit_knowledge_description" 9999 %}';
- const delT='{% url "delete_knowledge_entry" 9999 %}';
- const downT='{% url "download_knowledge_as_word" 9999 %}';
- data.knowledge.forEach(k=>{
+const editT='{% url "edit_knowledge_description" 9999 %}';
+const delT='{% url "delete_knowledge_entry" 9999 %}';
+const downT='{% url "download_knowledge_as_word" 9999 %}';
+ const viewGT='{% url "gutachten_view" 9999 %}';
+ const editGT='{% url "gutachten_edit" 9999 %}';
+ const delGT='{% url "gutachten_delete" 9999 %}';
+ const downGT='{% url "gutachten_download" 9999 %}';
+data.knowledge.forEach(k=>{
   let actions='';
   if(k.id){
     actions=`<a href="${editT.replace('9999',k.id)}" class="text-blue-700 underline mr-2">Bearbeiten</a>`+
@@ -199,13 +203,27 @@ function renderKnowledge(data){
       actions+=`<a href="${downT.replace('9999',k.id)}" class="text-blue-700 underline">Export</a>`;
     }
   }
+  let gutachten='';
+  if(k.gutachten_id){
+    gutachten=`<a href="${viewGT.replace('9999',k.gutachten_id)}">Anzeigen</a> |`+
+              `<a href="${editGT.replace('9999',k.gutachten_id)}">Bearbeiten</a>`+
+              `<form action="${delGT.replace('9999',k.gutachten_id)}" method="post" class="inline">`+
+              `<input type="hidden" name="csrfmiddlewaretoken" value="${getCookie('csrftoken')}">`+
+              `<button type="submit" class="btn-action-delete">Löschen</button></form> | `+
+              `<a href="${downGT.replace('9999',k.gutachten_id)}">Word exportieren</a>`;
+  }else if(k.id){
+    gutachten=`<button class="btn btn-sm btn-primary generate-gutachten-btn" data-knowledge-id="${k.id}">Gutachten erstellen</button>`+
+              `<span class="gutachten-status-spinner ms-2" id="gutachten-status-${k.id}"></span>`;
+  }
   const known=k.last_checked? (k.is_known_by_llm? 'Ja':'Nein') : '-';
   tbody.innerHTML+=`<tr class="border-t"><td class="px-2 py-1">${k.software_name}</td>`+
                     `<td class="px-2 py-1 text-center">${known}</td>`+
                     `<td class="px-2 py-1">${k.description_html||''}</td>`+
-                    `<td class="px-2 py-1 text-center">${actions}</td></tr>`;
- });
- document.getElementById('knowledge-progress').textContent=`${data.checked} / ${data.total}`;
+                    `<td class="px-2 py-1 text-center">${actions}</td>`+
+                    `<td class="px-2 py-1 text-center">${gutachten}</td></tr>`;
+});
+document.getElementById('knowledge-progress').textContent=`${data.checked} / ${data.total}`;
+ attachGutachtenHandlers();
 }
 
 
@@ -300,13 +318,7 @@ function startChecks(){
  }).catch(()=>{alert('Fehler beim Start');spinner.remove();btn.disabled=false;});
 }
 
-document.addEventListener('DOMContentLoaded',loadKnowledge);
-document.addEventListener('DOMContentLoaded',function(){
- const btn=document.getElementById('start-checks');
- if(btn){btn.addEventListener('click',startChecks);}
-});
-
-document.addEventListener('DOMContentLoaded',function(){
+function attachGutachtenHandlers(){
   document.querySelectorAll('.generate-gutachten-btn').forEach(button=>{
     button.addEventListener('click',function(event){
       event.preventDefault();
@@ -326,7 +338,7 @@ document.addEventListener('DOMContentLoaded',function(){
           const iv=setInterval(()=>{
             fetch(tmpl.replace('dummy',tid)).then(r=>r.json()).then(d=>{
               if(d.status==='SUCCESS'){
-                clearInterval(iv);location.reload();
+                clearInterval(iv);loadKnowledge();
               }else if(d.status==='FAIL'){
                 clearInterval(iv);
                 if(status){status.textContent='Fehler';}
@@ -337,9 +349,17 @@ document.addEventListener('DOMContentLoaded',function(){
         }).catch(()=>{
           if(status){status.textContent='Fehler';}
           button.classList.remove('disabled');
+        });
+    });
   });
-  });
+}
+
+document.addEventListener('DOMContentLoaded',loadKnowledge);
+document.addEventListener('DOMContentLoaded',function(){
+ const btn=document.getElementById('start-checks');
+ if(btn){btn.addEventListener('click',startChecks);}
 });
+
 
 document.addEventListener('DOMContentLoaded',function(){
   let contextId=null;


### PR DESCRIPTION
## Summary
- include gutachten ID in `project_detail_api`
- show gutachten actions in JS-rendered table
- add JS utility to rebind gutachten buttons

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685b0e07cedc832b8703e5c7c44bb9eb