### PR TITLE
Fix invalid DOCX handling

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -164,7 +164,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
         logger.debug(f"Dokument erfolgreich geladen: {path}")
     except Exception as e:  # pragma: no cover - ungültige Datei
         logger.error(f"Fehler beim Laden der Datei {path}: {e}")
-        return {}
+        return []
 
     cfg = Anlage2Config.get_instance()
     logger.debug("Aktive Anlage2Config: %s", cfg)

--- a/core/tests.py
+++ b/core/tests.py
@@ -463,6 +463,17 @@ class DocxExtractTests(TestCase):
         finally:
             Path(tmp.name).unlink(missing_ok=True)
 
+    def test_parse_anlage2_table_invalid_docx(self):
+        tmp = NamedTemporaryFile(delete=False, suffix=".docx")
+        tmp.write(b"invalid")
+        tmp.close()
+        try:
+            data = parse_anlage2_table(Path(tmp.name))
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+        self.assertEqual(data, [])
+
     def test_parse_anlage2_text(self):
         func = Anlage2Function.objects.create(
             name="Login",


### PR DESCRIPTION
## Summary
- return an empty list if DOCX parsing fails
- cover invalid DOCX scenario in tests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685d11013990832bb929aa8a06bb812b