### PR TITLE
feat: log missing tables

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -173,6 +173,9 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
     logger.debug("Erzeugtes Header-Mapping: %s", header_map)
 
     results: list[dict[str, object]] = []
+    if not doc.tables:
+        logger.debug("Keine Tabellen im Dokument gefunden")
+        parser_logger.debug("Keine Tabellen im Dokument gefunden")
     for table_idx, table in enumerate(doc.tables):
         headers_raw = [cell.text for cell in table.rows[0].cells]
         headers = [


### PR DESCRIPTION
## Summary
- add debugging message for documents without tables

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685d4b8857b0832b8b109270c178fea9