### PR TITLE
Fix textarea color in admin prompts

### DIFF
--- a/templates/admin_anlage1.html
+++ b/templates/admin_anlage1.html
@@ -32,18 +32,18 @@
                     <input type="checkbox" name="delete{{ q.id }}">
                 </td>
                 <td class="py-1">
-                    <textarea name="text{{ q.id }}" rows="2" class="border rounded p-2 w-full">{{ q.text }}</textarea>
+                    <textarea name="text{{ q.id }}" rows="2" class="border rounded p-2 w-full text-gray-900">{{ q.text }}</textarea>
                 </td>
             </tr>
             <tr class="border-b align-top text-sm">
                 <td colspan="4" class="py-1">
                     {% for v in q.variants.all %}
                         <div class="flex items-center mb-1">
-                            <textarea name="variant{{ v.id }}" rows="1" class="border rounded p-2 flex-1">{{ v.text }}</textarea>
+                            <textarea name="variant{{ v.id }}" rows="1" class="border rounded p-2 flex-1 text-gray-900">{{ v.text }}</textarea>
                             <label class="ml-2 text-sm"><input type="checkbox" name="delvar{{ v.id }}"> löschen</label>
                         </div>
                     {% endfor %}
-                    <textarea name="new_variant{{ q.id }}" rows="1" class="border rounded p-2 w-full" placeholder="Neue Variante"></textarea>
+                    <textarea name="new_variant{{ q.id }}" rows="1" class="border rounded p-2 w-full text-gray-900" placeholder="Neue Variante"></textarea>
                 </td>
             </tr>
         {% endfor %}
@@ -57,7 +57,7 @@
             </td>
             <td class="py-1 text-center"></td>
             <td class="py-1">
-                <textarea name="new_text" rows="2" class="border rounded p-2 w-full"></textarea>
+                <textarea name="new_text" rows="2" class="border rounded p-2 w-full text-gray-900"></textarea>
             </td>
         </tr>
         </tbody>

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -50,7 +50,7 @@
                         </label>
                 </td>
                 <td class="py-1">
-                        <textarea name="text" rows="4" class="border rounded p-2 w-full">{{ p.text }}</textarea>
+                        <textarea name="text" rows="4" class="border rounded p-2 w-full text-gray-900">{{ p.text }}</textarea>
                         <button name="action" value="save" class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
                     </form>
                 </td>


### PR DESCRIPTION
## Summary
- ensure textarea text is visible on load

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError: module 'core.management.commands' has no attribute 'check_anlage2_functions')*

------
https://chatgpt.com/codex/tasks/task_e_685c5ea9c020832b9c560e11129596c5