### PR TITLE
Add global CSRF handler for HTMX

### DIFF
--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -13,3 +13,13 @@ function hideSpinner(buttonElement) {
     }
     buttonElement.disabled = false;
 }
+
+function getCookie(name) {
+    const match = document.cookie.match('(^|;)\\s*' + name + '=([^;]*)');
+    return match ? decodeURIComponent(match[2]) : null;
+}
+
+document.body.addEventListener('htmx:configRequest', (evt) => {
+    const token = getCookie('csrftoken');
+    if (token) evt.detail.headers['X-CSRFToken'] = token;
+});

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -80,12 +80,12 @@
     </div>
     <div id="tab-rules" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Parser-Antwortregeln</h2>
-        <div id="rules-container" class="overflow-x-auto" hx-target="this" hx-swap="outerHTML">
+        <div id="rules-container" class="overflow-x-auto" hx-target="this" hx-swap="innerHTML">
             {% include 'partials/_response_rules_table.html' with formset=rule_formset %}
         </div>
         <div class="mt-2 space-x-2">
             <button type="button" class="px-3 py-1 bg-gray-300 rounded" onclick="addRule()">Neue Regel hinzufügen</button>
-            <button type="submit" name="action" value="save_rules" hx-post="{% url 'anlage2_config' %}" hx-target="#rules-container" hx-swap="outerHTML" class="px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+            <button type="submit" name="action" value="save_rules" hx-post="{% url 'anlage2_config' %}" hx-target="#rules-container" hx-swap="innerHTML" class="px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
         </div>
     </div>
 </form>

--- a/templates/admin_roles.html
+++ b/templates/admin_roles.html
@@ -20,7 +20,6 @@
     {% endif %}
 </div>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 const select=document.getElementById('group-select');
 select.addEventListener('change',()=>{
     const gid=select.value;

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -27,7 +27,6 @@
     <button type="button" id="llm-check-btn" class="bg-purple-600 text-white px-4 py-2 rounded ml-2">LLM-Funktionscheck</button>
 </form>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 document.getElementById('llm-check-btn').addEventListener('click',function(){
     const btn=this;
     const form=document.getElementById('llm-check-form');

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -203,7 +203,7 @@
   </div>
 </div>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
+
 
 function loadKnowledge(){
  fetch('{% url 'project_detail_api' projekt.pk %}')

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -40,7 +40,6 @@
     <textarea id="email-text" rows="8" class="border rounded w-full p-2 mt-4 hidden"></textarea>
 </form>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 const emailField=document.getElementById('email-text');
 document.getElementById('generate-email').addEventListener('click',function(){
     const btn=this;

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -111,21 +111,6 @@
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
-// Hilfsfunktion, um den CSRF-Token für POST-Requests zu bekommen
-function getCookie(name) {
-    let cookieValue = null;
-    if (document.cookie && document.cookie !== '') {
-        const cookies = document.cookie.split(';');
-        for (let i = 0; i < cookies.length; i++) {
-            const cookie = cookies[i].trim();
-            if (cookie.substring(0, name.length + 1) === (name + '=')) {
-                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                break;
-            }
-        }
-    }
-    return cookieValue;
-}
 const csrftoken = getCookie('csrftoken');
 
 document.addEventListener('DOMContentLoaded', function() {
@@ -142,13 +127,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
             const subquestionRows = document.querySelectorAll('.' + targetClass);
 
-            let isCurrentlyHidden = Array.from(subquestionRows).some(row => row.classList.contains('hidden-row'));
+            const wasCollapsed = Array.from(subquestionRows).every(row => row.classList.contains('hidden-row'));
 
             subquestionRows.forEach(row => {
                 row.classList.toggle('hidden-row');
             });
 
-            this.textContent = isCurrentlyHidden ? '-' : '+';
+            this.textContent = wasCollapsed ? '-' : '+';
         });
     });
 

--- a/templates/projekt_list.html
+++ b/templates/projekt_list.html
@@ -40,7 +40,6 @@
 
 </form>
 <script>
-function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'=([^;]*)');return m?decodeURIComponent(m[2]):null;}
 document.querySelectorAll('.llm-check-btn').forEach(btn=>{
   btn.addEventListener('click',ev=>{
     ev.preventDefault();


### PR DESCRIPTION
## Summary
- define `getCookie` and HTMX CSRF handling in `utils.js`
- reuse `getCookie` in templates
- fix toggle button logic so collapse/expand keeps plus/minus icons in sync
- preserve rules container after saving to keep HTMX working

## Testing
- `python manage.py makemigrations --check` *(fails: ImproperlyConfigured: DJANGO_SECRET_KEY muss in der Umgebung gesetzt sein)*
- `python manage.py test` *(fails: DJANGO_SECRET_KEY muss in der Umgebung gesetzt sein)*


------
https://chatgpt.com/codex/tasks/task_e_68661f473ed0832bbf1f46a0afa3decd