### PR TITLE
fix: use global phrase model in text parser

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -699,6 +699,28 @@ class DocxExtractTests(TestCase):
             ],
         )
 
+    def test_parse_anlage2_text_uses_global_phrases(self):
+        func = Anlage2Function.objects.create(name="Login")
+        cfg = Anlage2Config.get_instance()
+        cfg.text_technisch_verfuegbar_true = ["tv ja"]
+        cfg.save()
+        Anlage2GlobalPhrase.objects.create(
+            config=cfg,
+            phrase_type="technisch_verfuegbar_true",
+            phrase_text="verfuegbar",
+        )
+        text = "Login verfuegbar"
+        data = parse_anlage2_text(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Login",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                }
+            ],
+        )
+
     def test_extract_images(self):
         img = Image.new("RGB", (1, 1), color="blue")
         img_tmp = NamedTemporaryFile(delete=False, suffix=".png")


### PR DESCRIPTION
## Summary
- load `Anlage2GlobalPhrase` in `parse_anlage2_text`
- test global phrase usage in text parser

## Testing
- `python manage.py makemigrations --check --merge` *(fails: merge prompt)*
- `python manage.py test` *(fails: conflicting migrations)*

------
https://chatgpt.com/codex/tasks/task_e_6861a51d0bec832ba101bcc8f9efed02