### PR TITLE
Add EasyMDE editor to gutachten page

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1472,6 +1472,11 @@ class GutachtenEditDeleteTests(TestCase):
         self.gutachten.refresh_from_db()
         self.assertEqual(self.gutachten.text, "Neu")
 
+    def test_edit_page_has_mde(self):
+        url = reverse("gutachten_edit", args=[self.gutachten.pk])
+        resp = self.client.get(url)
+        self.assertContains(resp, "easymde.min.css")
+
     def test_delete_removes_file(self):
         url = reverse("gutachten_delete", args=[self.gutachten.pk])
         resp = self.client.post(url)

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-mK8e1zgS60F7uO3cu6UytzszbmWzxubUANe0yoyS9MhUlCT3ocOITkkpFmS6r30YIOCwRvDDDeZz7eGRIDcNQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
+    {% block extra_head %}{% endblock %}
 </head>
 <body class="flex flex-col min-h-screen bg-white text-gray-900">
     <header class="bg-gradient-to-r from-blue-600 to-blue-800 text-white">

--- a/templates/gutachten_edit.html
+++ b/templates/gutachten_edit.html
@@ -4,7 +4,18 @@
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }} bearbeiten</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
-    <textarea name="text" rows="20" class="w-full border rounded p-2">{{ text }}</textarea>
+    <textarea id="gutachten-text" name="text" rows="20" class="w-full border rounded p-2">{{ text }}</textarea>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
 </form>
+{% endblock %}
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+{% endblock %}
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    new EasyMDE({ element: document.getElementById('gutachten-text') });
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `extra_head` block to `base.html`
- integrate EasyMDE on `gutachten_edit.html`
- test for editor presence on the edit page

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685c4a0e9b48832b8782f1c1d221a1b2