### PR TITLE
Add log start message for text parser

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -333,6 +333,7 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
 
     logger = logging.getLogger(__name__)
     parser_logger = logging.getLogger("parser_debug")
+    parser_logger.info("parse_anlage2_text gestartet")
     if not text_content:
         return []
 


### PR DESCRIPTION
## Summary
- log when `parse_anlage2_text` starts so parser-debug.log shows the fallback parser usage

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685d9a61db98832b901224271db4f4dc