### PR TITLE
Ensure aliases always include name

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Modelle übersichtlich auf und bietet eine Suchleiste. Die neue Datei
 ### Funktionskatalog verwalten
 
 Administratorinnen und Administratoren erreichen die Übersicht aller Anlage‑2-Funktionen unter `/projects-admin/anlage2/`. Dort lassen sich neue Einträge anlegen, vorhandene Funktionen bearbeiten und auch wieder löschen. Über den Button **Importieren** kann eine JSON-Datei hochgeladen werden, die den Funktionskatalog enthält. Ist `/projects-admin/anlage2/import/` aufrufbar, bietet das Formular zudem die Option, die Datenbank vor dem Import zu leeren. Mit **Exportieren** wird der aktuelle Katalog als JSON unter `/projects-admin/anlage2/export/` heruntergeladen. Der Zugriff auf alle genannten URLs erfordert Mitgliedschaft in der Gruppe `admin`.
-Fehlt bei einer Funktion oder Unterfrage das Feld `name_aliases`, verwendet der Textparser automatisch den Funktionsnamen bzw. den Fragetext als Alias.
+Der Textparser berücksichtigt stets den Funktionsnamen bzw. den Fragetext als
+Alias. Zusätzliche Varianten können über das Feld `name_aliases` hinterlegt
+werden. Doppelte Einträge werden automatisch ignoriert.
 
 ### Anlage‑2‑Konfiguration importieren/exportieren
 

--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -349,18 +349,18 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
     # Alle Funktionen mit ihren Aliases vorbereiten
     functions: list[tuple[Anlage2Function, list[str]]] = []
     for func in Anlage2Function.objects.all():
-        aliases = [a.lower() for a in _get_list(func.detection_phrases, "name_aliases")]
-        if not aliases:
-            aliases = [func.name.lower()]
+        alias_list = [func.name.lower()]
+        alias_list += [a.lower() for a in _get_list(func.detection_phrases, "name_aliases")]
+        aliases = list(dict.fromkeys(alias_list))
         parser_logger.debug("Funktion '%s' Aliase: %s", func.name, aliases)
         functions.append((func, aliases))
 
     # Unterfragen pro Funktion sammeln
     sub_map: dict[int, list[tuple[Anlage2SubQuestion, list[str]]]] = {}
     for sub in Anlage2SubQuestion.objects.select_related("funktion"):
-        aliases = [a.lower() for a in _get_list(sub.detection_phrases, "name_aliases")]
-        if not aliases:
-            aliases = [sub.frage_text.lower()]
+        alias_list = [sub.frage_text.lower()]
+        alias_list += [a.lower() for a in _get_list(sub.detection_phrases, "name_aliases")]
+        aliases = list(dict.fromkeys(alias_list))
         parser_logger.debug(
             "Unterfrage '%s' (%s) Aliase: %s",
             sub.frage_text,

--- a/core/tests.py
+++ b/core/tests.py
@@ -574,6 +574,41 @@ class DocxExtractTests(TestCase):
             ],
         )
 
+    def test_parse_anlage2_text_name_always_alias(self):
+        func = Anlage2Function.objects.create(
+            name="Anmelden",
+            detection_phrases={"name_aliases": ["login"]},
+        )
+        Anlage2SubQuestion.objects.create(
+            funktion=func,
+            frage_text="Grund?",
+            detection_phrases={"name_aliases": ["reason"]},
+        )
+        cfg = Anlage2Config.get_instance()
+        Anlage2GlobalPhrase.objects.create(
+            config=cfg, phrase_type="technisch_verfuegbar_true", phrase_text="tv ja"
+        )
+        Anlage2GlobalPhrase.objects.create(
+            config=cfg,
+            phrase_type="technisch_verfuegbar_false",
+            phrase_text="tv nein",
+        )
+        text = "Anmelden tv ja\nGrund? tv nein"
+        data = parse_anlage2_text(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Anmelden",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                },
+                {
+                    "funktion": "Anmelden: Grund?",
+                    "technisch_verfuegbar": {"value": False, "note": None},
+                },
+            ],
+        )
+
     def test_extract_images(self):
         img = Image.new("RGB", (1, 1), color="blue")
         img_tmp = NamedTemporaryFile(delete=False, suffix=".png")


### PR DESCRIPTION
## Summary
- ensure parse_anlage2_text always adds the function/sub-question name to the alias list
- deduplicate aliases
- clarify behaviour in docs
- test that detection works even if name_aliases omit the original text

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685e5059a7fc832ba4f2249a7d15a9ab