### PR TITLE
Manage detection phrases via formset

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -358,15 +358,9 @@ class Anlage2ReviewForm(forms.Form):
 class Anlage2FunctionForm(forms.ModelForm):
     """Formular für eine Funktion aus Anlage 2."""
 
-    detection_phrases = forms.JSONField(
-        required=False,
-        widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 5}),
-        label="Detection Phrases (JSON)",
-    )
-
     class Meta:
         model = Anlage2Function
-        fields = ["name", "detection_phrases"]
+        fields = ["name"]
         widgets = {
             "name": forms.TextInput(attrs={"class": "border rounded p-2"}),
         }
@@ -375,15 +369,9 @@ class Anlage2FunctionForm(forms.ModelForm):
 class Anlage2SubQuestionForm(forms.ModelForm):
     """Formular für eine Unterfrage zu Anlage 2."""
 
-    detection_phrases = forms.JSONField(
-        required=False,
-        widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 5}),
-        label="Detection Phrases (JSON)",
-    )
-
     class Meta:
         model = Anlage2SubQuestion
-        fields = ["frage_text", "detection_phrases"]
+        fields = ["frage_text"]
         labels = {"frage_text": "Frage"}
         widgets = {
             "frage_text": Textarea(attrs={"class": "border rounded p-2", "rows": 3}),

--- a/core/views.py
+++ b/core/views.py
@@ -1811,7 +1811,7 @@ def anlage2_function_form(request, pk=None):
         formset = PhraseFormSet(request.POST, prefix="name_aliases")
         if form.is_valid() and formset.is_valid():
             funktion = form.save(commit=False)
-            detection_phrases = form.cleaned_data.get("detection_phrases") or {}
+            detection_phrases = copy.deepcopy(funktion.detection_phrases) if funktion else {}
             phrases = [
                 row.get("phrase", "").strip()
                 for row in formset.cleaned_data
@@ -1930,7 +1930,7 @@ def anlage2_subquestion_form(request, function_pk=None, pk=None):
         formset = PhraseFormSet(request.POST, prefix="name_aliases")
         if form.is_valid() and formset.is_valid():
             subquestion = form.save(commit=False)
-            detection_phrases = form.cleaned_data.get("detection_phrases") or {}
+            detection_phrases = copy.deepcopy(subquestion.detection_phrases) if subquestion.pk else {}
             phrases = [
                 row.get("phrase", "").strip()
                 for row in formset.cleaned_data

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -11,11 +11,6 @@
         {{ form.name.errors }}
     </div>
     <div>
-        {{ form.detection_phrases.label_tag }}<br>
-        {{ form.detection_phrases }}
-        {{ form.detection_phrases.errors }}
-    </div>
-    <div>
         <h3 class="font-semibold mt-4 mb-2">Name Aliase</h3>
         <div id="name_aliases-container">
             {{ formset.management_form }}

--- a/templates/anlage2/subquestion_form.html
+++ b/templates/anlage2/subquestion_form.html
@@ -11,11 +11,6 @@
         {{ form.frage_text.errors }}
     </div>
     <div>
-        {{ form.detection_phrases.label_tag }}<br>
-        {{ form.detection_phrases }}
-        {{ form.detection_phrases.errors }}
-    </div>
-    <div>
         <h3 class="font-semibold mt-4 mb-2">Erkennungsphrasen</h3>
         <div id="name_aliases-container">
             {{ formset.management_form }}


### PR DESCRIPTION
## Summary
- tweak `Anlage2FunctionForm` and `Anlage2SubQuestionForm` to remove JSON textarea
- build detection phrases from the `PhraseFormSet`
- update templates for the new behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68603ec34b00832b8d9577fe6a02a85f