### PR TITLE
feat: erweitere anlage2 import/export

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -2460,7 +2460,7 @@ class Anlage2ConfigImportExportTests(TestCase):
         data = json.loads(resp.content)
         self.assertIn(
             {"field_name": "technisch_vorhanden", "text": "Verfügbar?"},
-            data["column_headings"],
+            data["alias_headings"],
         )
         self.assertIn(
             {
@@ -2473,7 +2473,7 @@ class Anlage2ConfigImportExportTests(TestCase):
     def test_import_creates_headings(self):
         payload = json.dumps(
             {
-                "column_headings": [
+                "alias_headings": [
                     {"field_name": "ki_beteiligung", "text": "KI?"}
                 ],
                 "global_phrases": [


### PR DESCRIPTION
## Summary
- exportiere jetzt Aliasüberschriften und globale Phrasen gemeinsam
- passe Import-View an verschachtelte JSON-Struktur an
- aktualisiere zugehörige Tests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685c28fd2810832b83c79963d266a685