### PR TITLE
feat: erweitere debug ausgabe im match

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -422,6 +422,13 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
                         ph,
                         line,
                     )
+            parser_logger.debug(
+                "Finaler Vergleich: %r (%s) in %r (%s)",
+                ph,
+                type(ph).__name__,
+                line,
+                type(line).__name__,
+            )
             if ph in line:
                 parser_logger.debug("-> Treffer")
                 return True


### PR DESCRIPTION
## Summary
- log the final comparison strings and their types in `_match`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685e86be1f74832b9e18c620b948329d