### PR TITLE
Allow blank phrase entries in admin

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -442,6 +442,12 @@ class PhraseForm(forms.Form):
 class Anlage2GlobalPhraseForm(forms.ModelForm):
     """Formular für eine globale Erkennungsphrase."""
 
+    phrase_text = forms.CharField(
+        label="",
+        required=False,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+    )
+
     class Meta:
         model = Anlage2GlobalPhrase
         fields = ["phrase_text"]

--- a/core/views.py
+++ b/core/views.py
@@ -1751,15 +1751,21 @@ def anlage2_config(request):
             for key, _ in categories:
                 fs = phrase_sets[key]
                 for form in fs.forms:
-                    if form.cleaned_data.get("DELETE"):
+                    phrase = form.cleaned_data.get("phrase_text", "").strip()
+                    if form.cleaned_data.get("DELETE") or (
+                        form.instance.pk and not phrase
+                    ):
                         if form.instance.pk:
                             form.instance.delete()
+                        continue
+                    if not phrase:
                         continue
                     if not form.has_changed() and form.instance.pk:
                         continue
                     inst = form.save(commit=False)
                     inst.config = cfg
                     inst.phrase_type = key
+                    inst.phrase_text = phrase
                     inst.save()
             return redirect("anlage2_config")
     else:


### PR DESCRIPTION
## Summary
- permit empty rows in global phrase formsets
- ignore or delete blank phrases in config view

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686046d1e2c4832bbdbc0fdbb271220e