### PR TITLE
Redirect Anlage 3 check to review page

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1876,7 +1876,7 @@ class ProjektFileCheckResultTests(TestCase):
         with patch("core.views.analyse_anlage3") as mock_func:
             mock_func.return_value = {"task": "analyse_anlage3"}
             resp = self.client.get(url)
-        self.assertRedirects(resp, reverse("projekt_file_edit_json", args=[pf.pk]))
+        self.assertRedirects(resp, reverse("anlage3_review", args=[self.projekt.pk]))
         mock_func.assert_called_with(self.projekt.pk, model_name=None)
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -2215,6 +2215,10 @@ def projekt_file_check_view(request, pk):
     except Exception:
         logger.exception("LLM Fehler")
         messages.error(request, "Fehler bei der Anlagenpr\xfcfung")
+
+    if anlage.anlage_nr == 3:
+        return redirect("anlage3_review", pk=anlage.projekt_id)
+
     return redirect("projekt_file_edit_json", pk=pk)
 
 

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load recording_extras %}
 {% block title %}Anlage 3 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 3 Dateien für {{ projekt.title }} prüfen</h1>


### PR DESCRIPTION
## Summary
- after checking Anlage 3 redirect users to the manual review page
- ensure the review template loads custom filters
- adapt tests for the new redirect target

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_685db194b138832bbfb7ce71833a4cd0