### PR TITLE
Add parser debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ python manage.py test
 ## Logging
 
 Alle Debug-Ausgaben des Projekts werden zusätzlich in `debug.log` im Projektverzeichnis gespeichert. Diese Datei ist über `.gitignore` vom Versionskontrollsystem ausgenommen.
+Parserbezogene Informationen landen in `parser-debug.log` im selben Verzeichnis. Das Log hilft beim Nachvollziehen der Tabellen- und Textanalyse.
 
 ## Datenbankmigrationen
 

--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -156,6 +156,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
     ``note``.
     """
     logger = logging.getLogger(__name__)
+    parser_logger = logging.getLogger("parser_debug")
 
     logger.debug(f"Starte parse_anlage2_table mit Pfad: {path}")
 
@@ -226,9 +227,11 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
 
             if main_col_text and "Wenn die Funktion technisch" not in main_col_text:
                 current_main_function_name = main_col_text
+                parser_logger.debug("Hauptfunktion erkannt: %s", current_main_function_name)
                 row_data = {"funktion": current_main_function_name}
             elif sub_col_text and current_main_function_name:
                 full_name = f"{current_main_function_name}: {sub_col_text}"
+                parser_logger.debug("Unterfrage erkannt: %s", full_name)
                 row_data = {"funktion": full_name}
 
             if row_data is None:
@@ -242,6 +245,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
                 if idx is not None:
                     row_data[col_name] = _parse_cell_value(row.cells[idx].text)
 
+            parser_logger.debug("Verarbeite Zeile %s: %s", row_idx, row_data)
             logger.debug(
                 "Zeile %s: Funktion '%s' Daten %s",
                 row_idx,
@@ -270,6 +274,7 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
     """
 
     logger = logging.getLogger(__name__)
+    parser_logger = logging.getLogger("parser_debug")
     if not text_content:
         return []
 
@@ -333,6 +338,7 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
             for sub, aliases in sub_map.get(last_func.id, []):
                 if _match(aliases, lower):
                     full_name = f"{last_main['funktion']}: {sub.frage_text}"
+                    parser_logger.debug("Unterfrage erkannt: %s", full_name)
                     row = {"funktion": full_name}
                     row.update(_extract_values(lower))
                     results.append(row)
@@ -344,6 +350,7 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
         # Suche nach einer neuen Hauptfunktion
         for func, aliases in functions:
             if _match(aliases, lower):
+                parser_logger.debug("Hauptfunktion erkannt: %s", func.name)
                 row = {"funktion": func.name}
                 row.update(_extract_values(lower))
                 results.append(row)

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -189,6 +189,12 @@ LOGGING = {
             "filename": BASE_DIR / "llm-debug.log",
             "formatter": "llm_formatter",
         },
+        "parser_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "parser-debug.log",
+            "formatter": "verbose",
+        },
     },
     "loggers": {
         "": {  # Dies ist der Root-Logger. Er fängt alle Meldungen ab, die nicht von spezifischeren Loggern behandelt werden.
@@ -216,6 +222,11 @@ LOGGING = {
         # Wenn dein Skript z.B. in myapp/utils.py liegt, wäre __name__ 'myapp.utils'
         "bv_project_tasks": {  # Passe dies an den tatsächlichen Modulnamen an, wenn du nur diesen spezifischen Logger debuggen möchtest
             "handlers": ["console", "file"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
+        "parser_debug": {
+            "handlers": ["parser_file"],
             "level": "DEBUG",
             "propagate": False,
         },


### PR DESCRIPTION
## Summary
- write parser logs to a dedicated `parser-debug.log`
- configure logger `parser_debug`
- log when functions and subquestions are found in the parser
- document the new log file

## Testing
- `python manage.py makemigrations --check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685d11087844832bbf2cc987f71b2678