### PR TITLE
Update docs for detection phrase input

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Der Textparser berücksichtigt stets den Funktionsnamen bzw. den Fragetext als
 Alias. Zusätzliche Varianten können über das Feld `name_aliases` hinterlegt
 werden. Doppelte Einträge werden automatisch ignoriert.
 
+Erkennungsphrasen werden einfach zeilenweise eingegeben.
+JSON-Strukturen sind nicht mehr erforderlich; jede Zeile steht f\u00fcr eine Phrase.
+
 ### Anlage‑2‑Konfiguration importieren/exportieren
 
 Unter `/projects-admin/anlage2/config/` lässt sich zusätzlich die gesamte


### PR DESCRIPTION
## Summary
- clarify how detection phrases are entered in the admin area

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6860640d3dec832ba4f2079b55650ba3