### PR TITLE
Update docs for text parser usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ Logdatei `parser-debug.log`.
 Erkennungsphrasen für den Textparser können nun zeilenweise eingegeben werden;
 jede Zeile wird als eigene Phrase gespeichert.
 
+Um den Parser auch ohne Weboberfläche zu testen, steht das Skript
+`text_parser.py` bereit. Es erwartet eine Text- oder DOCX-Datei und gibt die
+erkannten Funktionen als JSON aus:
+
+```bash
+python text_parser.py anlage2.docx
+```
+
 
 
 ### Kachel-Zugriff verwalten
@@ -152,6 +160,10 @@ Die Konfigurationsseite ist in drei Tabs unterteilt: **Tabellen‑Parser**,
 Feldwert `parser_mode` setzen. Er bestimmt, ob beim Einlesen der Anlage nur der
 Tabellenparser, nur der Textparser oder der bisherige automatische Fallback
 verwendet wird.
+
+Zusätzlich legt die Option **Parser-Priorität** fest, welcher Parser bei
+aktiviertem Fallback zuerst ausgeführt wird. Standardmäßig besitzt der
+Tabellenparser Vorrang.
 
 ### KI-Begründung per Tooltip
 

--- a/text_parser.py
+++ b/text_parser.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Kommandozeilentool für den Text-Parser von Anlage 2."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "noesis.settings")
+django.setup()
+
+from core.docx_utils import extract_text, parse_anlage2_text
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: python text_parser.py <file>", file=sys.stderr)
+        return 1
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        print(f"File not found: {path}", file=sys.stderr)
+        return 1
+
+    if path.suffix.lower() == ".docx":
+        text = extract_text(path)
+    else:
+        text = path.read_text(encoding="utf-8")
+
+    results = parse_anlage2_text(text)
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document how to call `text_parser.py`
- explain parser priority in README
- include CLI helper script

## Testing
- `python manage.py makemigrations --check` *(fails: conflicting migrations)*
- `python manage.py test` *(fails: 1 test failing)*

------
https://chatgpt.com/codex/tasks/task_e_6862865cb9cc832bafa19c6bdb109511