### PR TITLE
Add clear option when importing Anlage 1 questions

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -391,6 +391,8 @@ class LLMRoleImportForm(forms.Form):
 
     json_file = forms.FileField(
         label="JSON-Datei der Rollen",
+        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
+    )
 
 class Anlage1ImportForm(forms.Form):
     """Formular für den JSON-Import der Anlage-1-Fragen."""
@@ -399,6 +401,11 @@ class Anlage1ImportForm(forms.Form):
         label="JSON-Datei",
 
         widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
+    )
+    clear_first = forms.BooleanField(
+        required=False,
+        label="Datenbank vorher leeren",
+        widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
     )
 
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -2390,6 +2390,30 @@ class UserImportExportTests(TestCase):
         self.assertTrue(user.tiles.filter(url_name="tile").exists())
 
 
+class Anlage1ImportTests(TestCase):
+    def setUp(self):
+        admin_group = Group.objects.create(name="admin")
+        self.user = User.objects.create_user("a1import", password="pass")
+        self.user.groups.add(admin_group)
+        self.client.login(username="a1import", password="pass")
+
+    def test_clear_first_resets_questions(self):
+        Anlage1Question.objects.create(num=99, text="Alt?", enabled=True)
+        payload = json.dumps([{"text": "Neu?"}])
+        file = SimpleUploadedFile("a1.json", payload.encode("utf-8"))
+        url = reverse("admin_anlage1_import")
+        resp = self.client.post(
+            url,
+            {"json_file": file, "clear_first": "on"},
+            format="multipart",
+        )
+        self.assertRedirects(resp, reverse("admin_anlage1"))
+        self.assertEqual(Anlage1Question.objects.count(), 1)
+        q = Anlage1Question.objects.first()
+        self.assertEqual(q.text, "Neu?")
+        self.assertEqual(q.num, 1)
+
+
 
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -1352,6 +1352,8 @@ def admin_anlage1_import(request):
         except Exception:  # noqa: BLE001
             messages.error(request, "Ungültige JSON-Datei")
             return redirect("admin_anlage1_import")
+        if form.cleaned_data.get("clear_first"):
+            Anlage1Question.objects.all().delete()
         for idx, item in enumerate(items, start=1):
             obj, _ = Anlage1Question.objects.update_or_create(
                 text=item.get("text", ""),

--- a/templates/admin_anlage1_import.html
+++ b/templates/admin_anlage1_import.html
@@ -10,6 +10,9 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
+    <div>
+        <label class="mr-2">{{ form.clear_first }} Datenbank vorher leeren</label>
+    </div>
     <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow deleting existing Anlage 1 questions before import
- display checkbox in import form
- test new behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685bf9b65eb8832bbe7a4c0219f7a84e