### PR TITLE
Fix incorrect parser log entry

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -157,8 +157,6 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
     """
     logger = logging.getLogger(__name__)
     parser_logger = logging.getLogger("parser_debug")
-    parser_logger.info("parse_anlage2_text gestartet")
-
     logger.debug(f"Starte parse_anlage2_table mit Pfad: {path}")
     parser_logger.info("parse_anlage2_table gestartet")
 


### PR DESCRIPTION
## Summary
- remove incorrect log line from `parse_anlage2_table`

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685d421430b4832bb8d856c6b8bc2556