### PR TITLE
feat: verbessertes Admin-Interface für Area und Tile

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import User
+from django import forms
+from django.utils.html import format_html
+from django.contrib.admin.widgets import FilteredSelectMultiple, AdminFileWidget
 from .models import (
     Recording,
     Prompt,
@@ -11,6 +14,77 @@ from .models import (
     Anlage2Function,
     Anlage2FunctionResult,
 )
+
+
+class AdminImagePreviewWidget(AdminFileWidget):
+    """Widget mit Bildvorschau."""
+
+    def render(self, name, value, attrs=None, renderer=None):
+        output = []
+        if value and getattr(value, "url", None):
+            output.append(
+                f'<img src="{value.url}" style="max-height: 100px;" />'
+            )
+        output.append(super().render(name, value, attrs, renderer))
+        return format_html("<br>".join(output))
+
+
+class AreaAdminForm(forms.ModelForm):
+    """Formular für Area mit Benutzerzuweisung."""
+
+    users = forms.ModelMultipleChoiceField(
+        queryset=User.objects.all(),
+        required=False,
+        widget=FilteredSelectMultiple("Benutzer", is_stacked=False),
+    )
+
+    class Meta:
+        model = Area
+        fields = ["slug", "name", "image", "users"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            self.fields["users"].initial = self.instance.users.all()
+
+    def save(self, commit=True):
+        area = super().save(commit)
+        if commit:
+            area.users.set(self.cleaned_data["users"])
+        return area
+
+
+class TileAdminForm(forms.ModelForm):
+    """Formular für Tile mit Bildvorschau."""
+
+    areas = forms.ModelMultipleChoiceField(
+        queryset=Area.objects.all(),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+    )
+    users = forms.ModelMultipleChoiceField(
+        queryset=User.objects.all(),
+        required=False,
+        widget=FilteredSelectMultiple("Benutzer", is_stacked=False),
+    )
+
+    class Meta:
+        model = Tile
+        fields = "__all__"
+        widgets = {"image": AdminImagePreviewWidget}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            self.fields["areas"].initial = self.instance.areas.all()
+            self.fields["users"].initial = self.instance.users.all()
+
+    def save(self, commit=True):
+        tile = super().save(commit)
+        if commit:
+            tile.areas.set(self.cleaned_data["areas"])
+            tile.users.set(self.cleaned_data["users"])
+        return tile
 
 
 @admin.register(Recording)
@@ -25,13 +99,31 @@ class PromptAdmin(admin.ModelAdmin):
 
 @admin.register(Tile)
 class TileAdmin(admin.ModelAdmin):
-    list_display = ("slug", "name", "url_name", "areas_display", "image")
+    form = TileAdminForm
+    list_display = ("name", "image_thumb", "areas_display")
+    readonly_fields = ("image_thumb",)
+
+    def has_add_permission(self, request):  # pragma: no cover - admin
+        return False
+
+    def has_delete_permission(self, request, obj=None):  # pragma: no cover - admin
+        return False
 
     def areas_display(self, obj) -> str:
         """Zeigt die zugewiesenen Bereiche."""
         return ", ".join(a.name for a in obj.areas.all())
 
     areas_display.short_description = "Bereiche"
+
+    def image_thumb(self, obj) -> str:
+        """Gibt eine kleine Bildvorschau zurück."""
+        if obj.image:
+            return format_html(
+                '<img src="{}" style="height:50px;" />', obj.image.url
+            )
+        return "-"
+
+    image_thumb.short_description = "Bild"
 
 
 @admin.register(UserTileAccess)
@@ -41,7 +133,14 @@ class UserTileAccessAdmin(admin.ModelAdmin):
 
 @admin.register(Area)
 class AreaAdmin(admin.ModelAdmin):
+    form = AreaAdminForm
     list_display = ("slug", "name", "image")
+
+    def has_add_permission(self, request):  # pragma: no cover - admin
+        return False
+
+    def has_delete_permission(self, request, obj=None):  # pragma: no cover - admin
+        return False
 
 
 class UserTileAccessInline(admin.TabularInline):


### PR DESCRIPTION
## Summary
- verbessere `Area` und `Tile` Admin
- verhindere Hinzufügen und Löschen dieser Objekte
- nutze FilteredSelectMultiple für Benutzerzuweisungen und Checkboxen für Area-Zuweisungen
- zeige Vorschaubilder bei Kacheln im Admin

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fehlt Abhängigkeiten und schlägt daher fehl)*

------
https://chatgpt.com/codex/tasks/task_e_68639c6000a4832b9395309993f18830