### PR TITLE
Add DOCX page count utility

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -29,6 +29,7 @@ from .models import (
 )
 from .docx_utils import (
     extract_text,
+    get_docx_page_count,
     parse_anlage2_table,
     parse_anlage2_text,
     _normalize_header_text,
@@ -180,6 +181,32 @@ class DocxExtractTests(TestCase):
         finally:
             Path(tmp.name).unlink(missing_ok=True)
         self.assertIn("Das ist ein Test", text)
+
+    def test_get_docx_page_count_single(self):
+        doc = Document()
+        doc.add_paragraph("Seite 1")
+        tmp = NamedTemporaryFile(delete=False, suffix=".docx")
+        doc.save(tmp.name)
+        tmp.close()
+        try:
+            count = get_docx_page_count(Path(tmp.name))
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+        self.assertEqual(count, 1)
+
+    def test_get_docx_page_count_two_pages(self):
+        doc = Document()
+        doc.add_paragraph("Seite 1")
+        doc.add_page_break()
+        doc.add_paragraph("Seite 2")
+        tmp = NamedTemporaryFile(delete=False, suffix=".docx")
+        doc.save(tmp.name)
+        tmp.close()
+        try:
+            count = get_docx_page_count(Path(tmp.name))
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+        self.assertEqual(count, 2)
 
     def test_normalize_header_text_variants(self):
         cases = {


### PR DESCRIPTION
## Summary
- implement page count extraction via python-docx
- add tests for page counting

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685d6531f46c832b86b0a90b77531d0b