### PR TITLE
Extend Anlage2 config import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ Modelle übersichtlich auf und bietet eine Suchleiste. Die neue Datei
 
 Administratorinnen und Administratoren erreichen die Übersicht aller Anlage‑2-Funktionen unter `/projects-admin/anlage2/`. Dort lassen sich neue Einträge anlegen, vorhandene Funktionen bearbeiten und auch wieder löschen. Über den Button **Importieren** kann eine JSON-Datei hochgeladen werden, die den Funktionskatalog enthält. Ist `/projects-admin/anlage2/import/` aufrufbar, bietet das Formular zudem die Option, die Datenbank vor dem Import zu leeren. Mit **Exportieren** wird der aktuelle Katalog als JSON unter `/projects-admin/anlage2/export/` heruntergeladen. Der Zugriff auf alle genannten URLs erfordert Mitgliedschaft in der Gruppe `admin`.
 
+### Anlage‑2‑Konfiguration importieren/exportieren
+
+Unter `/projects-admin/anlage2/config/` lässt sich zusätzlich die gesamte
+Konfiguration sichern. Die exportierte JSON-Datei enthält zwei Listen:
+
+```json
+{
+  "column_headings": [{"field_name": "technisch_vorhanden", "text": "Verfügbar?"}],
+  "global_phrases": [{"phrase_type": "technisch_verfuegbar_true", "phrase_text": "ja"}]
+}
+```
+
+Beim Import wird dieselbe Struktur erwartet. Fehlen einzelne Bereiche, werden
+lediglich die vorhandenen Daten eingelesen.
+
 ### KI-Begründung per Tooltip
 
 Bei der LLM-Prüfung einzelner Funktionen ruft der Hintergrundtask zusätzlich den

--- a/core/forms.py
+++ b/core/forms.py
@@ -570,7 +570,7 @@ class ProjectStatusImportForm(forms.Form):
     """Formular für den Import von Projektstatus."""
 
 class Anlage2ConfigImportForm(forms.Form):
