### PR TITLE
Add editable detection phrases

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -358,9 +358,15 @@ class Anlage2ReviewForm(forms.Form):
 class Anlage2FunctionForm(forms.ModelForm):
     """Formular für eine Funktion aus Anlage 2."""
 
+    detection_phrases = forms.JSONField(
+        required=False,
+        widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 5}),
+        label="Detection Phrases (JSON)",
+    )
+
     class Meta:
         model = Anlage2Function
-        fields = ["name"]
+        fields = ["name", "detection_phrases"]
         widgets = {
             "name": forms.TextInput(attrs={"class": "border rounded p-2"}),
         }
@@ -369,9 +375,15 @@ class Anlage2FunctionForm(forms.ModelForm):
 class Anlage2SubQuestionForm(forms.ModelForm):
     """Formular für eine Unterfrage zu Anlage 2."""
 
+    detection_phrases = forms.JSONField(
+        required=False,
+        widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 5}),
+        label="Detection Phrases (JSON)",
+    )
+
     class Meta:
         model = Anlage2SubQuestion
-        fields = ["frage_text"]
+        fields = ["frage_text", "detection_phrases"]
         labels = {"frage_text": "Frage"}
         widgets = {
             "frage_text": Textarea(attrs={"class": "border rounded p-2", "rows": 3}),

--- a/core/views.py
+++ b/core/views.py
@@ -1800,12 +1800,14 @@ def anlage2_function_form(request, pk=None):
         formset = PhraseFormSet(request.POST, prefix="name_aliases")
         if form.is_valid() and formset.is_valid():
             funktion = form.save(commit=False)
+            detection_phrases = form.cleaned_data.get("detection_phrases") or {}
             phrases = [
                 row.get("phrase", "").strip()
                 for row in formset.cleaned_data
                 if row.get("phrase") and not row.get("DELETE")
             ]
-            funktion.detection_phrases = {"name_aliases": phrases}
+            detection_phrases["name_aliases"] = phrases
+            funktion.detection_phrases = detection_phrases
             funktion.save()
             return redirect("anlage2_function_edit", funktion.pk)
     else:
@@ -1917,12 +1919,14 @@ def anlage2_subquestion_form(request, function_pk=None, pk=None):
         formset = PhraseFormSet(request.POST, prefix="name_aliases")
         if form.is_valid() and formset.is_valid():
             subquestion = form.save(commit=False)
+            detection_phrases = form.cleaned_data.get("detection_phrases") or {}
             phrases = [
                 row.get("phrase", "").strip()
                 for row in formset.cleaned_data
                 if row.get("phrase") and not row.get("DELETE")
             ]
-            subquestion.detection_phrases = {"name_aliases": phrases}
+            detection_phrases["name_aliases"] = phrases
+            subquestion.detection_phrases = detection_phrases
             subquestion.save()
             return redirect("anlage2_function_edit", funktion.pk)
     else:

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -11,6 +11,11 @@
         {{ form.name.errors }}
     </div>
     <div>
+        {{ form.detection_phrases.label_tag }}<br>
+        {{ form.detection_phrases }}
+        {{ form.detection_phrases.errors }}
+    </div>
+    <div>
         <h3 class="font-semibold mt-4 mb-2">Name Aliase</h3>
         <div id="name_aliases-container">
             {{ formset.management_form }}

--- a/templates/anlage2/subquestion_form.html
+++ b/templates/anlage2/subquestion_form.html
@@ -11,6 +11,11 @@
         {{ form.frage_text.errors }}
     </div>
     <div>
+        {{ form.detection_phrases.label_tag }}<br>
+        {{ form.detection_phrases }}
+        {{ form.detection_phrases.errors }}
+    </div>
+    <div>
         <h3 class="font-semibold mt-4 mb-2">Erkennungsphrasen</h3>
         <div id="name_aliases-container">
             {{ formset.management_form }}


### PR DESCRIPTION
## Summary
- extend `Anlage2FunctionForm` and `Anlage2SubQuestionForm` with `detection_phrases`
- show `detection_phrases` field in forms for functions and subquestions
- read and merge JSON from the form when saving functions and subquestions

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6860079cb254832b94d1cf831f2bc0f3