### PR TITLE
Enhance Anlage 2 config logging

### DIFF
--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -205,6 +205,13 @@ LOGGING = {
             "formatter": "verbose",
             "encoding": "utf-8",
         },
+        "anlage2_admin_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "debug-admin_anlage2_funktionen.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+        },
     },
     "loggers": {
         "": {  # Dies ist der Root-Logger. Er fängt alle Meldungen ab, die nicht von spezifischeren Loggern behandelt werden.
@@ -242,6 +249,11 @@ LOGGING = {
         },
         "anlage3_debug": {
             "handlers": ["anlage3_file"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
+        "anlage2_admin_debug": {
+            "handlers": ["anlage2_admin_file"],
             "level": "DEBUG",
             "propagate": False,
         },

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -10,6 +10,7 @@
     {% csrf_token %}
     {{ config_form.non_field_errors }}
     <input type="hidden" name="active_tab" id="active_tab" value="{{ active_tab }}">
+    <input type="hidden" name="phrase_key" id="phrase_key" value="">
     <nav class="space-x-2 mb-4">
         <button type="button" data-tab="table" class="tab-btn px-3 py-1 bg-gray-200 rounded">Tabellen-Parser</button>
         <button type="button" data-tab="text" class="tab-btn px-3 py-1 bg-gray-200 rounded">Text-Parser</button>
@@ -113,6 +114,7 @@
                 </div>
             </div>
             <button type="button" class="add-form bg-gray-300 px-2 py-1 rounded" data-prefix="{{ key }}">+ Weitere Phrase hinzufügen</button>
+            <button type="submit" name="action" value="save_phrase_set" class="ml-2 px-2 py-1 bg-blue-600 text-white rounded" onclick="document.getElementById('phrase_key').value='{{ key }}'">Speichern</button>
         </div>
         {% endfor %}
         <button type="submit" name="action" value="save_text" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>


### PR DESCRIPTION
## Summary
- allow saving a single phrase set
- add dedicated logger for admin Anlage‑2 actions
- log actions when editing Anlage‑2 configuration

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686053bb5104832b8b4ce79043b51891