### PR TITLE
Implement fallback aliases for Anlage2 parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Modelle übersichtlich auf und bietet eine Suchleiste. Die neue Datei
 ### Funktionskatalog verwalten
 
 Administratorinnen und Administratoren erreichen die Übersicht aller Anlage‑2-Funktionen unter `/projects-admin/anlage2/`. Dort lassen sich neue Einträge anlegen, vorhandene Funktionen bearbeiten und auch wieder löschen. Über den Button **Importieren** kann eine JSON-Datei hochgeladen werden, die den Funktionskatalog enthält. Ist `/projects-admin/anlage2/import/` aufrufbar, bietet das Formular zudem die Option, die Datenbank vor dem Import zu leeren. Mit **Exportieren** wird der aktuelle Katalog als JSON unter `/projects-admin/anlage2/export/` heruntergeladen. Der Zugriff auf alle genannten URLs erfordert Mitgliedschaft in der Gruppe `admin`.
+Fehlt bei einer Funktion oder Unterfrage das Feld `name_aliases`, verwendet der Textparser automatisch den Funktionsnamen bzw. den Fragetext als Alias.
 
 ### Anlage‑2‑Konfiguration importieren/exportieren
 

--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -350,6 +350,8 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
     functions: list[tuple[Anlage2Function, list[str]]] = []
     for func in Anlage2Function.objects.all():
         aliases = [a.lower() for a in _get_list(func.detection_phrases, "name_aliases")]
+        if not aliases:
+            aliases = [func.name.lower()]
         parser_logger.debug("Funktion '%s' Aliase: %s", func.name, aliases)
         functions.append((func, aliases))
 
@@ -357,6 +359,8 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
     sub_map: dict[int, list[tuple[Anlage2SubQuestion, list[str]]]] = {}
     for sub in Anlage2SubQuestion.objects.select_related("funktion"):
         aliases = [a.lower() for a in _get_list(sub.detection_phrases, "name_aliases")]
+        if not aliases:
+            aliases = [sub.frage_text.lower()]
         parser_logger.debug(
             "Unterfrage '%s' (%s) Aliase: %s",
             sub.frage_text,

--- a/core/tests.py
+++ b/core/tests.py
@@ -524,7 +524,40 @@ class DocxExtractTests(TestCase):
         Anlage2GlobalPhrase.objects.create(
             config=cfg, phrase_type="ki_beteiligung_false", phrase_text="ki nein"
         )
-        text = "Login tv ja ki nein\nWarum tv nein"
+        text = "Login tv ja ki nein\nWarum? tv nein"
+        data = parse_anlage2_text(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Login",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                    "ki_beteiligung": {"value": False, "note": None},
+                },
+                {
+                    "funktion": "Login: Warum?",
+                    "technisch_verfuegbar": {"value": False, "note": None},
+                },
+            ],
+        )
+
+    def test_parse_anlage2_text_default_aliases(self):
+        func = Anlage2Function.objects.create(name="Login")
+        Anlage2SubQuestion.objects.create(
+            funktion=func,
+            frage_text="Warum?",
+        )
+        cfg = Anlage2Config.get_instance()
+        Anlage2GlobalPhrase.objects.create(
+            config=cfg, phrase_type="technisch_verfuegbar_true", phrase_text="tv ja"
+        )
+        Anlage2GlobalPhrase.objects.create(
+            config=cfg, phrase_type="technisch_verfuegbar_false", phrase_text="tv nein"
+        )
+        Anlage2GlobalPhrase.objects.create(
+            config=cfg, phrase_type="ki_beteiligung_false", phrase_text="ki nein"
+        )
+        text = "Login tv ja ki nein\nWarum? tv nein"
         data = parse_anlage2_text(text)
         self.assertEqual(
             data,


### PR DESCRIPTION
## Summary
- support default alias fallbacks in `parse_anlage2_text`
- test text parser with default aliases
- document alias fallback in README

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685e40dd64b0832ba17d4e89f015cf35