### PR TITLE
Add partial save for Text-Parser config

### DIFF
--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -107,7 +107,8 @@
         <button type="button" class="add-form bg-gray-300 px-2 py-1 rounded" data-prefix="{{ key }}">+ Weitere Phrase hinzufügen</button>
     </div>
     {% endfor %}
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    <button type="submit" name="action" value="save_phrases" class="px-4 py-2 bg-blue-600 text-white rounded">Phrasen speichern</button>
+    <button type="submit" name="action" value="save_all" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
 </form>
 <script>
 function addForm(prefix){


### PR DESCRIPTION
## Summary
- add separate save button for text-parser phrases
- process form sections conditionally in `anlage2_config`

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685fd91286e8832b991964be0f1c1b0d