### PR TITLE
Implement global loading spinner

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -131,3 +131,18 @@ input[type="submit"]:hover {
     background-image: linear-gradient(to right, var(--color-primary), var(--color-primary-dark));
     color: #ffffff;
 }
+
+.spinner {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spinner-border 0.75s linear infinite;
+    vertical-align: middle;
+}
+
+@keyframes spinner-border {
+    to { transform: rotate(360deg); }
+}

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,0 +1,15 @@
+function showSpinner(buttonElement, spinnerText = 'Wird geladen...') {
+    if (!buttonElement) return;
+    buttonElement.dataset.originalHtml = buttonElement.innerHTML;
+    buttonElement.disabled = true;
+    buttonElement.innerHTML = `<span class="spinner"></span>${spinnerText ? ' ' + spinnerText : ''}`;
+}
+
+function hideSpinner(buttonElement) {
+    if (!buttonElement) return;
+    const original = buttonElement.dataset.originalHtml;
+    if (original !== undefined) {
+        buttonElement.innerHTML = original;
+    }
+    buttonElement.disabled = false;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,6 +52,7 @@
         <p>&copy; 2024 Noesis Assistant</p>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{% static 'js/utils.js' %}"></script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -15,7 +15,7 @@
     <textarea class="border rounded w-full p-2" rows="6" readonly>{{ projekt.gutachten_function_note }}</textarea>
 </div>
 {% endif %}
-<form method="post" action="{% url 'gutachten_llm_check' gutachten.id %}" class="mt-4">
+<form id="llm-check-form" class="mt-4">
     {% csrf_token %}
     <label class="font-semibold">LLM-Modell:</label>
     {% for key, data in categories.items %}
@@ -24,6 +24,19 @@
             {{ data.label }}
         </label>
     {% endfor %}
-    <button type="submit" class="bg-purple-600 text-white px-4 py-2 rounded ml-2">LLM-Funktionscheck</button>
+    <button type="button" id="llm-check-btn" class="bg-purple-600 text-white px-4 py-2 rounded ml-2">LLM-Funktionscheck</button>
 </form>
+<script>
+function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
+document.getElementById('llm-check-btn').addEventListener('click',function(){
+    const btn=this;
+    const form=document.getElementById('llm-check-form');
+    showSpinner(btn,'Prüfe...');
+    fetch('{% url 'gutachten_llm_check' gutachten.id %}',{
+        method:'POST',
+        headers:{'X-CSRFToken':getCookie('csrftoken')},
+        body:new FormData(form)
+    }).then(r=>{if(!r.ok) throw new Error(); return r.text();}).then(()=>window.location.reload()).catch(()=>{alert('Fehler beim Prüfen'); hideSpinner(btn);});
+});
+</script>
 {% endblock %}

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -153,13 +153,7 @@
                     <a href="{% url 'gutachten_edit' row.entry.gutachten.id %}">Bearbeiten</a> |
                     <a href="{% url 'gutachten_download' row.entry.gutachten.id %}">Download</a>
                 {% else %}
-                    <button class="btn btn-sm btn-primary generate-gutachten-btn flex items-center" data-knowledge-id="{{ row.entry.id }}">
-                        <span>Gutachten erstellen</span>
-                        <svg class="hidden w-4 h-4 ml-1 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-                        </svg>
-                    </button>
+                    <button class="btn btn-sm btn-primary generate-gutachten-btn" data-knowledge-id="{{ row.entry.id }}">Gutachten erstellen</button>
                 {% endif %}
                 <span class="gutachten-status-spinner ms-2" id="gutachten-status-{{ row.entry.id }}"></span>
             {% endif %}
@@ -169,13 +163,7 @@
     </tbody>
 </table>
 </div>
-<button id="start-checks" class="bg-green-600 text-white px-4 py-2 rounded flex items-center">
-    <span>Prüfung starten</span>
-    <svg class="hidden w-4 h-4 ml-2 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-    </svg>
-</button>
+<button id="start-checks" class="bg-green-600 text-white px-4 py-2 rounded">Prüfung starten</button>
 </div>
 </div>
 <div class="lg:w-1/3 mt-4 lg:mt-0">
@@ -278,11 +266,7 @@ function attachHandlers(){
 
 function startChecks(){
  const btn=document.getElementById('start-checks');
- const spinner=btn.querySelector('svg');
- const text=btn.querySelector('span');
- btn.disabled=true;
- if(text) text.textContent='Prüfung läuft...';
- if(spinner) spinner.classList.remove('hidden');
+ showSpinner(btn, 'Prüfung läuft...');
  fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
    method:'POST',
    headers:{'X-CSRFToken':getCookie('csrftoken')}
@@ -300,7 +284,7 @@ function startChecks(){
        });
      },3000);
    });
