### PR TITLE
Handle list input for software_typen

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -86,11 +86,21 @@ class BVProject(models.Model):
         ordering = ["-created_at"]
 
     def save(self, *args, **kwargs):
-        """Speichert das Projekt und setzt den Titel aus den Software-Namen."""
+        """Speichert das Projekt und bereitet ``software_typen`` auf.
+
+        Liegt ``software_typen`` als Liste vor, werden die Einträge zu einem
+        kommagetrennten String verbunden. Bei einem String bleibt die bisherige
+        Aufteilung nach Komma erhalten. Fehlt ein Titel, wird dieser aus den
+        Software-Namen gesetzt.
+        """
         if self.software_typen:
-            cleaned = ", ".join(
-                [s.strip() for s in self.software_typen.split(",") if s.strip()]
-            )
+            if isinstance(self.software_typen, list):
+                cleaned_list = [s.strip() for s in self.software_typen if s.strip()]
+                cleaned = ", ".join(cleaned_list)
+            else:
+                cleaned = ", ".join(
+                    [s.strip() for s in str(self.software_typen).split(",") if s.strip()]
+                )
             self.software_typen = cleaned
             if not self.title:
                 self.title = cleaned

--- a/core/tests.py
+++ b/core/tests.py
@@ -573,6 +573,13 @@ class BVProjectModelTests(TestCase):
         )
         self.assertEqual(projekt.title, "X")
 
+    def test_save_accepts_list_for_software_typen(self):
+        projekt = BVProject.objects.create(
+            software_typen=["A", "", "B "],
+            beschreibung="x",
+        )
+        self.assertEqual(projekt.software_typen, "A, B")
+
 
 class WorkflowTests(TestCase):
     def test_default_status(self):

--- a/core/views.py
+++ b/core/views.py
@@ -1995,7 +1995,7 @@ def projekt_create(request):
             cleaned_software_list = [s.strip() for s in software_typen_list if s.strip()]
 
             projekt = form.save(commit=False)
-            projekt.software_typen = cleaned_software_list
+            projekt.software_typen = ", ".join(cleaned_software_list)
             projekt.save()
             form.save_m2m()
             return redirect("projekt_detail", pk=projekt.pk)
@@ -2014,7 +2014,7 @@ def projekt_edit(request, pk):
             cleaned_software_list = [s.strip() for s in software_typen_list if s.strip()]
 
             projekt = form.save(commit=False)
-            projekt.software_typen = cleaned_software_list
+            projekt.software_typen = ", ".join(cleaned_software_list)
             projekt.save()
             form.save_m2m()
             return redirect("projekt_detail", pk=projekt.pk)


### PR DESCRIPTION
## Summary
- handle lists in `BVProject.save` and adjust the docstring
- join software types in form views
- test list handling for `software_typen`

## Testing
- `python manage.py makemigrations --check` *(fails: No module named 'django')*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685c556a2c98832bbbc2a709d7ceb515