### PR TITLE
Add parsed file path to parser log

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -158,7 +158,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
     logger = logging.getLogger(__name__)
     parser_logger = logging.getLogger("parser_debug")
     logger.debug(f"Starte parse_anlage2_table mit Pfad: {path}")
-    parser_logger.info("parse_anlage2_table gestartet")
+    parser_logger.info("parse_anlage2_table gestartet: %s", path)
 
     try:
         doc = Document(str(path))
@@ -260,7 +260,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
             break
 
     logger.debug(f"Endgültige Ergebnisse: {results}")
-    parser_logger.info("parse_anlage2_table beendet")
+    parser_logger.info("parse_anlage2_table beendet: %s", path)
     return results
 
 


### PR DESCRIPTION
## Summary
- include the source file path in parse_anlage2_table logging

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685d412169f8832b89fb5305bfd706a2