- }).catch(()=>{alert('Fehler beim Start'); if(spinner) spinner.classList.add('hidden'); if(text) text.textContent='Prüfung starten'; btn.disabled=false;});
+ }).catch(()=>{alert('Fehler beim Start'); hideSpinner(btn);});
 }
 
 document.addEventListener('DOMContentLoaded',loadKnowledge);
@@ -320,10 +304,7 @@ document.addEventListener('DOMContentLoaded',function(){
 
       this.classList.add('disabled');
       const status=document.getElementById('gutachten-status-'+knowledgeId);
-      const spinner=this.querySelector('svg');
-      const text=this.querySelector('span');
-      if(text) text.textContent='Erstelle...';
-      if(spinner) spinner.classList.remove('hidden');
+      showSpinner(this, 'Erstelle...');
 
       fetch(url,{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body:body})
         .then(r=>r.json()).then(data=>{
@@ -336,22 +317,16 @@ document.addEventListener('DOMContentLoaded',function(){
               }else if(d.status==='FAIL'){
                 clearInterval(iv);
                 if(status){status.textContent='Fehler';}
-                const sp=button.querySelector('svg');
-                const tx=button.querySelector('span');
-                if(sp) sp.classList.add('hidden');
-                if(tx) tx.textContent='Gutachten erstellen';
+                hideSpinner(button);
                 button.classList.remove('disabled');
               }
             });
           },3000);
         }).catch(()=>{
           if(status){status.textContent='Fehler';}
-          const spinner=button.querySelector('svg');
-          const text=button.querySelector('span');
-          if(spinner) spinner.classList.add('hidden');
-          if(text) text.textContent='Gutachten erstellen';
+          hideSpinner(button);
           button.classList.remove('disabled');
-  });
+        });
   });
 });
 
@@ -364,12 +339,13 @@ document.addEventListener('DOMContentLoaded',function(){
     });
   });
   const sendBtn=document.querySelector('.send-context-btn');
