### PR TITLE
Add Anlage2 text parser

### DIFF
--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 
 import logging
 import re
+import string
 from typing import List
 
-from .models import BVProjectFile
+from .models import (
+    BVProjectFile,
+    Anlage2Config,
+    Anlage2Function,
+    Anlage2SubQuestion,
+)
 from .parsers import AbstractParser
 
 logger = logging.getLogger(__name__)
@@ -93,5 +99,194 @@ def _map_lv(sentence: str) -> str:
         if "verwendet" in lower:
             return "Ja"
     return "Unbekannt"
+
+
+def _normalize_snippet(text: str) -> str:
+    """Normalisiert einen Textschnipsel für Alias-Vergleiche."""
+    text = (
+        text.replace("\n", " ")
+        .replace("\t", " ")
+        .replace("\u00b6", " ")
+        .replace("\xa0", " ")
+    )
+    text = text.lower()
+    text = re.sub(r"[\-_/]+", " ", text)
+    text = text.translate(str.maketrans("", "", string.punctuation))
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def parse_anlage2_text(text_content: str) -> list[dict[str, object]]:
+    """Parst den Text einer Anlage 2 anhand der Konfiguration."""
+
+    logger = logging.getLogger(__name__)
+    parser_logger = logging.getLogger("parser_debug")
+    parser_logger.info("parse_anlage2_text gestartet")
+
+    if not text_content:
+        return []
+
+    def _get_list(data: dict | None, key: str) -> list[str]:
+        val = data.get(key, []) if isinstance(data, dict) else []
+        if isinstance(val, str):
+            return [val]
+        return [str(v) for v in val]
+
+    functions: list[tuple[Anlage2Function, list[str]]] = []
+    for func in Anlage2Function.objects.all():
+        alias_list = [func.name]
+        alias_list += _get_list(getattr(func, "detection_phrases", {}), "name_aliases")
+        aliases = list(dict.fromkeys(_normalize_snippet(a) for a in alias_list))
+        parser_logger.debug("Funktion '%s' Aliase: %s", func.name, aliases)
+        functions.append((func, aliases))
+
+    sub_map: dict[int, list[tuple[Anlage2SubQuestion, list[str]]]] = {}
+    for sub in Anlage2SubQuestion.objects.select_related("funktion"):
+        alias_list = [sub.frage_text]
+        alias_list += _get_list(getattr(sub, "detection_phrases", {}), "name_aliases")
+        aliases = list(dict.fromkeys(_normalize_snippet(a) for a in alias_list))
+        parser_logger.debug(
+            "Unterfrage '%s' (%s) Aliase: %s",
+            sub.frage_text,
+            sub.funktion.name,
+            aliases,
+        )
+        sub_map.setdefault(sub.funktion_id, []).append((sub, aliases))
+
+    cfg = Anlage2Config.get_instance()
+    phrase_fields = [
+        "technisch_verfuegbar_true",
+        "technisch_verfuegbar_false",
+        "einsatz_telefonica_true",
+        "einsatz_telefonica_false",
+        "zur_lv_kontrolle_true",
+        "zur_lv_kontrolle_false",
+        "ki_beteiligung_true",
+        "ki_beteiligung_false",
+    ]
+    gp_dict: dict[str, list[str]] = {}
+    for field in phrase_fields:
+        phrases = getattr(cfg, f"text_{field}", []) or []
+        for ph in phrases:
+            parser_logger.debug("Globale Phrase '%s': %s", field, ph)
+            norm = _normalize_snippet(ph)
+            gp_dict.setdefault(field, []).append(norm)
+    parser_logger.debug("Gesammelte globale Phrasen: %s", gp_dict)
+
+    def _match(
+        phrases: list[str],
+        line: str,
+        origin: str | None = None,
+        raw_line: str | None = None,
+    ) -> bool:
+        valid_phrases = [p for p in phrases if p]
+        if not valid_phrases:
+            parser_logger.debug(
+                "Keine gültigen Aliase zum Prüfen für '%s' vorhanden. Überspringe.",
+                origin or "Unbekannt",
+            )
+            return False
+        for ph in valid_phrases:
+            if origin:
+                if raw_line is not None:
+                    parser_logger.debug(
+                        "Prüfe Alias '%s' aus '%s' gegen Zeile '%s' (Rohtext: '%s')",
+                        ph,
+                        origin,
+                        line,
+                        raw_line,
+                    )
+                else:
+                    parser_logger.debug(
+                        "Prüfe Alias '%s' aus '%s' gegen Zeile '%s'",
+                        ph,
+                        origin,
+                        line,
+                    )
+            else:
+                parser_logger.debug("Prüfe Alias '%s' gegen Zeile '%s'", ph, line)
+            if ph in line:
+                parser_logger.debug("-> Treffer")
+                return True
+        return False
+
+    def _extract_values(line: str, raw_line: str) -> dict[str, dict[str, object]]:
+        result: dict[str, dict[str, object]] = {}
+        for field in [
+            "technisch_verfuegbar",
+            "einsatz_telefonica",
+            "zur_lv_kontrolle",
+            "ki_beteiligung",
+        ]:
+            val = None
+            if _match(gp_dict.get(f"{field}_true", []), line, origin=f"{field}_true", raw_line=raw_line):
+                val = True
+            elif _match(gp_dict.get(f"{field}_false", []), line, origin=f"{field}_false", raw_line=raw_line):
+                val = False
+            if val is not None:
+                result[field] = {"value": val, "note": None}
+                parser_logger.debug("Extrahierter Wert für %s: %s", field, val)
+        return result
+
+    lines = [l.strip() for l in text_content.replace("\u00b6", "\n").splitlines()]
+    results: list[dict[str, object]] = []
+    results_by_func: dict[str, dict[str, object]] = {}
+    last_main: dict[str, object] | None = None
+    last_func: Anlage2Function | None = None
+
+    for line in lines:
+        parser_logger.debug("Prüfe Zeile: %s", line)
+        norm_line = _normalize_snippet(line)
+        parser_logger.debug("Zeile | ROH: %r | NORMALISIERT: %r", line, norm_line)
+        if not norm_line:
+            continue
+
+        found = False
+
+        if last_func:
+            for sub, aliases in sub_map.get(last_func.id, []):
+                if _match(aliases, norm_line, origin=f"Unterfrage {sub.frage_text}", raw_line=line):
+                    full_name = f"{last_main['funktion']}: {sub.frage_text}"
+                    parser_logger.debug("Unterfrage erkannt: %s", full_name)
+                    row = {"funktion": full_name}
+                    row.update(_extract_values(norm_line, line))
+                    results.append(row)
+                    found = True
+                    break
+        if found:
+            continue
+
+        for func, aliases in functions:
+            if _match(aliases, norm_line, origin=f"Funktion {func.name}", raw_line=line):
+                parser_logger.debug("Hauptfunktion erkannt: %s", func.name)
+                new_data = {"funktion": func.name}
+                new_data.update(_extract_values(norm_line, line))
+                if func.name in results_by_func:
+                    row = results_by_func[func.name]
+                    row.update(new_data)
+                else:
+                    row = new_data
+                    results_by_func[func.name] = row
+                    results.append(row)
+                last_main = row
+                last_func = func
+                found = True
+                break
+
+        if not found:
+            extra_values = _extract_values(norm_line, line)
+            if extra_values and last_main is not None:
+                parser_logger.debug(
+                    "Ergänze letzte Funktion %s um Werte %s",
+                    last_main.get("funktion"),
+                    extra_values,
+                )
+                last_main.update(extra_values)
+            else:
+                parser_logger.debug("Keine Funktion erkannt für Zeile: %s", line)
+
+    logger.debug("parse_anlage2_text Ergebnisse: %s", results)
+    parser_logger.info("parse_anlage2_text beendet")
+    return results
 
 

--- a/text_parser.py
+++ b/text_parser.py
@@ -13,7 +13,8 @@ import django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "noesis.settings")
 django.setup()
 
-from core.docx_utils import extract_text, parse_anlage2_text
+from core.docx_utils import extract_text
+from core.text_parser import parse_anlage2_text
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- implement `parse_anlage2_text` for analysing plain text
- adjust CLI to import the parser from `core.text_parser`

## Testing
- `python manage.py makemigrations --check` *(fails: Unknown field specified)*
- `python manage.py test` *(fails: Unknown field specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862df7def7c832b852c63ff8b08f4d5