### PR TITLE
Fix text parser import

### DIFF
--- a/text_parser.py
+++ b/text_parser.py
@@ -13,7 +13,8 @@ import django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "noesis.settings")
 django.setup()
 
-from core.docx_utils import extract_text, parse_anlage2_text
+from core.docx_utils import extract_text
+from core.llm_tasks import parse_anlage2_text
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- use `parse_anlage2_text` from `core.llm_tasks`

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6862f5bc3110832bb00b03b646c54ee2