### PR TITLE
Remove comment

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -66,7 +66,7 @@ def _normalize_header_text(text: str) -> str:
     # Zuerst doppelt-escapte Newlines durch ein einfaches Leerzeichen ersetzen
     # Wichtig: Dies muss passieren, bevor "echte" Newlines ersetzt werden,
     # falls beides vorkommt, oder wenn die Quelle schon so escapet.
-    text = text.replace("\\n", " ")  # <-- NEUE ZEILE / ÄNDERUNG HIER!
+    text = text.replace("\\n", " ")
     # Ersetzt '\\n' durch ein Leerzeichen
 
     text = text.replace(


### PR DESCRIPTION
## Summary
- remove the German comment marker around the newline replacement

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_685d11064c68832b8ec1b062826960ef