### PR TITLE
feat: vereinfachte eingabe der erkennungsphrasen

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -439,6 +439,33 @@ class PhraseForm(forms.Form):
     )
 
 
+class PhraseListField(forms.Field):
+    """Feld für mehrere Zeilen, die als Liste gespeichert werden."""
+
+    widget = forms.Textarea
+
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs.setdefault("required", False)
+        if "widget" not in kwargs:
+            kwargs["widget"] = forms.Textarea()
+        super().__init__(*args, **kwargs)
+
+    def prepare_value(self, value):  # pragma: no cover - trivial
+        if isinstance(value, list):
+            return "\n".join(str(v) for v in value)
+        if value is None:
+            return ""
+        return str(value)
+
+    def to_python(self, value):
+        if not value:
+            return []
+        if isinstance(value, list):
+            return value
+        lines = [line.strip() for line in str(value).splitlines()]
+        return [l for l in lines if l]
+
+
 class Anlage2GlobalPhraseForm(forms.ModelForm):
     """Formular für eine globale Erkennungsphrase."""
 
@@ -461,6 +488,15 @@ Anlage2GlobalPhraseFormSet = modelformset_factory(
 
 class Anlage2ConfigForm(forms.ModelForm):
     """Formular für die Anlage-2-Konfiguration."""
+
+    text_technisch_verfuegbar_true = PhraseListField(widget=forms.Textarea(attrs={"rows": 2}))
+    text_technisch_verfuegbar_false = PhraseListField(widget=forms.Textarea(attrs={"rows": 2}))
+    text_einsatz_telefonica_true = PhraseListField(widget=forms.Textarea(attrs={"rows": 2}))
+    text_einsatz_telefonica_false = PhraseListField(widget=forms.Textarea(attrs={"rows": 2}))
+    text_zur_lv_kontrolle_true = PhraseListField(widget=forms.Textarea(attrs={"rows": 2}))
+    text_zur_lv_kontrolle_false = PhraseListField(widget=forms.Textarea(attrs={"rows": 2}))
+    text_ki_beteiligung_true = PhraseListField(widget=forms.Textarea(attrs={"rows": 2}))
+    text_ki_beteiligung_false = PhraseListField(widget=forms.Textarea(attrs={"rows": 2}))
 
     class Meta:
         model = Anlage2Config

--- a/core/models.py
+++ b/core/models.py
@@ -644,7 +644,7 @@ class Anlage2Function(models.Model):
     detection_phrases = models.JSONField(
         blank=True,
         default=dict,
-        help_text="JSON-Objekt zur Speicherung von Erkennungsphrasen für den Text-Parser.",
+        help_text="Liste der Erkennungsphrasen für den Text-Parser.",
     )
 
     class Meta:
@@ -694,7 +694,7 @@ class Anlage2SubQuestion(models.Model):
     detection_phrases = models.JSONField(
         blank=True,
         default=dict,
-        help_text="JSON-Objekt zur Speicherung von Erkennungsphrasen für den Text-Parser.",
+        help_text="Liste der Erkennungsphrasen für den Text-Parser.",
     )
 
     class Meta:

--- a/core/tests.py
+++ b/core/tests.py
@@ -3313,24 +3313,22 @@ class Anlage2ConfigViewTests(TestCase):
             Anlage2ColumnHeading.objects.filter(text="Verfügbar?").exists()
         )
 
-    def test_invalid_json_shows_error(self):
+    def test_multiline_phrases_saved(self):
         url = reverse("anlage2_config")
         data = {
-            "text_technisch_verfuegbar_true": "[",
+            "text_technisch_verfuegbar_true": "ja\nokay\n",
             "action": "save_text",
             "active_tab": "text",
         }
         for key, _ in Anlage2GlobalPhrase.PHRASE_TYPE_CHOICES:
-            data[f"{key}-TOTAL_FORMS"] = "1"
+            data[f"{key}-TOTAL_FORMS"] = "0"
             data[f"{key}-INITIAL_FORMS"] = "0"
             data[f"{key}-MIN_NUM_FORMS"] = "0"
             data[f"{key}-MAX_NUM_FORMS"] = "1000"
-            data[f"{key}-0-id"] = ""
-            data[f"{key}-0-phrase_text"] = ""
-            data[f"{key}-0-DELETE"] = ""
         resp = self.client.post(url, data)
-        self.assertEqual(resp.status_code, 200)
-        self.assertContains(resp, "gültiges JSON")
+        self.assertRedirects(resp, url + "?tab=text")
+        self.cfg.refresh_from_db()
+        self.assertEqual(self.cfg.text_technisch_verfuegbar_true, ["ja", "okay"])
 
 
 


### PR DESCRIPTION
## Summary
- allow multi-line text for Textparser detection phrases
- adjust help text of detection phrase fields
- add regression test for multi-line phrases

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68605eaf5e58832bb4e247280f192d1d