### PR TITLE
Fix for HTMX partial loading on rule add

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1790,8 +1790,11 @@ def anlage2_config(request):
 
 @login_required
 @admin_required
+@require_http_methods(["GET"])
 def anlage2_rule_add(request):
     """Liefert eine leere Formularzeile für eine Antwortregel."""
+    if not request.headers.get("HX-Request"):
+        return redirect("anlage2_config")
     index = int(request.GET.get("index", 0))
     RuleFormSet = modelformset_factory(
         AntwortErkennungsRegel,


### PR DESCRIPTION
## Summary
- validate HTMX header before returning the HTML snippet for a new parser rule

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68658e6c7a28832bb3735a7eb43a9d9e