### PR TITLE
Add TextParser tests

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -36,6 +36,7 @@ from .docx_utils import (
     parse_anlage2_text,
     _normalize_header_text,
 )
+from . import text_parser
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from docx import Document
@@ -699,6 +700,44 @@ class DocxExtractTests(TestCase):
             ],
         )
 
+class TextParserFormatBTests(TestCase):
+    def test_parse_format_b_basic(self):
+        text = "Login; tv: ja; tel: nein; lv: nein; ki: ja"
+        data = text_parser.parse_format_b(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Login",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                    "einsatz_telefonica": {"value": False, "note": None},
+                    "zur_lv_kontrolle": {"value": False, "note": None},
+                    "ki_beteiligung": {"value": True, "note": None},
+                }
+            ],
+        )
+
+    def test_parse_format_b_numbering(self):
+        text = "1. Logout - tv=nein - ki=ja"
+        data = text_parser.parse_format_b(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Logout",
+                    "technisch_verfuegbar": {"value": False, "note": None},
+                    "ki_beteiligung": {"value": True, "note": None},
+                }
+            ],
+        )
+
+    def test_parse_format_b_multiple_lines(self):
+        text = "Login; tv: ja\nLogout; tv: nein"
+        data = text_parser.parse_format_b(text)
+        self.assertEqual(len(data), 2)
+        self.assertTrue(data[0]["technisch_verfuegbar"]["value"])
+        self.assertFalse(data[1]["technisch_verfuegbar"]["value"])
+
     def test_extract_images(self):
         img = Image.new("RGB", (1, 1), color="blue")
         img_tmp = NamedTemporaryFile(delete=False, suffix=".png")
@@ -1150,6 +1189,49 @@ class LLMTasksTests(TestCase):
             run_anlage2_analysis(pf)
         m_tab.assert_not_called()
         m_text.assert_called_once()
+
+    def test_run_anlage2_analysis_auto_prefers_table(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+            text_content="t",
+        )
+        cfg = Anlage2Config.get_instance()
+        cfg.parser_mode = "auto"
+        cfg.save()
+        table_result = [{"funktion": "Login"}]
+        with patch(
+            "core.llm_tasks.parse_anlage2_table", return_value=table_result
+        ) as m_tab, patch(
+            "core.llm_tasks.parse_anlage2_text", return_value=[{"funktion": "Alt"}]
+        ) as m_text:
+            result = run_anlage2_analysis(pf)
+        m_tab.assert_called_once()
+        m_text.assert_not_called()
+        self.assertEqual(result, table_result)
+
+    def test_run_anlage2_analysis_auto_fallback_empty_table(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+            text_content="t",
+        )
+        cfg = Anlage2Config.get_instance()
+        cfg.parser_mode = "auto"
+        cfg.save()
+        with patch(
+            "core.llm_tasks.parse_anlage2_table", return_value=[]
+        ) as m_tab, patch(
+            "core.llm_tasks.parse_anlage2_text", return_value=[{"funktion": "Login"}]
+        ) as m_text:
+            result = run_anlage2_analysis(pf)
+        m_tab.assert_called_once()
+        m_text.assert_called_once()
+        self.assertEqual(result, [{"funktion": "Login"}])
 
     def test_check_anlage2_table_error_fallback(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -1,0 +1,41 @@
+import re
+from typing import List, Dict, Any
+
+
+def parse_format_b(text: str) -> List[Dict[str, Any]]:
+    """Parst ein einfaches Listenformat fuer Anlage 2.
+
+    Jede Zeile enthaelt den Funktionsnamen gefolgt von optionalen
+    Informationen zu technischen Flags. Zeilen koennen durch
+    Semikolons oder Bindestriche getrennt sein.
+    Beispiel::
+
+        "Login; tv: ja; tel: nein; lv: nein; ki: ja"
+    """
+
+    mapping = {
+        "tv": "technisch_verfuegbar",
+        "tel": "einsatz_telefonica",
+        "lv": "zur_lv_kontrolle",
+        "ki": "ki_beteiligung",
+    }
+    results = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        # Entferne Nummerierung wie "1." oder "a)"
+        line = re.sub(r"^[\d]+[.)]\s*", "", line)
+        parts = re.split(r"[;|-]", line)
+        if not parts:
+            continue
+        entry = {"funktion": parts[0].strip()}
+        for part in parts[1:]:
+            part = part.strip()
+            m = re.match(r"(tv|tel|lv|ki)\s*[:=]\s*(ja|nein)", part, re.I)
+            if not m:
+                continue
+            key, val = m.groups()
+            entry[mapping[key.lower()]] = {"value": val.lower() == "ja", "note": None}
+        results.append(entry)
+    return results


### PR DESCRIPTION
## Summary
- add simple `text_parser.parse_format_b` implementation
- expand `core/tests.py` with new format B cases
- test parser selection logic in `run_anlage2_analysis`

## Testing
- `python manage.py makemigrations --check` *(fails: conflicting migrations)*
- `python manage.py test` *(fails: 1 failed, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862865bd3c0832b893c99a17b270dec