### PR TITLE
Fix circular import in parser system

### DIFF
--- a/core/parser_manager.py
+++ b/core/parser_manager.py
@@ -1,35 +1,13 @@
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import Callable, Dict, List, Type
+from typing import Dict, List, Type
 
 from .models import BVProjectFile, Anlage2Config
-from .docx_utils import parse_anlage2_table
+from .parsers import AbstractParser, TableParser
 from .text_parser import TextParser
 
 logger = logging.getLogger(__name__)
-
-
-class AbstractParser(ABC):
-    """Abstrakte Basisklasse für Parser."""
-
-    name: str
-
-    @abstractmethod
-    def parse(self, project_file: BVProjectFile) -> list[dict[str, object]]:
-        """Parst eine Projektdatei."""
-        raise NotImplementedError
-
-
-class TableParser(AbstractParser):
-    """Parser für strukturierte Tabelle."""
-
-    name = "table"
-
-    def parse(self, project_file: BVProjectFile) -> list[dict[str, object]]:
-        return parse_anlage2_table(Path(project_file.upload.path))
 
 
 class ParserManager:

--- a/core/parsers.py
+++ b/core/parsers.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from .models import BVProjectFile
+from .docx_utils import parse_anlage2_table
+
+logger = logging.getLogger(__name__)
+
+
+class AbstractParser(ABC):
+    """Abstrakte Basisklasse f\u00fcr Parser."""
+
+    name: str
+
+    @abstractmethod
+    def parse(self, project_file: BVProjectFile) -> list[dict[str, object]]:
+        """Parst eine Projektdatei."""
+        raise NotImplementedError
+
+
+class TableParser(AbstractParser):
+    """Parser f\u00fcr strukturierte Tabelle."""
+
+    name = "table"
+
+    def parse(self, project_file: BVProjectFile) -> list[dict[str, object]]:
+        return parse_anlage2_table(Path(project_file.upload.path))
+

--- a/core/tests.py
+++ b/core/tests.py
@@ -37,7 +37,8 @@ from .docx_utils import (
 
 from . import text_parser
 
-from .parser_manager import parser_manager, AbstractParser
+from .parser_manager import parser_manager
+from .parsers import AbstractParser
 from .text_parser import TextParser
 
 from pathlib import Path

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -6,7 +6,7 @@ import re
 from typing import List
 
 from .models import BVProjectFile
-from .parser_manager import AbstractParser
+from .parsers import AbstractParser
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- extrahiere `AbstractParser` und `TableParser` in neues Modul `parsers`
- importiere Parser-Basisklassen aus dem neuen Modul
- passe Tests entsprechend an

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django_q')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django_q')*

------
https://chatgpt.com/codex/tasks/task_e_6862d43870d4832b96e3d41725b2b88c