### PR TITLE
Refactor Anlage2 parser config

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1765,11 +1765,13 @@ def anlage2_config(request):
 
         if action == "save_general":
             admin_a2_logger.debug("Speichere Allgemeine Einstellungen")
-            cfg_form = Anlage2ConfigForm(request.POST, instance=cfg)
-            if cfg_form.is_valid():
-                admin_a2_logger.debug("Geänderte Felder: %r", {f: cfg_form.cleaned_data[f] for f in cfg_form.changed_data})
-                cfg_form.save()
-                return redirect(f"{reverse('anlage2_config')}?tab=general")
+            cfg.enforce_subquestion_override = bool(
+                request.POST.get("enforce_subquestion_override")
+            )
+            cfg.parser_order = request.POST.getlist("parser_order")
+            cfg.save(update_fields=["enforce_subquestion_override", "parser_order"])
+            messages.success(request, "Einstellungen gespeichert")
+            return redirect(f"{reverse('anlage2_config')}?tab=general")
 
     cfg_form = cfg_form if 'cfg_form' in locals() else Anlage2ConfigForm(instance=cfg)
     rule_formset = RuleFormSet(queryset=rules_qs, prefix="rules")

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -68,17 +68,12 @@
                 {% for val, label in parser_choices %}
                 <li class="flex items-center py-1" draggable="true" data-val="{{ val }}">
                     <span class="mr-2 cursor-move">&#x2630;</span>
-                    <input type="checkbox" class="parser-cb mr-2" {% if val in config_form.initial.parser_order %}checked{% endif %}>
+                    <input type="checkbox" name="active_parsers" value="{{ val }}" class="parser-cb mr-2" {% if val in config_form.initial.parser_order %}checked{% endif %}>
                     <span>{{ label }}</span>
                 </li>
                 {% endfor %}
             </ul>
-            <div id="parser-order-inputs">{{ config_form.parser_order }}</div>
-            {{ config_form.parser_order.errors }}
-        </div>
-        <div>
-            <label class="block">{{ config_form.parser_order.label }}</label>
-            {{ config_form.parser_order }}
+            <div id="parser-order-inputs"></div>
             {{ config_form.parser_order.errors }}
         </div>
         <button type="submit" name="action" value="save_general" class="mt-6 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>


### PR DESCRIPTION
## Summary
- rework parser list UI to be sortable with drag-and-drop
- store parser order and override flag directly in view

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: LLM prompts missing)*

------
https://chatgpt.com/codex/tasks/task_e_68653ebc1040832bb3ec10beb11441e5