### PR TITLE
Fix admin user link

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -31,7 +31,7 @@
             </div>
              <div>
                 <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">Systemverwaltung</h3>
-                <a href="{% url 'admin_user_list' %}">Benutzer</a>
+                <a href="{% url 'admin_user_list' %}">Benutzer verwalten</a>
                 <a href="{% url 'admin:auth_group_changelist' %}">Gruppen</a>
             </div>
         </nav>

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -23,7 +23,7 @@
                 </ul>
                 <li class="font-semibold text-gray-700 mt-4">Systemverwaltung</li>
                 <ul class="ml-4 space-y-1">
-                    <li><a href="{% url 'admin:auth_user_changelist' %}" class="text-blue-700 hover:underline">Benutzer</a></li>
+                    <li><a href="{% url 'admin_user_list' %}" class="text-blue-700 hover:underline">Benutzer verwalten</a></li>
                     <li><a href="{% url 'admin:auth_group_changelist' %}" class="text-blue-700 hover:underline">Gruppen</a></li>
                 </ul>
             </ul>


### PR DESCRIPTION
## Summary
- link admin sidebar 'Benutzer' to `admin_user_list`
- tweak anchor text to "Benutzer verwalten"

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685bd60bead8832ba1e164a3a006d500