### PR TITLE
feat: erweitere parser logging

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -157,8 +157,10 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
     """
     logger = logging.getLogger(__name__)
     parser_logger = logging.getLogger("parser_debug")
+    parser_logger.info("parse_anlage2_text gestartet")
 
     logger.debug(f"Starte parse_anlage2_table mit Pfad: {path}")
+    parser_logger.info("parse_anlage2_table gestartet")
 
     try:
         doc = Document(str(path))
@@ -260,6 +262,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
             break
 
     logger.debug(f"Endgültige Ergebnisse: {results}")
+    parser_logger.info("parse_anlage2_table beendet")
     return results
 
 
@@ -360,4 +363,5 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
                 break
 
     logger.debug("parse_anlage2_text Ergebnisse: %s", results)
+    parser_logger.info("parse_anlage2_text beendet")
     return results

--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -35,6 +35,7 @@ from .docx_utils import (
 from docx import Document
 
 logger = logging.getLogger(__name__)
+parser_logger = logging.getLogger("parser_debug")
 
 ANLAGE1_QUESTIONS = [
     "Frage 1: Extrahiere alle Unternehmen als Liste.",
@@ -603,7 +604,7 @@ def check_anlage2(projekt_id: int, model_name: str | None = None) -> dict:
         )
         logger.debug("Tabellenzeile: %s", row)
         if row is None:
-            logger.debug("Parser fand Funktion '%s' nicht", func.name)
+            parser_logger.debug("Parser fand Funktion '%s' nicht", func.name)
         def _val(item, key):
             value = item.get(key)
             if isinstance(value, dict) and "value" in value:
@@ -658,7 +659,7 @@ def check_anlage2(projekt_id: int, model_name: str | None = None) -> dict:
                 None,
             )
             if sub_row is None:
-                logger.debug("Parser fand Unterfrage '%s' nicht", sub_name)
+                parser_logger.debug("Parser fand Unterfrage '%s' nicht", sub_name)
             prompt_text = f"{prompt_base}Funktion: {sub.frage_text}\n\n{text}"
             logger.debug(
                 "LLM Prompt f\u00fcr Subfrage '%s': %s", sub.frage_text, prompt_text


### PR DESCRIPTION
## Summary
- log parser start and end in parser-debug log
- include missing functions and subquestions in parser-debug log

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685d3d2bc52c832b96b787e73858d71a