### PR TITLE
fix: improve text parser for follow-up status lines

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -574,7 +574,16 @@ def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
                 break
 
         if not found:
-            parser_logger.debug("Keine Funktion erkannt für Zeile: %s", line)
+            extra_values = _extract_values(norm_line, line)
+            if extra_values and last_main is not None:
+                parser_logger.debug(
+                    "Ergänze letzte Funktion %s um Werte %s",
+                    last_main.get("funktion"),
+                    extra_values,
+                )
+                last_main.update(extra_values)
+            else:
+                parser_logger.debug("Keine Funktion erkannt für Zeile: %s", line)
 
     logger.debug("parse_anlage2_text Ergebnisse: %s", results)
     parser_logger.info("parse_anlage2_text beendet")

--- a/core/tests.py
+++ b/core/tests.py
@@ -680,6 +680,25 @@ class DocxExtractTests(TestCase):
             ],
         )
 
+    def test_parse_anlage2_text_updates_values_without_function(self):
+        func = Anlage2Function.objects.create(name="Analyse")
+        cfg = Anlage2Config.get_instance()
+        cfg.text_technisch_verfuegbar_true = ["verfuegbar"]
+        cfg.text_zur_lv_kontrolle_false = ["kein lv"]
+        cfg.save()
+        text = "Analyse verfuegbar\nkein lv"
+        data = parse_anlage2_text(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Analyse",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                    "zur_lv_kontrolle": {"value": False, "note": None},
+                }
+            ],
+        )
+
     def test_extract_images(self):
         img = Image.new("RGB", (1, 1), color="blue")
         img_tmp = NamedTemporaryFile(delete=False, suffix=".png")


### PR DESCRIPTION
## Summary
- extend `parse_anlage2_text` so subsequent lines with only status phrases
  update the previously recognised function
- add regression test covering this behaviour

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_685fc01533c4832bb4c0ba1c8fe81b7c