### PR TITLE
Remove unused software_type field

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -18,11 +18,6 @@ from .models import (
     Tile,
 )
 from django.contrib.auth.models import Group
-
-try:
-    from .models import SoftwareType
-except Exception:  # pragma: no cover - optional model
-    SoftwareType = None
 from .llm_tasks import ANLAGE1_QUESTIONS
 
 
@@ -117,13 +112,6 @@ class DocxValidationMixin:
 
 
 class BVProjectForm(DocxValidationMixin, forms.ModelForm):
-    if SoftwareType:
-        software_type = forms.ModelMultipleChoiceField(
-            queryset=SoftwareType.objects.none(),
-            widget=forms.CheckboxSelectMultiple,
-            required=False,
-            label="Software-Typen",
-        )
 
     class Meta:
         model = BVProject
@@ -143,8 +131,6 @@ class BVProjectForm(DocxValidationMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if SoftwareType:
-            self.fields["software_type"].queryset = SoftwareType.objects.all()
         if not self.instance or not self.instance.pk:
             self.fields.pop("status", None)
         else:

--- a/core/views.py
+++ b/core/views.py
@@ -67,7 +67,6 @@ from .models import (
     Anlage2GlobalPhrase,
     Anlage2FunctionResult,
     SoftwareKnowledge,
-    SoftwareType,
     Gutachten,
     Tile,
     Area,
@@ -1993,7 +1992,6 @@ def projekt_detail(request, pk):
         if entry and entry.last_checked:
             checked += 1
         knowledge_rows.append({"name": name, "entry": entry})
-    software_types = list(SoftwareType.objects.filter(name__in=software_list))
     context = {
         "projekt": projekt,
         "status_choices": ProjectStatus.objects.all(),
@@ -2005,7 +2003,6 @@ def projekt_detail(request, pk):
         "knowledge_rows": knowledge_rows,
         "knowledge_checked": checked,
         "total_software": len(software_list),
-        "software_types": software_types,
         "software_list": software_list,
 
     }


### PR DESCRIPTION
## Summary
- remove dangling SoftwareType field from BVProjectForm
- drop related import and queryset setup
- clean up unused import/variable in project detail view

## Testing
- `python manage.py makemigrations --check` *(fails: Conflicting migrations detected)*
- `python manage.py test` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_685c6177d0c4832bafad9d21325b03a3