### PR TITLE
Improve text normalization for feature detection

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from docx import Document
 import logging
 import re
+import string
 import zipfile
 
 from .models import (
@@ -146,9 +147,15 @@ def _normalize_function_name(name: str) -> str:
 
 def _normalize_snippet(text: str) -> str:
     """Normalisiert Textschnipsel für Alias-Vergleiche."""
-    text = text.replace("\n", " ").replace("\t", " ").replace("\u00b6", " ")
+    text = (
+        text.replace("\n", " ")
+        .replace("\t", " ")
+        .replace("\u00b6", " ")
+        .replace("\xa0", " ")
+    )
     text = text.lower()
     text = re.sub(r"[\-_/]+", " ", text)
+    text = text.translate(str.maketrans("", "", string.punctuation))
     text = re.sub(r"\s+", " ", text)
     return text.strip()
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -627,6 +627,27 @@ class DocxExtractTests(TestCase):
             ],
         )
 
+    def test_parse_anlage2_text_punctuation_variants(self):
+        func = Anlage2Function.objects.create(
+            name="Analyse-/Reportingfunktionen",
+            detection_phrases={"name_aliases": ["Analyse-/Reportingfunktionen"]},
+        )
+        cfg = Anlage2Config.get_instance()
+        Anlage2GlobalPhrase.objects.create(
+            config=cfg, phrase_type="technisch_verfuegbar_true", phrase_text="tv ja"
+        )
+        text = "Analyse- / Reportingfunktionen tv ja"
+        data = parse_anlage2_text(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Analyse-/Reportingfunktionen",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                }
+            ],
+        )
+
     def test_extract_images(self):
         img = Image.new("RGB", (1, 1), color="blue")
         img_tmp = NamedTemporaryFile(delete=False, suffix=".png")


### PR DESCRIPTION
## Summary
- erweitere Text-Normalisierung um Zeichensetzung und geschützte Leerzeichen
- füge Test zur Erkennung von Varianten mit Leerzeichen und Sonderzeichen hinzu

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685e6c82b990832b807b278f6fe64c4b