-  if(sendBtn){
-    sendBtn.addEventListener('click',function(){
+ if(sendBtn){
+   sendBtn.addEventListener('click',function(){
       const text=document.getElementById('contextText').value;
       const body=new FormData();
       body.append('knowledge_id',contextId);
       body.append('user_context',text);
+      showSpinner(sendBtn, 'Senden...');
       fetch('{% url "ajax_rerun_initial_check_with_context" %}',{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body:body})
         .then(r=>r.json()).then(data=>{
           const tid=data.task_id;

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -43,18 +43,19 @@
 function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 const emailField=document.getElementById('email-text');
 document.getElementById('generate-email').addEventListener('click',function(){
-    const btn=this;btn.disabled=true;
+    const btn=this;
+    showSpinner(btn, 'Generiere...');
     fetch('{% url "anlage1_generate_email" anlage.pk %}',{
         method:'POST',
         headers:{'X-CSRFToken':getCookie('csrftoken')}
     }).then(r=>r.json()).then(data=>{
-        btn.disabled=false;
+        hideSpinner(btn);
         if(data.text){
             emailField.classList.remove('hidden');
             emailField.value=data.text;
             navigator.clipboard.writeText(data.text).then(()=>alert('E-Mail Text kopiert'));
         }else if(data.error){alert('Fehler: '+data.error);}
-    }).catch(()=>{btn.disabled=false;alert('Fehler bei der Generierung');});
+    }).catch(()=>{hideSpinner(btn);alert('Fehler bei der Generierung');});
 });
 </script>
 {% endblock %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -269,8 +269,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const clickedButton = this;
 
             // UI sofort auf Ladezustand setzen
-            clickedButton.disabled = true;
-            clickedButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
+            showSpinner(clickedButton, '');
 
             // Daten aus dem geklickten Button extrahieren
             const { projectFileId, functionId, subquestionId } = clickedButton.dataset;
@@ -316,7 +315,7 @@ document.addEventListener('DOMContentLoaded', function() {
             })
             .catch(error => {
                 console.error('Fehler bei der KI-Prüfung:', error);
-                clickedButton.innerHTML = '⚠️';
+                clickedButton.textContent = '⚠️';
                 clickedButton.disabled = false;
             });
         });
@@ -329,8 +328,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (confirm('Sind Sie sicher, dass Sie alle manuellen und KI-Bewertungen f\u00fcr diese Anlage unwiderruflich l\u00f6schen und auf den Zustand der Dokumenten-Analyse zur\u00fccksetzen wollen?')) {
 
                 const url = "{% url 'ajax_reset_all_reviews' anlage.pk %}";
-                resetButton.disabled = true;
-                resetButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Zur\u00fccksetzen...';
+                showSpinner(resetButton, 'Zur\u00fccksetzen...');
 
                 fetch(url, {
                     method: 'POST',
@@ -342,15 +340,13 @@ document.addEventListener('DOMContentLoaded', function() {
                         window.location.reload();
                     } else {
                         alert('Ein Fehler ist aufgetreten.');
-                        resetButton.disabled = false;
-                        resetButton.textContent = 'Alle Bewertungen zur\u00fccksetzen';
+                        hideSpinner(resetButton);
                     }
                 })
                 .catch(error => {
                     alert('Ein Netzwerkfehler ist aufgetreten.');
                     console.error("Reset error:", error);
-                    resetButton.disabled = false;
-                    resetButton.textContent = 'Alle Bewertungen zur\u00fccksetzen';
+                    hideSpinner(resetButton);
                 });
             }
         });

--- a/templates/talkdiary.html
+++ b/templates/talkdiary.html
@@ -34,13 +34,7 @@
             <form action="{% url 'transcribe_recording' rec.pk %}" method="post" class="transcribe-form">
                 {% csrf_token %}
                 <input type="hidden" name="track" value="1">
-                <button type="submit" class="px-2 py-1 text-white bg-blue-600 rounded flex items-center">
-                    <span>Transkribieren</span>
-                    <svg class="hidden w-4 h-4 ml-2 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-                    </svg>
-                </button>
+                <button type="submit" class="px-2 py-1 text-white bg-blue-600 rounded">Transkribieren</button>
             </form>
             {% if rec.transcript_file %}
             <a href="{% url 'talkdiary_detail' rec.pk %}" class="px-2 py-1 bg-green-600 text-white rounded">Transcript</a>
@@ -102,13 +96,8 @@ document.querySelectorAll('.transcribe-form').forEach(f => {
         if (trackInput) trackInput.value = track;
 
         const btn = f.querySelector('button[type="submit"]');
-        const spinner = btn.querySelector('svg');
         if (btn) {
-            btn.disabled = true;
-            btn.querySelector('span').textContent = 'Transkribiere...';
-            if (spinner) {
-                spinner.classList.remove('hidden');
-            }
+            showSpinner(btn, 'Transkribiere...');
         }
     });
 });


### PR DESCRIPTION
## Summary
- add reusable spinner styles and global JS helpers
- include spinner script in `base.html`
- refactor async buttons across templates to use `showSpinner`/`hideSpinner`
- convert Gutachten LLM check to AJAX with spinner feedback

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864cf11b358832bbbe1923e8f62a973