### PR TITLE
Fix AJAX requests on project detail page

### DIFF
--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -134,7 +134,7 @@
     {% endfor %}
     </tbody>
 </table>
-<button id="start-checks" class="bg-green-600 text-white px-4 py-2 rounded">Prüfung starten</button>
+<button id="btn-start-all-initial-checks" class="bg-green-600 text-white px-4 py-2 rounded">Prüfung starten</button>
 
 </div>
 <div class="lg:w-1/3 mt-4 lg:mt-0">
@@ -175,6 +175,7 @@
 </div>
 <script>
 function getCookie(name){const m=document.cookie.match('(^|;)\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
+const csrftoken = getCookie('csrftoken');
 
 function loadKnowledge(){
  fetch('{% url 'project_detail_api' projekt.pk %}')
@@ -287,21 +288,19 @@ function sendCheck(payload){
  sec.appendChild(spinner);
  fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
    method:'POST',
-   headers:{'X-CSRFToken':getCookie('csrftoken')},
+   headers:{'X-CSRFToken':csrftoken},
    body:new URLSearchParams(payload)
- }).then(r=>r.json()).then(d=>{if(d.error){alert(d.error);}/* reload or update */}).catch(()=>alert('LLM-Prüfung fehlgeschlagen')).finally(()=>spinner.remove());
+}).then(r=>r.json()).then(d=>{if(d.error){alert(d.error);}/* reload or update */}).catch(()=>alert('LLM-Prüfung fehlgeschlagen')).finally(()=>spinner.remove());
 }
 
 function startChecks(){
- const btn=document.getElementById('start-checks');
+ const btn=document.getElementById('btn-start-all-initial-checks');
  btn.disabled=true;
- const spinner=document.createElement('span');
- spinner.textContent=' ...';
- btn.after(spinner);
- fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
-   method:'POST',
-   headers:{'X-CSRFToken':getCookie('csrftoken')}
- }).then(r=>r.json()).then(data=>{
+ btn.innerHTML='<span class="spinner-border spinner-border-sm"></span> Prüfungen werden gestartet...';
+fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
+  method:'POST',
+  headers:{'X-CSRFToken':csrftoken}
+}).then(r=>r.json()).then(data=>{
    const tasks=data.tasks||[];
    const tmpl='{% url "ajax_check_task_status" "dummy" %}';
    let done=0;
@@ -315,7 +314,7 @@ function startChecks(){
        });
      },3000);
    });
- }).catch(()=>{alert('Fehler beim Start');spinner.remove();btn.disabled=false;});
+}).catch(()=>{alert('Fehler beim Start');btn.disabled=false;btn.textContent='Prüfung starten';});
 }
 
 function attachGutachtenHandlers(){
@@ -327,11 +326,13 @@ function attachGutachtenHandlers(){
       const body=new FormData();
       body.append('knowledge_id',knowledgeId);
 
-      this.classList.add('disabled');
+      const btn=this;
+      btn.classList.add('disabled');
+      btn.innerHTML='<span class="spinner-border spinner-border-sm"></span> Wird erstellt...';
       const status=document.getElementById('gutachten-status-'+knowledgeId);
       if(status){status.textContent='...';}
 
-      fetch(url,{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body:body})
+      fetch(url,{method:'POST',headers:{'X-CSRFToken':csrftoken},body:body})
         .then(r=>r.json()).then(data=>{
           const tid=data.task_id;
           const tmpl='{% url "ajax_check_task_status" "dummy" %}';
@@ -342,13 +343,15 @@ function attachGutachtenHandlers(){
               }else if(d.status==='FAIL'){
                 clearInterval(iv);
                 if(status){status.textContent='Fehler';}
-                button.classList.remove('disabled');
-              }
+                btn.classList.remove('disabled');
+                btn.textContent='Gutachten erstellen';
+             }
             });
-          },3000);
+         },3000);
         }).catch(()=>{
           if(status){status.textContent='Fehler';}
-          button.classList.remove('disabled');
+          btn.classList.remove('disabled');
+          btn.textContent='Gutachten erstellen';
         });
     });
   });
@@ -356,7 +359,7 @@ function attachGutachtenHandlers(){
 
 document.addEventListener('DOMContentLoaded',loadKnowledge);
 document.addEventListener('DOMContentLoaded',function(){
- const btn=document.getElementById('start-checks');
+ const btn=document.getElementById('btn-start-all-initial-checks');
  if(btn){btn.addEventListener('click',startChecks);}
 });
 
@@ -376,7 +379,7 @@ document.addEventListener('DOMContentLoaded',function(){
       const body=new FormData();
       body.append('knowledge_id',contextId);
       body.append('user_context',text);
-      fetch('{% url "ajax_rerun_initial_check_with_context" %}',{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body:body})
+      fetch('{% url "ajax_rerun_initial_check_with_context" %}',{method:'POST',headers:{'X-CSRFToken':csrftoken},body:body})
         .then(r=>r.json()).then(data=>{
           const tid=data.task_id;
           const tmpl='{% url "ajax_check_task_status" "dummy" %}';


### PR DESCRIPTION
## Summary
- ensure a constant `csrftoken` is used for all fetch requests
- rename start button id to `btn-start-all-initial-checks`
- enhance start and gutachten actions with spinners and proper error handling

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685b173eb4a8832bac80968e3d89a739