### PR TITLE
feat: normalize text snippets for parser

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -609,6 +609,24 @@ class DocxExtractTests(TestCase):
             ],
         )
 
+    def test_parse_anlage2_text_normalizes_variants(self):
+        func = Anlage2Function.objects.create(name="User Login")
+        cfg = Anlage2Config.get_instance()
+        Anlage2GlobalPhrase.objects.create(
+            config=cfg, phrase_type="technisch_verfuegbar_true", phrase_text="tv ja"
+        )
+        text = "User-Login   tv ja"
+        data = parse_anlage2_text(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "User Login",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                }
+            ],
+        )
+
     def test_extract_images(self):
         img = Image.new("RGB", (1, 1), color="blue")
         img_tmp = NamedTemporaryFile(delete=False, suffix=".png")


### PR DESCRIPTION
## Summary
- add `_normalize_snippet` helper for text cleanup
- normalize aliases and lines in `parse_anlage2_text`
- test alias matching with whitespace variants

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685e64e96fd4832ba1eb7ed0b8cf22fb