### PR TITLE
Update Anlage 3 vision prompt

### DIFF
--- a/core/migrations/0074_update_check_anlage3_vision_prompt.py
+++ b/core/migrations/0074_update_check_anlage3_vision_prompt.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+
+PROMPT_NAME = "check_anlage3_vision"
+OLD_TEXT = (
+    "Pr\u00fcfe die folgende Anlage auf Basis der Bilder. "
+    "Gib ein JSON mit 'ok' und 'hinweis' zur\u00fcck:\n\n"
+)
+NEW_TEXT = (
+    "Pr\u00fcfe die folgenden Bilder der Anlage. "
+    "Gib ein JSON mit 'ok' und 'hinweis' zur\u00fcck:\n\n"
+)
+
+def forwards_func(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    Prompt.objects.update_or_create(
+        name=PROMPT_NAME,
+        defaults={"text": NEW_TEXT},
+    )
+
+
+def reverse_func(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    Prompt.objects.update_or_create(
+        name=PROMPT_NAME,
+        defaults={"text": OLD_TEXT},
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0073_add_vision_model_and_prompt"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]

--- a/core/tests.py
+++ b/core/tests.py
@@ -1433,7 +1433,7 @@ class PromptTests(TestCase):
     def test_check_anlage3_vision_prompt_text(self):
         p = Prompt.objects.get(name="check_anlage3_vision")
         expected = (
-            "Pr\u00fcfe die folgende Anlage auf Basis der Bilder. "
+            "Pr\u00fcfe die folgenden Bilder der Anlage. "
             "Gib ein JSON mit 'ok' und 'hinweis' zur\u00fcck:\n\n"
         )
         self.assertEqual(p.text, expected)


### PR DESCRIPTION
## Summary
- add migration to alter the `check_anlage3_vision` prompt text
- adjust regression test for updated default

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685ef41bd6b8832b920e96560a975e4f