### PR TITLE
Improve matching strategy for Anlage 2 parser

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -734,6 +734,27 @@ class DocxExtractTests(NoesisTestCase):
             ],
         )
 
+    def test_parse_anlage2_text_prefers_specific_subquestion(self):
+        func = Anlage2Function.objects.create(name="Analyse-/Reportingfunktionen")
+        Anlage2SubQuestion.objects.create(
+            funktion=func,
+            frage_text="Bitte wähle zutreffendes aus",
+        )
+        cfg = Anlage2Config.get_instance()
+        cfg.text_technisch_verfuegbar_true = ["ja"]
+        cfg.save()
+        text = "Analyse- / Reportingfunktionen - Bitte wähle zutreffendes aus: ja"
+        data = parse_anlage2_text(text)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Analyse-/Reportingfunktionen - Bitte wähle zutreffendes aus",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                }
+            ],
+        )
+
     def test_parse_anlage2_text_merges_duplicate_functions(self):
         func = Anlage2Function.objects.create(name="Login")
         cfg = Anlage2Config.get_instance()


### PR DESCRIPTION
## Summary
- refine fuzzy matching logic in `parse_anlage2_text`
- sort known phrases by length and iterate in order
- add regression test for subquestion matching

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError, missing prompts and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686624fbe1a0832b92e2e9de82ac30af