### PR TITLE
Fix GUTACHTEN_OK status assignment

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -377,7 +377,10 @@ def generate_gutachten(
         old_path.unlink(missing_ok=True)
     doc.save(path)
     projekt.gutachten_file.name = f"gutachten/{fname}"
-    projekt.status = ProjectStatus.objects.get(key="GUTACHTEN_OK")
+    try:
+        projekt.status = ProjectStatus.objects.get(key="GUTACHTEN_OK")
+    except ProjectStatus.DoesNotExist:
+        pass
     projekt.save(update_fields=["gutachten_file", "status"])
     return path
 


### PR DESCRIPTION
## Summary
- handle missing `ProjectStatus` when setting `GUTACHTEN_OK` in `generate_gutachten`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: SSL errors while fetching external models)*

------
https://chatgpt.com/codex/tasks/task_e_6865a48f515c832b98cc916f95903e40