### PR TITLE
Add user import/export

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -538,3 +538,12 @@ class UserPermissionsForm(forms.Form):
             self.fields["groups"].initial = user.groups.all()
             self.fields["tiles"].initial = user.tiles.all()
 
+
+class UserImportForm(forms.Form):
+    """Formular für den Import von Benutzerrechten."""
+
+    json_file = forms.FileField(
+        label="JSON-Datei",
+        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
+    )
+

--- a/core/urls.py
+++ b/core/urls.py
@@ -74,6 +74,16 @@ urlpatterns = [
     path("projects-admin/models/", views.admin_models, name="admin_models"),
     path("projects-admin/users/", views.admin_user_list, name="admin_user_list"),
     path(
+        "projects-admin/users/export/",
+        views.admin_export_users_permissions,
+        name="admin_export_users_permissions",
+    ),
+    path(
+        "projects-admin/users/import/",
+        views.admin_import_users_permissions,
+        name="admin_import_users_permissions",
+    ),
+    path(
         "projects-admin/users/<int:user_id>/permissions/",
         views.admin_edit_user_permissions,
         name="admin_edit_user_permissions",

--- a/templates/admin_user_import.html
+++ b/templates/admin_user_import.html
@@ -1,0 +1,15 @@
+{% extends 'admin/base_site.html' %}
+{% block title %}Benutzer importieren{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Benutzer importieren</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.json_file.label_tag }}<br>
+        {{ form.json_file }}
+        {{ form.json_file.errors }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+</form>
+{% endblock %}

--- a/templates/admin_user_list.html
+++ b/templates/admin_user_list.html
@@ -2,6 +2,10 @@
 {% block title %}Benutzer{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Benutzer</h1>
+<div class="mb-4 space-x-2">
+    <a href="{% url 'admin_import_users_permissions' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
+    <a href="{% url 'admin_export_users_permissions' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
+</div>
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">


### PR DESCRIPTION
## Summary
- implement JSON import/export for users and permissions
- add admin views and URL routes
- provide upload form template and buttons on user list
- include tests for new functionality

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test -v 2` *(fails: AttributeError in command tests)*

------
https://chatgpt.com/codex/tasks/task_e_685bbb332960832ba388cbc47570cc32