### PR TITLE
Add LLMRole JSON import/export

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -385,6 +385,15 @@ class PromptImportForm(forms.Form):
     )
 
 
+class LLMRoleImportForm(forms.Form):
+    """Formular für den JSON-Import der LLM-Rollen."""
+
+    json_file = forms.FileField(
+        label="JSON-Datei der Rollen",
+        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
+    )
+
+
 class PhraseForm(forms.Form):
     """Einzelnes Feld für eine Erkennungsphrase."""
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -50,6 +50,8 @@ urlpatterns = [
     path("projects-admin/roles/new/", views.admin_llm_role_form, name="admin_llm_role_new"),
     path("projects-admin/roles/<int:pk>/edit/", views.admin_llm_role_form, name="admin_llm_role_edit"),
     path("projects-admin/roles/<int:pk>/delete/", views.admin_llm_role_delete, name="admin_llm_role_delete"),
+    path("projects-admin/llm-roles/export/", views.admin_llm_role_export, name="admin_llm_role_export"),
+    path("projects-admin/llm-roles/import/", views.admin_llm_role_import, name="admin_llm_role_import"),
     path(
         "projects-admin/<int:pk>/delete/",
         views.admin_project_delete,

--- a/core/views.py
+++ b/core/views.py
@@ -43,6 +43,7 @@ from .forms import (
 
     ProjectStatusForm,
     LLMRoleForm,
+    LLMRoleImportForm,
     UserPermissionsForm,
     UserImportForm,
 
@@ -1374,6 +1375,50 @@ def admin_llm_role_delete(request, pk):
     role = get_object_or_404(LLMRole, pk=pk)
     role.delete()
     return redirect("admin_llm_roles")
+
+
+@login_required
+@admin_required
+def admin_llm_role_export(request):
+    """Exportiert alle LLM-Rollen als JSON-Datei."""
+    roles = [
+        {
+            "name": r.name,
+            "role_prompt": r.role_prompt,
+            "is_default": r.is_default,
+        }
+        for r in LLMRole.objects.all().order_by("name")
+    ]
+    content = json.dumps(roles, ensure_ascii=False, indent=2)
+    resp = HttpResponse(content, content_type="application/json")
+    resp["Content-Disposition"] = "attachment; filename=llm_roles.json"
+    return resp
+
+
+@login_required
+@admin_required
+def admin_llm_role_import(request):
+    """Importiert LLM-Rollen aus einer JSON-Datei."""
+    form = LLMRoleImportForm(request.POST or None, request.FILES or None)
+    if request.method == "POST" and form.is_valid():
+        data = form.cleaned_data["json_file"].read().decode("utf-8")
+        try:
+            items = json.loads(data)
+        except Exception:  # noqa: BLE001
+            messages.error(request, "Ungültige JSON-Datei")
+            return redirect("admin_llm_role_import")
+        for item in items:
+            LLMRole.objects.update_or_create(
+                name=item.get("name", ""),
+                defaults={
+                    "role_prompt": item.get("role_prompt", ""),
+                    "is_default": item.get("is_default", False),
+                },
+            )
+        messages.success(request, "LLM-Rollen importiert")
+        return redirect("admin_llm_roles")
+    context = {"form": form}
+    return render(request, "admin_llm_role_import.html", context)
 
 
 @login_required

--- a/templates/admin_llm_role_import.html
+++ b/templates/admin_llm_role_import.html
@@ -1,0 +1,15 @@
+{% extends 'admin_base.html' %}
+{% block title %}LLM Rollen importieren{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">LLM Rollen importieren</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.json_file.label_tag }}<br>
+        {{ form.json_file }}
+        {{ form.json_file.errors }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+</form>
+{% endblock %}

--- a/templates/admin_llm_roles.html
+++ b/templates/admin_llm_roles.html
@@ -2,7 +2,11 @@
 {% block title %}LLM Rollen{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">LLM Rollen</h1>
-<a href="{% url 'admin_llm_role_new' %}" class="inline-block mb-4 px-4 py-2 bg-blue-600 text-white rounded">Neue Rolle hinzufügen</a>
+<div class="mb-4 space-x-2">
+    <a href="{% url 'admin_llm_role_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
+    <a href="{% url 'admin_llm_role_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
+    <a href="{% url 'admin_llm_role_new' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Neue Rolle hinzufügen</a>
+</div>
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">


### PR DESCRIPTION
## Summary
- allow exporting all LLM roles in JSON format
- add file upload form for importing LLM roles
- link new import/export actions from the role list
- wire new views in the URL configuration

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685be29e541c832b9150702d21474d43