### PR TITLE
Add vision-based Anlage 3 check

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -206,7 +206,6 @@ class BVProjectFileJSONForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.instance and self.instance.anlage_nr == 3:
-            self.fields.pop("analysis_json", None)
             self.fields.pop("manual_analysis_json", None)
 
     class Meta:

--- a/core/templatetags/recording_extras.py
+++ b/core/templatetags/recording_extras.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-
+import json
 import markdown
 from django import template
 from django.utils.safestring import mark_safe
@@ -55,3 +55,12 @@ def markdownify(text: str) -> str:
 
     html = markdown.markdown(text, extensions=extensions)
     return mark_safe(html)
+
+
+@register.filter
+def tojson(value) -> str:
+    """Wandelt ein Python-Objekt in formatiertes JSON um."""
+    try:
+        return json.dumps(value, indent=2, ensure_ascii=False)
+    except Exception:  # pragma: no cover - ungültige Daten
+        return str(value)

--- a/core/views.py
+++ b/core/views.py
@@ -82,6 +82,7 @@ from .llm_tasks import (
     analyse_anlage2,
     analyse_anlage3,
     check_anlage2,
+    check_anlage3_vision,
     check_anlage4,
     check_anlage5,
     check_anlage6,
@@ -2127,7 +2128,7 @@ def projekt_file_check(request, pk, nr):
     funcs = {
         1: check_anlage1,
         2: check_anlage2 if use_llm else analyse_anlage2,
-        3: analyse_anlage3,
+        3: check_anlage3_vision if use_llm else analyse_anlage3,
         4: check_anlage4,
         5: check_anlage5,
         6: check_anlage6,
@@ -2164,7 +2165,7 @@ def projekt_file_check_pk(request, pk):
     funcs = {
         1: check_anlage1,
         2: check_anlage2 if use_llm else analyse_anlage2,
-        3: analyse_anlage3,
+        3: check_anlage3_vision if use_llm else analyse_anlage3,
         4: check_anlage4,
         5: check_anlage5,
         6: check_anlage6,
@@ -2198,7 +2199,7 @@ def projekt_file_check_view(request, pk):
     funcs = {
         1: check_anlage1,
         2: check_anlage2 if use_llm else analyse_anlage2,
-        3: analyse_anlage3,
+        3: check_anlage3_vision if use_llm else analyse_anlage3,
         4: check_anlage4,
         5: check_anlage5,
         6: check_anlage6,

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -7,6 +7,7 @@
     <thead>
         <tr>
             <th class="px-2 py-1">Datei</th>
+            <th class="px-2 py-1 text-center">LLM-Prüfung</th>
             <th class="px-2 py-1 text-center">Geprüft</th>
         </tr>
     </thead>
@@ -14,6 +15,12 @@
     {% for a in anlagen %}
         <tr class="border-t">
             <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name|basename }}</a></td>
+            <td class="px-2 py-1 text-center">
+                <form method="post" action="{% url 'projekt_file_check_view' a.pk %}?llm=1">
+                    {% csrf_token %}
+                    <button class="bg-purple-600 text-white px-2 py-1 rounded">LLM-Prüfung</button>
+                </form>
+            </td>
             <td class="px-2 py-1 text-center">
                 <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
                     {% csrf_token %}
@@ -24,8 +31,21 @@
                 </form>
             </td>
         </tr>
+        {% if a.analysis_json %}
+        <tr class="border-b">
+            <td colspan="3">
+                <div class="prose max-w-none bg-gray-100 p-2 rounded">
+                    {{ a.analysis_json|tojson|markdownify }}
+                </div>
+                <div class="mt-1 space-x-2">
+                    <a href="{% url 'projekt_file_edit_json' a.pk %}" class="btn-action">Bearbeiten</a>
+                    <a href="{{ a.upload.url }}" class="text-blue-700 underline">Download</a>
+                </div>
+            </td>
+        </tr>
+        {% endif %}
     {% empty %}
-        <tr><td colspan="2">Keine Anlagen vorhanden</td></tr>
+        <tr><td colspan="3">Keine Anlagen vorhanden</td></tr>
     {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- implement `check_anlage3_vision` to process Anlage 3 files with images or PDF bytes
- integrate new task into views
- keep analysis JSON editable for Anlage 3
- add `tojson` template filter and update review template
- extend tests for vision check and form behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685ef3f6a250832b931ccf8f87e55e23