### PR TITLE
Implement JSON import/export for global phrases

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -547,3 +547,12 @@ class UserImportForm(forms.Form):
         widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
     )
 
+
+class Anlage2ConfigImportForm(forms.Form):
+    """Formular für den Import der globalen Phrasen."""
+
+    json_file = forms.FileField(
+        label="JSON-Datei",
+        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
+    )
+

--- a/core/urls.py
+++ b/core/urls.py
@@ -95,6 +95,16 @@ urlpatterns = [
         name="anlage2_config",
     ),
     path(
+        "projects-admin/anlage2-config/export/",
+        views.admin_anlage2_config_export,
+        name="admin_anlage2_config_export",
+    ),
+    path(
+        "projects-admin/anlage2-config/import/",
+        views.admin_anlage2_config_import,
+        name="admin_anlage2_config_import",
+    ),
+    path(
         "projects-admin/anlage2/",
         views.anlage2_function_list,
         name="anlage2_function_list",

--- a/core/views.py
+++ b/core/views.py
@@ -45,6 +45,7 @@ from .forms import (
     LLMRoleForm,
     UserPermissionsForm,
     UserImportForm,
+    Anlage2ConfigImportForm,
 
 )
 from .models import (
@@ -1466,6 +1467,52 @@ def admin_import_users_permissions(request):
         messages.success(request, "Benutzerdaten importiert")
         return redirect("admin_user_list")
     return render(request, "admin_user_import.html", {"form": form})
+
+
+@login_required
+@admin_required
+def admin_anlage2_config_export(request):
+    """Exportiert alle globalen Phrasen als JSON-Datei."""
+    cfg = Anlage2Config.get_instance()
+    items = [
+        {"phrase_type": p.phrase_type, "phrase_text": p.phrase_text}
+        for p in cfg.global_phrases.all().order_by("phrase_type", "phrase_text")
+    ]
+    content = json.dumps(items, ensure_ascii=False, indent=2)
+    resp = HttpResponse(content, content_type="application/json")
+    resp["Content-Disposition"] = (
+        "attachment; filename=anlage2_global_phrases.json"
+    )
+    return resp
+
+
+@login_required
+@admin_required
+def admin_anlage2_config_import(request):
+    """Importiert globale Phrasen aus einer JSON-Datei."""
+    form = Anlage2ConfigImportForm(request.POST or None, request.FILES or None)
+    if request.method == "POST" and form.is_valid():
+        raw = form.cleaned_data["json_file"].read().decode("utf-8")
+        try:
+            items = json.loads(raw)
+        except Exception:  # noqa: BLE001
+            messages.error(request, "Ungültige JSON-Datei")
+            return redirect("admin_anlage2_config_import")
+        cfg = Anlage2Config.get_instance()
+        for entry in items:
+            phrase_type = entry.get("phrase_type")
+            phrase_text = entry.get("phrase_text", "")
+            if not phrase_type or not phrase_text:
+                continue
+            Anlage2GlobalPhrase.objects.update_or_create(
+                config=cfg,
+                phrase_type=phrase_type,
+                phrase_text=phrase_text,
+                defaults={},
+            )
+        messages.success(request, "Phrasen importiert")
+        return redirect("anlage2_config")
+    return render(request, "admin_anlage2_config_import.html", {"form": form})
 
 
 @login_required

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -2,6 +2,10 @@
 {% block title %}Anlage 2 Konfiguration{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Konfiguration</h1>
+<div class="mb-4 space-x-2">
+    <a href="{% url 'admin_anlage2_config_export' %}" class="px-4 py-2 bg-gray-300 rounded">Exportieren</a>
+    <a href="{% url 'admin_anlage2_config_import' %}" class="px-4 py-2 bg-gray-300 rounded">Importieren</a>
+</div>
 <form method="post" class="space-y-4">
     {% csrf_token %}
 

--- a/templates/admin_anlage2_config_import.html
+++ b/templates/admin_anlage2_config_import.html
@@ -1,0 +1,15 @@
+{% extends 'admin_base.html' %}
+{% block title %}Anlage 2 Phrasen importieren{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Anlage 2 Phrasen importieren</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.json_file.label_tag }}<br>
+        {{ form.json_file }}
+        {{ form.json_file.errors }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add form for importing Anlage 2 phrases
- add export/import views for Anlage 2 phrases
- wire new routes
- provide template for JSON import
- show Import/Export buttons on configuration page

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685be1c4202c832b86f7e7197a150f16