### PR TITLE
Add import/export for Anlage1 questions

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -385,6 +385,15 @@ class PromptImportForm(forms.Form):
     )
 
 
+class Anlage1ImportForm(forms.Form):
+    """Formular für den JSON-Import der Anlage-1-Fragen."""
+
+    json_file = forms.FileField(
+        label="JSON-Datei",
+        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
+    )
+
+
 class PhraseForm(forms.Form):
     """Einzelnes Feld für eine Erkennungsphrase."""
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -90,6 +90,16 @@ urlpatterns = [
     ),
     path("projects-admin/anlage1/", views.admin_anlage1, name="admin_anlage1"),
     path(
+        "projects-admin/anlage1/export/",
+        views.admin_anlage1_export,
+        name="admin_anlage1_export",
+    ),
+    path(
+        "projects-admin/anlage1/import/",
+        views.admin_anlage1_import,
+        name="admin_anlage1_import",
+    ),
+    path(
         "projects-admin/anlage2/config/",
         views.anlage2_config,
         name="anlage2_config",

--- a/templates/admin_anlage1.html
+++ b/templates/admin_anlage1.html
@@ -2,6 +2,10 @@
 {% block title %}Anlage 1 Fragen{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen</h1>
+<div class="mb-4 space-x-2">
+    <a href="{% url 'admin_anlage1_import' %}" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">Importieren</a>
+    <a href="{% url 'admin_anlage1_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Exportieren</a>
+</div>
 <form method="post" class="space-y-4">
     {% csrf_token %}
     <table class="min-w-full">

--- a/templates/admin_anlage1_import.html
+++ b/templates/admin_anlage1_import.html
@@ -1,0 +1,15 @@
+{% extends 'admin_base.html' %}
+{% block title %}Anlage 1 Fragen importieren{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen importieren</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.json_file.label_tag }}<br>
+        {{ form.json_file }}
+        {{ form.json_file.errors }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `Anlage1ImportForm` for uploading JSON
- implement admin views to export and import Anlage 1 questions and variants
- register new routes for those views
- provide import template and buttons on the question admin page

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685be0b8cf10832bb52604229d7aec02