### PR TITLE
Add text phrase export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,16 @@ werden. Doppelte Einträge werden automatisch ignoriert.
 ### Anlage‑2‑Konfiguration importieren/exportieren
 
 Unter `/projects-admin/anlage2/config/` lässt sich zusätzlich die gesamte
-Konfiguration sichern. Die exportierte JSON-Datei enthält zwei Listen:
+Konfiguration sichern. Die exportierte JSON-Datei enthält zwei Listen und ein zusätzliches Objekt:
 
 ```json
 {
   "column_headings": [{"field_name": "technisch_vorhanden", "text": "Verfügbar?"}],
-  "global_phrases": [{"phrase_type": "technisch_verfuegbar_true", "phrase_text": "ja"}]
+  "global_phrases": [{"phrase_type": "technisch_verfuegbar_true", "phrase_text": "ja"}],
+  "text_phrases": {
+    "text_technisch_verfuegbar_true": ["tv ja"],
+    "text_technisch_verfuegbar_false": []
+  }
 }
 ```
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -3179,6 +3179,8 @@ class Anlage2ConfigImportExportTests(TestCase):
             phrase_type="technisch_verfuegbar_true",
             phrase_text="ja",
         )
+        self.cfg.text_technisch_verfuegbar_true = ["tv ja"]
+        self.cfg.save()
         url = reverse("admin_anlage2_config_export")
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
@@ -3194,6 +3196,10 @@ class Anlage2ConfigImportExportTests(TestCase):
             },
             data["global_phrases"],
         )
+        self.assertEqual(
+            data["text_phrases"]["text_technisch_verfuegbar_true"],
+            ["tv ja"],
+        )
 
     def test_import_creates_headings(self):
         payload = json.dumps(
@@ -3207,6 +3213,9 @@ class Anlage2ConfigImportExportTests(TestCase):
                         "phrase_text": "Ja",
                     }
                 ],
+                "text_phrases": {
+                    "text_technisch_verfuegbar_false": ["nein"]
+                },
             }
         )
         file = SimpleUploadedFile("cfg.json", payload.encode("utf-8"))
@@ -3218,6 +3227,8 @@ class Anlage2ConfigImportExportTests(TestCase):
                 field_name="ki_beteiligung", text="KI?"
             ).exists()
         )
+        self.cfg.refresh_from_db()
+        self.assertEqual(self.cfg.text_technisch_verfuegbar_false, ["nein"])
 
 
 

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -6,6 +6,11 @@
     <a href="{% url 'admin_anlage2_config_export' %}" class="px-4 py-2 bg-gray-300 rounded">Exportieren</a>
     <a href="{% url 'admin_anlage2_config_import' %}" class="px-4 py-2 bg-gray-300 rounded">Importieren</a>
 </div>
+<p class="text-sm mb-4">
+    Die exportierte JSON-Datei enthält neben <code>alias_headings</code>
+    und <code>global_phrases</code> jetzt auch ein Objekt
+    <code>text_phrases</code>.
+</p>
 <form method="post" class="space-y-4">
     {% csrf_token %}
 


### PR DESCRIPTION
## Summary
- include all text fields in Anlage2 config export
- import new text phrase structure and store in config
- update admin configuration page with hint about new JSON key
- document updated export structure in README
- extend tests for new field export and import

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685fb4bc04b8832b82d24dc342494c13