### PR TITLE
feat: add parser test button

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -2003,6 +2003,19 @@ class ProjektFileCheckResultTests(TestCase):
         self.assertRedirects(resp, reverse("anlage3_review", args=[self.projekt.pk]))
         mock_func.assert_called_with(self.projekt.pk, model_name=None)
 
+    def test_parse_view_runs_parser(self):
+        url = reverse("projekt_file_parse_anlage2", args=[self.file2.pk])
+        with patch("core.views.run_anlage2_analysis") as mock_func:
+            mock_func.return_value = []
+            resp = self.client.get(url)
+        self.assertRedirects(resp, reverse("projekt_file_edit_json", args=[self.file2.pk]))
+        mock_func.assert_called_with(self.file2)
+
+    def test_parse_view_rejects_other_files(self):
+        url = reverse("projekt_file_parse_anlage2", args=[self.file.pk])
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 404)
+
 
 class LLMConfigTests(TestCase):
     @override_settings(GOOGLE_API_KEY="x")

--- a/core/urls.py
+++ b/core/urls.py
@@ -238,6 +238,11 @@ urlpatterns = [
         name="projekt_file_check_view",
     ),
     path(
+        "work/anlage/<int:pk>/parse/",
+        views.projekt_file_parse_anlage2,
+        name="projekt_file_parse_anlage2",
+    ),
+    path(
         "work/anlage/<int:pk>/edit-json/",
         views.projekt_file_edit_json,
         name="projekt_file_edit_json",

--- a/core/views.py
+++ b/core/views.py
@@ -86,6 +86,7 @@ from .llm_tasks import (
     check_anlage5,
     check_anlage6,
     check_anlage2_functions,
+    run_anlage2_analysis,
     check_gutachten_functions,
     generate_gutachten,
     get_prompt,
@@ -2219,6 +2220,16 @@ def projekt_file_check_view(request, pk):
     if anlage.anlage_nr == 3:
         return redirect("anlage3_review", pk=anlage.projekt_id)
 
+    return redirect("projekt_file_edit_json", pk=pk)
+
+
+@login_required
+def projekt_file_parse_anlage2(request, pk):
+    """Parst Anlage 2 ohne LLM-Aufrufe."""
+    anlage = get_object_or_404(BVProjectFile, pk=pk)
+    if anlage.anlage_nr != 2:
+        raise Http404
+    run_anlage2_analysis(anlage)
     return redirect("projekt_file_edit_json", pk=pk)
 
 

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -47,6 +47,10 @@
             <td class="px-2 py-1 text-center">
                 <a href="{% url 'projekt_file_check_view' a.pk %}"
                    class="{% if a.analysis_json %}bg-green-600{% else %}bg-red-600{% endif %} text-white px-2 py-1 rounded">Prüfen</a>
+                {% if a.anlage_nr == 2 %}
+                    <a href="{% url 'projekt_file_parse_anlage2' a.pk %}"
+                       class="bg-blue-600 text-white px-2 py-1 rounded ml-2">Parser</a>
+                {% endif %}
             </td>
             <td class="px-2 py-1 text-center">
             {% if a.analysis_json %}


### PR DESCRIPTION
## Summary
- add new view `projekt_file_parse_anlage2`
- hook it up with a new URL and button to test the parser only
- import new helper function in views
- cover parser view with tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685eb85695fc832b99b9f992f84ebc0f