### PR TITLE
Add admin import/export for prompts

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -376,6 +376,15 @@ class Anlage2FunctionImportForm(forms.Form):
     )
 
 
+class PromptImportForm(forms.Form):
+    """Formular für den JSON-Import der Prompts."""
+
+    json_file = forms.FileField(
+        label="JSON-Datei der Prompts",
+        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
+    )
+
+
 class PhraseForm(forms.Form):
     """Einzelnes Feld für eine Erkennungsphrase."""
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -61,6 +61,16 @@ urlpatterns = [
         name="admin_project_cleanup",
     ),
     path("projects-admin/prompts/", views.admin_prompts, name="admin_prompts"),
+    path(
+        "projects-admin/prompts/export/",
+        views.admin_prompt_export,
+        name="admin_prompt_export",
+    ),
+    path(
+        "projects-admin/prompts/import/",
+        views.admin_prompt_import,
+        name="admin_prompt_import",
+    ),
     path("projects-admin/models/", views.admin_models, name="admin_models"),
     path("projects-admin/users/", views.admin_user_list, name="admin_user_list"),
     path(

--- a/templates/admin_prompt_import.html
+++ b/templates/admin_prompt_import.html
@@ -1,0 +1,15 @@
+{% extends 'admin_base.html' %}
+{% block title %}Prompts importieren{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Prompts importieren</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.json_file.label_tag }}<br>
+        {{ form.json_file }}
+        {{ form.json_file.errors }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+</form>
+{% endblock %}

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -3,6 +3,10 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Admin Prompts</h1>
 <div class="mb-4 space-x-2">
+    <a href="{% url 'admin_prompt_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
+    <a href="{% url 'admin_prompt_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
+</div>
+<div class="mb-4 space-x-2">
     {% for key, label, items in grouped %}
         <button class="tab-btn px-3 py-1 bg-blue-600 text-white rounded" data-tab="{{ key }}">{{ label }}</button>
     {% endfor %}


### PR DESCRIPTION
## Summary
- add `PromptImportForm`
- implement admin views to import/export prompts
- wire up URLs for prompt JSON import/export
- add buttons in prompt admin template and create import page

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685ba0ea88ac832b8ec709ce2866d258