### PR TITLE
Remove old TextParser

### DIFF
--- a/core/parser_manager.py
+++ b/core/parser_manager.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Type
 
 from .models import BVProjectFile, Anlage2Config
 from .parsers import AbstractParser, TableParser
-from .text_parser import TextParser
+from .text_parser import FuzzyTextParser
 
 logger = logging.getLogger(__name__)
 
@@ -67,4 +67,4 @@ def _count_technisch_true(data: list[dict[str, object]]) -> int:
 
 parser_manager = ParserManager()
 parser_manager.register(TableParser)
-parser_manager.register(TextParser)
+parser_manager.register(FuzzyTextParser)

--- a/core/tests.py
+++ b/core/tests.py
@@ -40,7 +40,6 @@ from . import text_parser
 
 from .parser_manager import parser_manager
 from .parsers import AbstractParser
-from .text_parser import TextParser
 
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -832,7 +831,7 @@ class DocxExtractTests(NoesisTestCase):
             },
         )
 
-class TextParserFormatBTests(NoesisTestCase):
+class FormatBParserTests(NoesisTestCase):
     def test_parse_format_b_basic(self):
         text = "Login; tv: ja; tel: nein; lv: nein; ki: ja"
         data = text_parser.parse_format_b(text)
@@ -1409,31 +1408,6 @@ class LLMTasksTests(NoesisTestCase):
             cfg.save()
 
         self.assertEqual(result, [{"val": 2}])
-
-    def test_text_parser_basic(self):
-        text = (
-            "Chat: Stehen technisch zur Verf\u00fcgung und sollen verwendet werden. "
-            "Sollen zur \u00dcberwachung von Leistung oder Verhalten NICHT verwendet werden.\n"
-            "Detail?: Ja\n\n"
-            "Logging: Stehen technisch NICHT zur Verf\u00fcgung."
-        )
-        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        pf = BVProjectFile.objects.create(
-            projekt=projekt,
-            anlage_nr=2,
-            upload=SimpleUploadedFile("a.txt", b"x"),
-            text_content=text,
-        )
-        parser = TextParser()
-        data = parser.parse(pf)
-        self.assertEqual(len(data), 2)
-        self.assertEqual(data[0]["funktion"], "Chat")
-        self.assertEqual(data[0]["technisch_verfuegbar"], "Ja")
-        self.assertEqual(data[0]["soll_verwendet_werden"], "Ja")
-        self.assertEqual(data[0]["ueberwachung_leistung_verhalten"], "Nein")
-        self.assertEqual(data[0]["details"][0]["antwort_verwendung"], "Ja")
-        self.assertEqual(data[1]["technisch_verfuegbar"], "Nein")
-        self.assertEqual(data[1]["soll_verwendet_werden"], "Nein")
 
     def test_parser_manager_selects_best(self):
         class P1(AbstractParser):

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -15,104 +15,10 @@ from .models import (
     Anlage2SubQuestion,
     AntwortErkennungsRegel,
 )
-
 from .parsers import AbstractParser
 
 logger = logging.getLogger(__name__)
 parser_logger = logging.getLogger("parser_debug")
-
-
-class TextParser(AbstractParser):
-    """Parser für textbasierte Dokumente im Format B."""
-
-    name = "text"
-
-    def parse(self, project_file: BVProjectFile) -> List[dict[str, object]]:
-        """Parst den Textinhalt einer Projektdatei."""
-        text = project_file.text_content or ""
-        lines = [line.strip() for line in text.splitlines() if line.strip()]
-        results: List[dict[str, object]] = []
-        func_re = re.compile(r"^(.+?):\s*(.*)")
-        i = 0
-        while i < len(lines):
-            m = func_re.match(lines[i])
-            if not m:
-                i += 1
-                continue
-            name = m.group(1).strip()
-            sentence = m.group(2).strip()
-            technisch = _map_technisch(sentence)
-            verwenden = _map_verwendung(sentence, technisch)
-            lv = _map_lv(sentence)
-            i += 1
-            details: List[dict[str, object]] = []
-            while i < len(lines) and not func_re.match(lines[i]):
-                detail_match = re.match(r"(.+?)[:?]\s*(.*)", lines[i])
-                if detail_match:
-                    frage = detail_match.group(1).strip()
-                    antwort = detail_match.group(2).strip()
-                    antwort_verw = (
-                        "Ja" if re.search(r"\bja\b", antwort, re.I) else "Nein"
-                    )
-                    details.append(
-                        {
-                            "frage": frage,
-                            "antwort_text": antwort,
-                            "antwort_verwendung": antwort_verw,
-                        }
-                    )
-                i += 1
-            results.append(
-                {
-                    "funktion": name,
-                    "technisch_verfuegbar": technisch,
-                    "soll_verwendet_werden": verwenden,
-                    "ueberwachung_leistung_verhalten": lv,
-                    "details": details,
-                }
-            )
-        return results
-
-
-def _map_technisch(sentence: str) -> str:
-    """Ermittelt, ob eine Funktion technisch verfügbar ist."""
-    lower = sentence.lower()
-    if "stehen technisch zur ver\u00fcgung" in lower:
-        return "Ja"
-    if "stehen technisch nicht zur ver\u00fcgung" in lower:
-        return "Nein"
-    if re.search(r"\bja\b", sentence, re.I):
-        return "Ja"
-    if re.search(r"\bnein\b", sentence, re.I):
-        return "Nein"
-    return "Unbekannt"
-
-
-def _map_verwendung(sentence: str, technisch: str) -> str:
-    """Bewertet die geplante Verwendung einer Funktion."""
-    lower = sentence.lower()
-    if technisch == "Nein":
-        return "Nein"
-    if "und sollen verwendet werden" in lower:
-        return "Ja"
-    if (
-        "sollen nicht verwendet" in lower
-        or "soll aber nicht verwendet" in lower
-    ):
-        return "Nein"
-    return "Unbekannt"
-
-
-def _map_lv(sentence: str) -> str:
-    """Gibt an, ob die Funktion der Leistungs- oder
-    Verhaltenskontrolle dient."""
-    lower = sentence.lower()
-    if "\u00fcberwachung von leistung oder verhalten" in lower:
-        if "nicht verwendet" in lower:
-            return "Nein"
-        if "verwendet" in lower:
-            return "Ja"
-    return "Unbekannt"
 
 
 
@@ -310,3 +216,12 @@ def parse_anlage2_text(text: str, threshold: int = 80) -> List[dict[str, object]
             unmatched.append(entry)
 
     return list(results.values()) + unmatched
+
+
+class FuzzyTextParser(AbstractParser):
+    """Parser für Freitext mit Fuzzy-Logik."""
+
+    name = "text"
+
+    def parse(self, project_file: BVProjectFile) -> List[dict[str, object]]:
+        return parse_anlage2_text(project_file.text_content or "")


### PR DESCRIPTION
## Summary
- delete legacy `TextParser`
- introduce `FuzzyTextParser` and register it
- clean up tests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: Prompt not found etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686592dafe78832b868f988eb4543e00