-    """Formular für den Import der globalen Phrasen."""
+    """Formular für den Import der Anlage-2-Konfiguration."""
 
 
     json_file = forms.FileField(

--- a/core/tests.py
+++ b/core/tests.py
@@ -2390,6 +2390,66 @@ class UserImportExportTests(TestCase):
         self.assertTrue(user.tiles.filter(url_name="tile").exists())
 
 
+class Anlage2ConfigImportExportTests(TestCase):
+    def setUp(self):
+        admin_group = Group.objects.create(name="admin")
+        self.user = User.objects.create_user("cfgadmin", password="pass")
+        self.user.groups.add(admin_group)
+        self.client.login(username="cfgadmin", password="pass")
+        self.cfg = Anlage2Config.get_instance()
+
+    def test_export_contains_headings_and_phrases(self):
+        Anlage2ColumnHeading.objects.create(
+            config=self.cfg,
+            field_name="technisch_vorhanden",
+            text="Verfügbar?",
+        )
+        Anlage2GlobalPhrase.objects.create(
+            config=self.cfg,
+            phrase_type="technisch_verfuegbar_true",
+            phrase_text="ja",
+        )
+        url = reverse("admin_anlage2_config_export")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertIn(
+            {"field_name": "technisch_vorhanden", "text": "Verfügbar?"},
+            data["column_headings"],
+        )
+        self.assertIn(
+            {
+                "phrase_type": "technisch_verfuegbar_true",
+                "phrase_text": "ja",
+            },
+            data["global_phrases"],
+        )
+
+    def test_import_creates_headings(self):
+        payload = json.dumps(
+            {
+                "column_headings": [
+                    {"field_name": "ki_beteiligung", "text": "KI?"}
+                ],
+                "global_phrases": [
+                    {
+                        "phrase_type": "ki_beteiligung_true",
+                        "phrase_text": "Ja",
+                    }
+                ],
+            }
+        )
+        file = SimpleUploadedFile("cfg.json", payload.encode("utf-8"))
+        url = reverse("admin_anlage2_config_import")
+        resp = self.client.post(url, {"json_file": file}, format="multipart")
+        self.assertRedirects(resp, reverse("anlage2_config"))
+        self.assertTrue(
+            Anlage2ColumnHeading.objects.filter(
+                field_name="ki_beteiligung", text="KI?"
+            ).exists()
+        )
+
+
 
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -1623,24 +1623,28 @@ def admin_import_users_permissions(request):
 @login_required
 @admin_required
 def admin_anlage2_config_export(request):
-    """Exportiert alle globalen Phrasen als JSON-Datei."""
+    """Exportiert Spaltenüberschriften und globale Phrasen als JSON-Datei."""
     cfg = Anlage2Config.get_instance()
-    items = [
-        {"phrase_type": p.phrase_type, "phrase_text": p.phrase_text}
-        for p in cfg.global_phrases.all().order_by("phrase_type", "phrase_text")
-    ]
-    content = json.dumps(items, ensure_ascii=False, indent=2)
+    data = {
+        "column_headings": [
+            {"field_name": h.field_name, "text": h.text}
+            for h in cfg.headers.all().order_by("field_name", "id")
+        ],
+        "global_phrases": [
+            {"phrase_type": p.phrase_type, "phrase_text": p.phrase_text}
+            for p in cfg.global_phrases.all().order_by("phrase_type", "phrase_text")
+        ],
+    }
+    content = json.dumps(data, ensure_ascii=False, indent=2)
     resp = HttpResponse(content, content_type="application/json")
-    resp["Content-Disposition"] = (
-        "attachment; filename=anlage2_global_phrases.json"
-    )
+    resp["Content-Disposition"] = "attachment; filename=anlage2_config.json"
     return resp
 
 
 @login_required
 @admin_required
 def admin_anlage2_config_import(request):
-    """Importiert globale Phrasen aus einer JSON-Datei."""
+    """Importiert Spaltenüberschriften und globale Phrasen aus JSON."""
     form = Anlage2ConfigImportForm(request.POST or None, request.FILES or None)
     if request.method == "POST" and form.is_valid():
         raw = form.cleaned_data["json_file"].read().decode("utf-8")
@@ -1650,7 +1654,15 @@ def admin_anlage2_config_import(request):
             messages.error(request, "Ungültige JSON-Datei")
             return redirect("admin_anlage2_config_import")
         cfg = Anlage2Config.get_instance()
-        for entry in items:
+        headings = items.get("column_headings", [])
+        phrases = items.get("global_phrases", [])
+        for h in headings:
+            Anlage2ColumnHeading.objects.update_or_create(
+                config=cfg,
+                field_name=h.get("field_name"),
+                defaults={"text": h.get("text", "")},
+            )
+        for entry in phrases:
             phrase_type = entry.get("phrase_type")
             phrase_text = entry.get("phrase_text", "")
             if not phrase_type or not phrase_text:
@@ -1661,7 +1673,7 @@ def admin_anlage2_config_import(request):
                 phrase_text=phrase_text,
                 defaults={},
             )
-        messages.success(request, "Phrasen importiert")
+        messages.success(request, "Konfiguration importiert")
         return redirect("anlage2_config")
     return render(request, "admin_anlage2_config_import.html", {"form": form})
 

--- a/templates/admin_anlage2_config_import.html
+++ b/templates/admin_anlage2_config_import.html
@@ -1,7 +1,7 @@
 {% extends 'admin_base.html' %}
-{% block title %}Anlage 2 Phrasen importieren{% endblock %}
+{% block title %}Anlage 2 Konfiguration importieren{% endblock %}
 {% block admin_content %}
-<h1 class="text-2xl font-semibold mb-4">Anlage 2 Phrasen importieren</h1>
+<h1 class="text-2xl font-semibold mb-4">Anlage 2 Konfiguration importieren</h1>
 <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
     {{ form.non_field_errors }}


### PR DESCRIPTION
## Summary
- support column headings in Anlage2 config export
- parse new structure on import
- update admin template and form text
- document JSON structure
- test import & export logic

## Testing
- `python manage.py makemigrations --check` *(fails: DJANGO_SECRET_KEY not set)*
- `python manage.py test` *(fails: DJANGO_SECRET_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_685bfb3e64b0832bb3a7bd11a0ab9851