### PR TITLE
Fix CSRF in project detail ajax

### DIFF
--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -174,7 +174,20 @@
   </div>
 </div>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
+function getCookie(name) {
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+        const cookies = document.cookie.split(';');
+        for (let i = 0; i < cookies.length; i++) {
+            const cookie = cookies[i].trim();
+            if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
 const csrftoken = getCookie('csrftoken');
 
 function loadKnowledge(){
@@ -286,11 +299,14 @@ function sendCheck(payload){
  const spinner=document.createElement('span');
  spinner.textContent='...';
  sec.appendChild(spinner);
- fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
+  fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
    method:'POST',
-   headers:{'X-CSRFToken':csrftoken},
+   headers:{
+      'X-CSRFToken':csrftoken,
+      'X-Requested-With':'XMLHttpRequest'
+   },
    body:new URLSearchParams(payload)
-}).then(r=>r.json()).then(d=>{if(d.error){alert(d.error);}/* reload or update */}).catch(()=>alert('LLM-Prüfung fehlgeschlagen')).finally(()=>spinner.remove());
+  }).then(r=>r.json()).then(d=>{if(d.error){alert(d.error);}/* reload or update */}).catch(()=>alert('LLM-Prüfung fehlgeschlagen')).finally(()=>spinner.remove());
 }
 
 function startChecks(){
@@ -299,7 +315,10 @@ function startChecks(){
  btn.innerHTML='<span class="spinner-border spinner-border-sm"></span> Prüfungen werden gestartet...';
 fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
   method:'POST',
-  headers:{'X-CSRFToken':csrftoken}
+  headers:{
+    'X-CSRFToken':csrftoken,
+    'X-Requested-With':'XMLHttpRequest'
+  }
 }).then(r=>r.json()).then(data=>{
    const tasks=data.tasks||[];
    const tmpl='{% url "ajax_check_task_status" "dummy" %}';
@@ -332,7 +351,7 @@ function attachGutachtenHandlers(){
       const status=document.getElementById('gutachten-status-'+knowledgeId);
       if(status){status.textContent='...';}
 
-      fetch(url,{method:'POST',headers:{'X-CSRFToken':csrftoken},body:body})
+      fetch(url,{method:'POST',headers:{'X-CSRFToken':csrftoken,'X-Requested-With':'XMLHttpRequest'},body:body})
         .then(r=>r.json()).then(data=>{
           const tid=data.task_id;
           const tmpl='{% url "ajax_check_task_status" "dummy" %}';
@@ -379,7 +398,14 @@ document.addEventListener('DOMContentLoaded',function(){
       const body=new FormData();
       body.append('knowledge_id',contextId);
       body.append('user_context',text);
-      fetch('{% url "ajax_rerun_initial_check_with_context" %}',{method:'POST',headers:{'X-CSRFToken':csrftoken},body:body})
+      fetch('{% url "ajax_rerun_initial_check_with_context" %}',{
+        method:'POST',
+        headers:{
+          'X-CSRFToken':csrftoken,
+          'X-Requested-With':'XMLHttpRequest'
+        },
+        body:body
+      })
         .then(r=>r.json()).then(data=>{
           const tid=data.task_id;
           const tmpl='{% url "ajax_check_task_status" "dummy" %}';


### PR DESCRIPTION
## Summary
- implement Django helper to read CSRF token
- send X-CSRFToken header on async POST requests

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685b1f1b44a4832b943a949af36d6e2f