### PR TITLE
Fix duplicate gutachten

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -382,7 +382,11 @@ def worker_generate_gutachten(project_id: int, software_type_id: int | None = No
     path = generate_gutachten(projekt.id, text, model_name=model)
 
     if knowledge:
-        Gutachten.objects.create(software_knowledge=knowledge, text=text)
+        gutachten, _ = Gutachten.objects.get_or_create(
+            software_knowledge=knowledge
+        )
+        gutachten.text = text
+        gutachten.save(update_fields=["text"])
 
     return str(path)
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -1437,6 +1437,15 @@ class WorkerGenerateGutachtenTests(TestCase):
         self.assertEqual(Gutachten.objects.filter(software_knowledge=self.knowledge).count(), 1)
         Path(path).unlink(missing_ok=True)
 
+    def test_worker_updates_existing_gutachten(self):
+        Gutachten.objects.create(software_knowledge=self.knowledge, text="Alt")
+        with patch("core.llm_tasks.query_llm", return_value="Neu"):
+            path = worker_generate_gutachten(self.projekt.pk, self.knowledge.pk)
+        gutachten = Gutachten.objects.get(software_knowledge=self.knowledge)
+        self.assertEqual(gutachten.text, "Neu")
+        self.assertEqual(Gutachten.objects.filter(software_knowledge=self.knowledge).count(), 1)
+        Path(path).unlink(missing_ok=True)
+
 
 class GutachtenEditDeleteTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- avoid duplicate `Gutachten` creation
- update worker tests to confirm gutachten updates

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685c4e94170c832b9029a771243b0ca5