### PR TITLE
Update parser headings in admin config

### DIFF
--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -54,7 +54,7 @@
         </div>
     </div>
 
-    <h2 class="text-xl font-semibold mt-6 mb-2">Aliasüberschriften</h2>
+    <h2 class="text-xl font-semibold mt-6 mb-2">Tabellen-Parser: Spaltenüberschriften (Alias)</h2>
     <table class="min-w-full mb-4">
         <thead>
             <tr class="border-b text-left">
@@ -85,7 +85,7 @@
         </tbody>
     </table>
 
-    <h2 class="text-xl font-semibold mt-6 mb-2">Globale Phrasen</h2>
+    <h2 class="text-xl font-semibold mt-6 mb-2">Text-Parser: Erkennungsphrasen</h2>
     {% for key, label, formset in phrase_sets %}
     <div class="mb-4">
         <h3 class="font-semibold mb-2">{{ label }}</h3>


### PR DESCRIPTION
## Summary
- rename heading "Aliasüberschriften" to "Tabellen-Parser: Spaltenüberschriften (Alias)"
- rename heading "Globale Phrasen" to "Text-Parser: Erkennungsphrasen"

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_685fd70bdebc832b83efac98fc67daab