### PR TITLE
Improve Markdown editing for software knowledge

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -465,7 +465,7 @@ class KnowledgeDescriptionForm(forms.ModelForm):
         labels = {"description": "Beschreibung"}
         widgets = {
             "description": forms.Textarea(
-                attrs={"class": "border rounded p-2", "rows": 5}
+                attrs={"class": "border rounded p-2 w-full", "rows": 20}
             )
         }
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -1508,6 +1508,31 @@ class GutachtenEditDeleteTests(TestCase):
         self.assertFalse(Gutachten.objects.filter(pk=self.gutachten.pk).exists())
 
 
+class KnowledgeDescriptionEditTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("kwuser", password="pass")
+        self.client.login(username="kwuser", password="pass")
+        self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        self.knowledge = SoftwareKnowledge.objects.create(
+            projekt=self.projekt,
+            software_name="A",
+            is_known_by_llm=True,
+            description="Alt",
+        )
+
+    def test_edit_page_has_mde(self):
+        url = reverse("edit_knowledge_description", args=[self.knowledge.pk])
+        resp = self.client.get(url)
+        self.assertContains(resp, "easymde.min.css")
+
+    def test_edit_updates_description(self):
+        url = reverse("edit_knowledge_description", args=[self.knowledge.pk])
+        resp = self.client.post(url, {"description": "Neu"})
+        self.assertRedirects(resp, reverse("projekt_detail", args=[self.projekt.pk]))
+        self.knowledge.refresh_from_db()
+        self.assertEqual(self.knowledge.description, "Neu")
+
+
 class ProjektFileCheckResultTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user("vuser", password="pass")

--- a/templates/edit_knowledge_description.html
+++ b/templates/edit_knowledge_description.html
@@ -1,4 +1,8 @@
 {% extends 'base.html' %}
+{% block extra_head %}
+{{ block.super }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+{% endblock %}
 {% block title %}Beschreibung bearbeiten{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Beschreibung bearbeiten</h1>
@@ -8,4 +12,15 @@
     {{ form.description }}
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
 </form>
+{% endblock %}
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const textarea = document.getElementById('id_description');
+    if (textarea) {
+      new EasyMDE({ element: textarea });
+    }
+  });
+</script>
 {% endblock %}

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -87,7 +87,9 @@
             </td>
             <td class="px-2 py-1">
                 {% if row.entry and row.entry.is_known_by_llm is True %}
-                    {{ row.entry.description|markdownify }}
+                    <div class="prose max-w-none">
+                        {{ row.entry.description|markdownify }}
+                    </div>
                 {% elif row.entry and row.entry.is_known_by_llm is False %}
                     <p class="text-sm text-gray-500">Die automatische Prüfung konnte diese Software nicht eindeutig identifizieren. Bitte fügen Sie zusätzlichen Kontext hinzu, um die Prüfung zu wiederholen.</p>
                 {% else %}


### PR DESCRIPTION
## Summary
- expand textarea for SoftwareKnowledge description
- enable EasyMDE editor on the description page
- render knowledge descriptions with typography styling
- test knowledge description editing

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django_q')*
- `python manage.py test` *(not run due to previous failure)*

------
https://chatgpt.com/codex/tasks/task_e_685c68edbe2c832bb82b8d03b5a9777c