### PR TITLE
Add text phrase import/export tests

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -3219,6 +3219,38 @@ class Anlage2ConfigImportExportTests(TestCase):
             ).exists()
         )
 
+    def test_export_includes_text_phrases(self):
+        self.cfg.text_technisch_verfuegbar_true = ["ja"]
+        self.cfg.text_ki_beteiligung_false = ["nein"]
+        self.cfg.save()
+        url = reverse("admin_anlage2_config_export")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertEqual(
+            data["text_phrases"]["technisch_verfuegbar_true"], ["ja"]
+        )
+        self.assertEqual(
+            data["text_phrases"]["ki_beteiligung_false"], ["nein"]
+        )
+
+    def test_import_text_phrases(self):
+        payload = json.dumps(
+            {
+                "text_phrases": {
+                    "technisch_verfuegbar_true": ["ja"],
+                    "ki_beteiligung_false": ["nein"],
+                }
+            }
+        )
+        file = SimpleUploadedFile("cfg.json", payload.encode("utf-8"))
+        url = reverse("admin_anlage2_config_import")
+        resp = self.client.post(url, {"json_file": file}, format="multipart")
+        self.assertRedirects(resp, reverse("anlage2_config"))
+        self.cfg.refresh_from_db()
+        self.assertEqual(self.cfg.text_technisch_verfuegbar_true, ["ja"])
+        self.assertEqual(self.cfg.text_ki_beteiligung_false, ["nein"])
+
 
 
 


### PR DESCRIPTION
## Summary
- include text phrase lists in Anlage2Config export
- allow text phrase lists to be imported
- test new functionality in admin export and import

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_685fb4c14238832b8ebfab3dab29362f