### PR TITLE
Fix tab styling and save button visibility

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -121,19 +121,22 @@
 /* Tab-Navigation in Anlage 2 */
 .tab-btn {
     padding: 0.5rem 1rem;
-    color: #6b7280; /* gray-500 */
-    background: transparent;
-    border: none;
-    border-bottom: 2px solid transparent;
+    color: #4b5563; /* gray-600 */
+    background-color: #e5e7eb; /* gray-200 */
+    border: 1px solid #d1d5db; /* gray-300 */
+    border-bottom: 0;
+    border-radius: 0.5rem 0.5rem 0 0;
     cursor: pointer;
 }
 
 .tab-btn:hover {
-    color: var(--color-primary);
+    background-color: #f3f4f6; /* gray-100 */
 }
 
 .tab-active {
-    color: var(--color-primary);
-    border-bottom-color: var(--color-primary);
+    background-color: #ffffff;
+    color: #2563eb; /* blue-600 */
     font-weight: 600;
+    border-color: #d1d5db;
+    border-bottom-color: transparent;
 }

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -49,7 +49,7 @@
             </tbody>
         </table>
         </div>
-        <button type="submit" name="action" value="save_table" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+        <button type="submit" name="action" value="save_table" class="mt-6 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
     </div>
     <div id="tab-general" class="tab-content">
         <div>
@@ -81,7 +81,7 @@
             {{ config_form.parser_order }}
             {{ config_form.parser_order.errors }}
         </div>
-        <button type="submit" name="action" value="save_general" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+        <button type="submit" name="action" value="save_general" class="mt-6 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
     </div>
     <div id="tab-rules" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Parser-Antwortregeln</h2>
@@ -131,7 +131,7 @@
             </tbody>
         </table>
         </div>
-        <button type="submit" name="action" value="save_rules" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+        <button type="submit" name="action" value="save_rules" class="mt-6 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
     </div>
 </form>
 <script>


### PR DESCRIPTION
## Summary
- style tab navigation in admin area
- ensure save buttons are visible in Anlage 2 config

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: various missing data and prompts)*

------
https://chatgpt.com/codex/tasks/task_e_68651e2e4a14832bbc5c62b580c0db04