### PR TITLE
Fix background task path for Gutachten generation

### DIFF
--- a/core/workflow.py
+++ b/core/workflow.py
@@ -1,4 +1,7 @@
-from .models import BVProject, BVProjectStatusHistory, ProjectStatus
+from django_q.tasks import async_task
+import logging
+
+from .models import BVProject, BVProjectStatusHistory, ProjectStatus, Gutachten
 
 
 def set_project_status(projekt: BVProject, status: str) -> None:
@@ -15,3 +18,23 @@ def set_project_status(projekt: BVProject, status: str) -> None:
     projekt.status = status_obj
     projekt.save(update_fields=["status"])
     BVProjectStatusHistory.objects.create(projekt=projekt, status=status_obj)
+
+
+logger = logging.getLogger(__name__)
+
+
+def task_completion_hook(task) -> None:
+    """Einfacher Hook, der den Abschluss eines Tasks protokolliert."""
+    logger.info("Task %s abgeschlossen", task)
+
+
+def run_generate_gutachten(gutachten: Gutachten) -> None:
+    """Startet die asynchrone Erstellung eines Gutachtens."""
+
+    logger.info("Starting Gutachten generation for Gutachten %s", gutachten.id)
+    async_task(
+        "core.llm_tasks.worker_generate_gutachten",
+        gutachten.id,
+        task_name=f"Generate Gutachten #{gutachten.id}",
+        hook="core.workflow.task_completion_hook",
+    )


### PR DESCRIPTION
## Summary
- add async task imports and utilities in `workflow.py`
- add helper hook and fix path to `worker_generate_gutachten`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685b12c55260832ba903b3cc45df4417