### PR TITLE
Fix fallback for Anlage 2 parsing

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -288,6 +288,8 @@ def analyse_anlage2(projekt_id: int, model_name: str | None = None) -> dict:
         raise ValueError("Anlage 2 fehlt") from exc
 
     table_data = parse_anlage2_table(Path(anlage2.upload.path))
+    if not table_data:
+        table_data = parse_anlage2_text(anlage2.text_content)
     table_names = [row["funktion"] for row in table_data]
     anlage_funcs = _parse_anlage2(anlage2.text_content) or []
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -1050,6 +1050,23 @@ class LLMTasksTests(TestCase):
         self.assertEqual(data["missing"]["value"], [])
         self.assertEqual(file_obj.analysis_json["additional"]["value"], [])
 
+    def test_analyse_anlage2_text_fallback(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="b")
+        BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("b.txt", b"data"),
+            text_content="dummy",
+        )
+
+        expected = [{"funktion": "Login"}]
+        with patch("core.llm_tasks.parse_anlage2_table", return_value=[]), patch(
+            "core.llm_tasks.parse_anlage2_text", return_value=expected
+        ) as mock_text:
+            data = analyse_anlage2(projekt.pk)
+        mock_text.assert_called_once()
+        self.assertEqual(data["functions"]["value"], expected)
+
     def test_analyse_anlage3_auto_ok(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         doc = Document()


### PR DESCRIPTION
## Summary
- call the text parser if no table was found
- add unit test to ensure fallback is triggered

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_685eb2081208832bba598ed8d2b3f27d