### PR TITLE
Log text content before fallback parsing

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -257,6 +257,10 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
     if analysis_result:
         logger.info("Tabellen-Parser verwendet")
     else:
+        parser_logger.debug(
+            "Textinhalt vor Text-Parser:\n%s",
+            project_file.text_content,
+        )
         analysis_result = parse_anlage2_text(project_file.text_content)
         logger.info("Text-Parser als Fallback verwendet")
 


### PR DESCRIPTION
## Summary
- log text content into `parser-debug.log` before calling the fallback text parser

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685db9daac5c832ba00d8417bce07697