### PR TITLE
feat: fuzzy matching for free-text parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ django-q2>=1.8.0
 pypandoc
 pyMuPdf
 fpdf
+thefuzz[speedup]
 


### PR DESCRIPTION
## Summary
- add `thefuzz` dependency
- extend `parse_anlage2_text` with fuzzy matching and response rules

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ProjectStatus matching query does not exist, NameError and various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6865050155dc832b90030c713d6d6f86