### PR TITLE
Add visual role editor

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -92,6 +92,11 @@ urlpatterns = [
         views.admin_edit_user_permissions,
         name="admin_edit_user_permissions",
     ),
+    path(
+        "projects-admin/roles-editor/",
+        views.admin_role_editor,
+        name="admin_role_editor",
+    ),
     path("projects-admin/anlage1/", views.admin_anlage1, name="admin_anlage1"),
     path(
         "projects-admin/anlage1/export/",

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -90,6 +90,10 @@
                         <i class="fas fa-user-shield fa-fw mr-2"></i>
                         Gruppen
                     </a>
+                    <a href="{% url 'admin_role_editor' %}" class="nav-link {% if request.resolver_match.url_name == 'admin_role_editor' %}active-nav-link{% endif %}">
+                        <i class="fas fa-check-square fa-fw mr-2"></i>
+                        Rollen &amp; Rechte
+                    </a>
                 </div>
                 {% endwith %}
             </div>

--- a/templates/admin_roles.html
+++ b/templates/admin_roles.html
@@ -1,0 +1,33 @@
+{% extends 'admin/base_site.html' %}
+{% block title %}Rollen & Rechte{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Rollen & Rechte</h1>
+<div class="mb-4">
+    <label for="group-select" class="mr-2">Rolle:</label>
+    <select id="group-select" class="border rounded p-1">
+        <option value="">Rolle wählen</option>
+        {% for g in groups %}
+            <option value="{{ g.id }}" {% if selected_group and g.id == selected_group.id %}selected{% endif %}>{{ g.name }}</option>
+        {% endfor %}
+    </select>
+    <a href="{% url 'admin:auth_group_add' %}" class="ml-2 px-2 py-1 bg-blue-600 text-white rounded">Neue Rolle</a>
+</div>
+<div id="role-form">
+    {% if selected_group %}
+        {% include 'partials/_role_tile_form.html' %}
+    {% else %}
+        <p>Bitte eine Rolle auswählen.</p>
+    {% endif %}
+</div>
+<script>
+function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
+const select=document.getElementById('group-select');
+select.addEventListener('change',()=>{
+    const gid=select.value;
+    if(!gid){document.getElementById('role-form').innerHTML='';return;}
+    fetch('{% url 'admin_role_editor' %}?group='+gid,{headers:{'X-Requested-With':'XMLHttpRequest'}})
+      .then(r=>r.text())
+      .then(html=>{document.getElementById('role-form').innerHTML=html;});
+});
+</script>
+{% endblock %}

--- a/templates/partials/_role_tile_form.html
+++ b/templates/partials/_role_tile_form.html
@@ -1,0 +1,20 @@
+{% if selected_group %}
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    <input type="hidden" name="group_id" value="{{ selected_group.id }}">
+    {% for area, items in tiles_by_area.items %}
+        <h2 class="text-xl font-semibold mt-4">{{ area.name }}-Dashboard</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {% for item in items %}
+                <label class="flex items-center space-x-2">
+                    <input type="checkbox" name="tiles" value="{{ item.tile.id }}" {% if item.checked %}checked{% endif %}>
+                    <span>{{ item.tile.name }}</span>
+                </label>
+            {% empty %}
+                <p>Keine Kacheln vorhanden.</p>
+            {% endfor %}
+        </div>
+    {% endfor %}
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+</form>
+{% endif %}


### PR DESCRIPTION
## Summary
- add view to edit tile permissions for roles
- hook view up in admin URLs
- add new templates for the role editor and tile list
- link role editor in the admin navigation

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: IndexError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686447972fc8832ba434b44ba0b4f49d