### PR TITLE
Add global CSRF handler for HTMX

### DIFF
--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -13,3 +13,14 @@ function hideSpinner(buttonElement) {
     }
     buttonElement.disabled = false;
 }
+
+function getCookie(name) {
+    const match = document.cookie.match('(^|;)\\s*' + name + '=([^;]*)');
+    return match ? decodeURIComponent(match[2]) : null;
+}
+
+document.body.addEventListener('htmx:configRequest', (evt) => {
+    const token = getCookie('csrftoken');
+    if (token) evt.detail.headers['X-CSRFToken'] = token;
+});
+

--- a/templates/admin_roles.html
+++ b/templates/admin_roles.html
@@ -20,7 +20,6 @@
     {% endif %}
 </div>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 const select=document.getElementById('group-select');
 select.addEventListener('change',()=>{
     const gid=select.value;

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -27,7 +27,6 @@
     <button type="button" id="llm-check-btn" class="bg-purple-600 text-white px-4 py-2 rounded ml-2">LLM-Funktionscheck</button>
 </form>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 document.getElementById('llm-check-btn').addEventListener('click',function(){
     const btn=this;
     const form=document.getElementById('llm-check-form');

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -203,7 +203,6 @@
   </div>
 </div>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 
 function loadKnowledge(){
  fetch('{% url 'project_detail_api' projekt.pk %}')

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -40,7 +40,6 @@
     <textarea id="email-text" rows="8" class="border rounded w-full p-2 mt-4 hidden"></textarea>
 </form>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 const emailField=document.getElementById('email-text');
 document.getElementById('generate-email').addEventListener('click',function(){
     const btn=this;

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -111,21 +111,6 @@
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
-// Hilfsfunktion, um den CSRF-Token für POST-Requests zu bekommen
-function getCookie(name) {
-    let cookieValue = null;
-    if (document.cookie && document.cookie !== '') {
-        const cookies = document.cookie.split(';');
-        for (let i = 0; i < cookies.length; i++) {
-            const cookie = cookies[i].trim();
-            if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                break;
-            }
-        }
-    }
-    return cookieValue;
-}
 const csrftoken = getCookie('csrftoken');
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/templates/projekt_list.html
+++ b/templates/projekt_list.html
@@ -40,7 +40,6 @@
 
 </form>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 document.querySelectorAll('.llm-check-btn').forEach(btn=>{
   btn.addEventListener('click',ev=>{
     ev.preventDefault();


### PR DESCRIPTION
## Summary
- centralize `getCookie` helper in `utils.js`
- automatically inject CSRF token for all HTMX requests
- reuse global helper in various templates

## Testing
- `python manage.py makemigrations --check` *(fails: No module named 'django')*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6865a40443cc832b8df4ba75cb6e0788