### PR TITLE
Show form errors in Anlage2 configuration

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -3313,6 +3313,25 @@ class Anlage2ConfigViewTests(TestCase):
             Anlage2ColumnHeading.objects.filter(text="Verfügbar?").exists()
         )
 
+    def test_invalid_json_shows_error(self):
+        url = reverse("anlage2_config")
+        data = {
+            "text_technisch_verfuegbar_true": "[",
+            "action": "save_text",
+            "active_tab": "text",
+        }
+        for key, _ in Anlage2GlobalPhrase.PHRASE_TYPE_CHOICES:
+            data[f"{key}-TOTAL_FORMS"] = "1"
+            data[f"{key}-INITIAL_FORMS"] = "0"
+            data[f"{key}-MIN_NUM_FORMS"] = "0"
+            data[f"{key}-MAX_NUM_FORMS"] = "1000"
+            data[f"{key}-0-id"] = ""
+            data[f"{key}-0-phrase_text"] = ""
+            data[f"{key}-0-DELETE"] = ""
+        resp = self.client.post(url, data)
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "gültiges JSON")
+
 
 
 

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -8,6 +8,7 @@
 </div>
 <form method="post" class="space-y-4">
     {% csrf_token %}
+    {{ config_form.non_field_errors }}
     <input type="hidden" name="active_tab" id="active_tab" value="{{ active_tab }}">
     <nav class="space-x-2 mb-4">
         <button type="button" data-tab="table" class="tab-btn px-3 py-1 bg-gray-200 rounded">Tabellen-Parser</button>
@@ -52,34 +53,42 @@
             <div>
                 <label class="block">{{ config_form.text_technisch_verfuegbar_true.label }}</label>
                 {{ config_form.text_technisch_verfuegbar_true }}
+                {{ config_form.text_technisch_verfuegbar_true.errors }}
             </div>
             <div>
                 <label class="block">{{ config_form.text_technisch_verfuegbar_false.label }}</label>
                 {{ config_form.text_technisch_verfuegbar_false }}
+                {{ config_form.text_technisch_verfuegbar_false.errors }}
             </div>
             <div>
                 <label class="block">{{ config_form.text_einsatz_telefonica_true.label }}</label>
                 {{ config_form.text_einsatz_telefonica_true }}
+                {{ config_form.text_einsatz_telefonica_true.errors }}
             </div>
             <div>
                 <label class="block">{{ config_form.text_einsatz_telefonica_false.label }}</label>
                 {{ config_form.text_einsatz_telefonica_false }}
+                {{ config_form.text_einsatz_telefonica_false.errors }}
             </div>
             <div>
                 <label class="block">{{ config_form.text_zur_lv_kontrolle_true.label }}</label>
                 {{ config_form.text_zur_lv_kontrolle_true }}
+                {{ config_form.text_zur_lv_kontrolle_true.errors }}
             </div>
             <div>
                 <label class="block">{{ config_form.text_zur_lv_kontrolle_false.label }}</label>
                 {{ config_form.text_zur_lv_kontrolle_false }}
+                {{ config_form.text_zur_lv_kontrolle_false.errors }}
             </div>
             <div>
                 <label class="block">{{ config_form.text_ki_beteiligung_true.label }}</label>
                 {{ config_form.text_ki_beteiligung_true }}
+                {{ config_form.text_ki_beteiligung_true.errors }}
             </div>
             <div>
                 <label class="block">{{ config_form.text_ki_beteiligung_false.label }}</label>
                 {{ config_form.text_ki_beteiligung_false }}
+                {{ config_form.text_ki_beteiligung_false.errors }}
             </div>
         </div>
         <h2 class="text-xl font-semibold mt-6 mb-2">Text-Parser: Erkennungsphrasen</h2>
@@ -93,6 +102,8 @@
                     {{ form.phrase_text }}
                     <label class="ml-2 text-sm">{{ form.DELETE }} löschen</label>
                 </div>
+                {{ form.phrase_text.errors }}
+                {{ form.non_field_errors }}
                 {% endfor %}
             </div>
             <div id="{{ key }}-empty-form" style="display:none;">
@@ -115,10 +126,12 @@
             <p class="text-sm text-gray-600">
                 {{ config_form.enforce_subquestion_override.help_text }}
             </p>
+            {{ config_form.enforce_subquestion_override.errors }}
         </div>
         <div>
             <label class="block">{{ config_form.parser_mode.label }}</label>
             {{ config_form.parser_mode }}
+            {{ config_form.parser_mode.errors }}
         </div>
         <button type="submit" name="action" value="save_general" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
     </div>


### PR DESCRIPTION
## Summary
- show non-field errors and field errors in `admin_anlage2_config.html`
- display errors for phrase formsets
- add regression test for invalid JSON display

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68603c253f68832b88d97045fdb37ef2