### PR TITLE
Merge duplicate functions in text parser

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -661,6 +661,25 @@ class DocxExtractTests(TestCase):
             ],
         )
 
+    def test_parse_anlage2_text_merges_duplicate_functions(self):
+        func = Anlage2Function.objects.create(name="Login")
+        cfg = Anlage2Config.get_instance()
+        cfg.text_technisch_verfuegbar_true = ["tv ja"]
+        cfg.text_ki_beteiligung_false = ["ki nein"]
+        cfg.save()
+        text = "Login tv ja\nLogin ki nein"
+        data = parse_anlage2_text(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Login",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                    "ki_beteiligung": {"value": False, "note": None},
+                }
+            ],
+        )
+
     def test_extract_images(self):
         img = Image.new("RGB", (1, 1), color="blue")
         img_tmp = NamedTemporaryFile(delete=False, suffix=".png")


### PR DESCRIPTION
## Summary
- merge results for recurring main functions in `parse_anlage2_text`
- clarify docstring on merging behaviour
- test merging of duplicate function entries

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685f17b3a1c8832b9c21d2685e89f372