### PR TITLE
Fix template 'with' expressions

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -14,12 +14,12 @@
         <h2 class="text-xl font-bold mb-4">Admin-Navigation</h2>
         <nav class="admin-nav space-y-4 text-sm">
             <div>
-                {% with open_proj=request.resolver_match.url_name in 'admin_projects admin_project_statuses' %}
+                {% with open_proj=request.resolver_match.url_name %}
                 <h3 class="accordion-header text-gray-600 uppercase tracking-wider text-sm">
                     <span>Projekt-Konfiguration</span>
-                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_proj %}rotate-180{% endif %}"></i>
+                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_proj in 'admin_projects admin_project_statuses' %}rotate-180{% endif %}"></i>
                 </h3>
-                <div class="accordion-content pl-2 space-y-1 {% if open_proj %}block{% else %}hidden{% endif %}">
+                <div class="accordion-content pl-2 space-y-1 {% if open_proj in 'admin_projects admin_project_statuses' %}block{% else %}hidden{% endif %}">
                     <a href="{% url 'admin_projects' %}" class="nav-link {% if request.resolver_match.url_name == 'admin_projects' %}active-nav-link{% endif %}">
                         <i class="fas fa-list-alt fa-fw mr-2"></i>
                         Projekt-Liste
@@ -32,12 +32,12 @@
                 {% endwith %}
             </div>
             <div>
-                {% with open_anl=request.resolver_match.url_name in 'admin_anlage1 anlage2_function_list anlage2_config' %}
+                {% with open_anl=request.resolver_match.url_name %}
                 <h3 class="accordion-header text-gray-600 uppercase tracking-wider text-sm">
                     <span>Anlagen-Konfiguration</span>
-                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_anl %}rotate-180{% endif %}"></i>
+                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_anl in 'admin_anlage1 anlage2_function_list anlage2_config' %}rotate-180{% endif %}"></i>
                 </h3>
-                <div class="accordion-content pl-2 space-y-1 {% if open_anl %}block{% else %}hidden{% endif %}">
+                <div class="accordion-content pl-2 space-y-1 {% if open_anl in 'admin_anlage1 anlage2_function_list anlage2_config' %}block{% else %}hidden{% endif %}">
                     <a href="{% url 'admin_anlage1' %}" class="nav-link {% if request.resolver_match.url_name == 'admin_anlage1' %}active-nav-link{% endif %}">
                         <i class="fas fa-question-circle fa-fw mr-2"></i>
                         Anlage 1 Fragen
@@ -54,12 +54,12 @@
                 {% endwith %}
             </div>
             <div>
-                {% with open_ki=request.resolver_match.url_name in 'admin_llm_roles admin_prompts admin_models' %}
+                {% with open_ki=request.resolver_match.url_name %}
                 <h3 class="accordion-header text-gray-600 uppercase tracking-wider text-sm">
                     <span>KI-Konfiguration</span>
-                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_ki %}rotate-180{% endif %}"></i>
+                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_ki in 'admin_llm_roles admin_prompts admin_models' %}rotate-180{% endif %}"></i>
                 </h3>
-                <div class="accordion-content pl-2 space-y-1 {% if open_ki %}block{% else %}hidden{% endif %}">
+                <div class="accordion-content pl-2 space-y-1 {% if open_ki in 'admin_llm_roles admin_prompts admin_models' %}block{% else %}hidden{% endif %}">
                     <a href="{% url 'admin_llm_roles' %}" class="nav-link {% if request.resolver_match.url_name == 'admin_llm_roles' %}active-nav-link{% endif %}">
                         <i class="fas fa-user-gear fa-fw mr-2"></i>
                         LLM-Rollen
@@ -76,12 +76,12 @@
                 {% endwith %}
             </div>
             <div>
-                {% with open_sys=request.resolver_match.url_name in 'admin_user_list auth_group_changelist' %}
+                {% with open_sys=request.resolver_match.url_name %}
                 <h3 class="accordion-header text-gray-600 uppercase tracking-wider text-sm">
                     <span>Systemverwaltung</span>
-                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_sys %}rotate-180{% endif %}"></i>
+                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_sys in 'admin_user_list auth_group_changelist' %}rotate-180{% endif %}"></i>
                 </h3>
-                <div class="accordion-content pl-2 space-y-1 {% if open_sys %}block{% else %}hidden{% endif %}">
+                <div class="accordion-content pl-2 space-y-1 {% if open_sys in 'admin_user_list auth_group_changelist' %}block{% else %}hidden{% endif %}">
                     <a href="{% url 'admin_user_list' %}" class="nav-link {% if request.resolver_match.url_name == 'admin_user_list' %}active-nav-link{% endif %}">
                         <i class="fas fa-users fa-fw mr-2"></i>
                         Benutzer verwalten


### PR DESCRIPTION
## Summary
- fix `with` tag usage in admin template so Django 5.2 doesn't error

## Testing
- `python manage.py makemigrations --check` *(fails: Couldn't import Django)*
- `pip install --no-cache-dir -r requirements.txt` *(failed: operation cancelled)*
- `python manage.py test` *(fails: DJANGO_SECRET_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68644c386a90832bbea33f350e0aa673