### PR TITLE
Serverseitige Fallback-Regelverwaltung

### DIFF
--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -15,6 +15,7 @@
         <button type="button" data-tab="table" class="tab-btn">Tabellen-Parser</button>
         <button type="button" data-tab="general" class="tab-btn">Allgemein</button>
         <button type="button" data-tab="rules" class="tab-btn">Parser-Antwortregeln</button>
+        <button type="button" data-tab="rules2" class="tab-btn">Regeln Fallback</button>
     </nav>
     <div id="tab-table" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Tabellen-Parser: Spaltenüberschriften (Alias)</h2>
@@ -84,9 +85,17 @@
             {% include 'partials/_response_rules_table.html' with formset=rule_formset %}
         </div>
         <div class="mt-2 space-x-2">
-            <button type="button" class="px-3 py-1 bg-gray-300 rounded" onclick="addRule()">Neue Regel hinzufügen</button>
-            <button type="submit" name="action" value="save_rules" hx-post="{% url 'anlage2_config' %}" hx-target="#rules-container" hx-swap="innerHTML" class="px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+            <!-- HTMX-Funktion vorübergehend deaktiviert -->
+            <button type="button" class="px-3 py-1 bg-gray-300 rounded" disabled>Neue Regel hinzufügen</button>
+            <button type="submit" name="action" value="save_rules" class="px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
         </div>
+    </div>
+    <div id="tab-rules2" class="tab-content">
+        <h2 class="text-xl font-semibold mb-2">Parser-Antwortregeln (Fallback)</h2>
+        <div class="overflow-x-auto">
+            {% include 'partials/_response_rules_table_simple.html' with formset=rule_formset_fb %}
+        </div>
+        <button type="submit" name="action" value="save_rules_fb" class="mt-2 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
     </div>
 </form>
 <script>
@@ -149,46 +158,7 @@ list.addEventListener('drop',e=>{e.preventDefault();updateParserInputs();});
 list.addEventListener('change',updateParserInputs);
 updateParserInputs();
 
-function updateOrder(){
-    document.querySelectorAll('#rule-rows tr').forEach((tr,idx)=>{
-        const inp=tr.querySelector('input[name$="-ORDER"]');
-        if(inp){inp.value=idx;}
-    });
-}
-
-function updateTotals(){
-    const total=document.getElementById('id_rules-TOTAL_FORMS');
-    if(total){total.value=document.querySelectorAll('#rule-rows tr').length;}
-    updateOrder();
-}
-
-let ruleSortable;
-function initializeSortable(){
-    const tbody=document.getElementById('rule-rows');
-    if(tbody){
-        if(ruleSortable){ruleSortable.destroy();}
-        ruleSortable=Sortable.create(tbody,{handle:'.drag-handle',animation:150,onSort:updateOrder});
-        updateTotals();
-    }
-}
-
-function addRule(){
-    const total=document.getElementById('id_rules-TOTAL_FORMS');
-    const idx=parseInt(total.value);
-    htmx.ajax('GET','{% url 'anlage2_rule_add' %}?index='+idx,{target:'#rule-rows',swap:'beforeend'});
-    total.value=idx+1;
-}
-
-document.addEventListener('DOMContentLoaded',function(){
-    initializeSortable();
-    const tbody=document.getElementById('rule-rows');
-    if(tbody){
-        tbody.addEventListener('htmx:afterSwap',initializeSortable);
-    }
-});
+// Deaktivierter HTMX-Code für die Regelverwaltung
 </script>
 {% endblock %}
-{% block extra_js %}
-<script src="https://unpkg.com/htmx.org@1.9.10"></script>
-<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-{% endblock %}
+{% block extra_js %}{% endblock %}

--- a/templates/partials/_response_rule_row_simple.html
+++ b/templates/partials/_response_rule_row_simple.html
@@ -1,0 +1,9 @@
+<tr class="border-b text-sm">
+    {{ form.id }}
+    {{ form.ORDER }}
+    <td class="py-1">{{ form.regel_name }}</td>
+    <td class="py-1">{{ form.erkennungs_phrase }}</td>
+    <td class="py-1">{{ form.ziel_feld }}</td>
+    <td class="py-1 text-center">{{ form.wert }}</td>
+    <td class="py-1 text-center">{{ form.DELETE }}</td>
+</tr>

--- a/templates/partials/_response_rules_table_simple.html
+++ b/templates/partials/_response_rules_table_simple.html
@@ -1,0 +1,19 @@
+{{ formset.management_form }}
+<table class="min-w-full mb-4">
+    <thead>
+        <tr class="border-b text-left">
+            <th class="py-2">Name</th>
+            <th class="py-2">Phrase</th>
+            <th class="py-2">Ziel-Feld</th>
+            <th class="py-2">Wert</th>
+            <th class="py-2 text-center">Entfernen</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for form in formset %}
+            {% include 'partials/_response_rule_row_simple.html' with form=form %}
+        {% empty %}
+        <tr><td colspan="5">Keine Regeln</td></tr>
+        {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
## Summary
- ergänze eine serverseitige Variante zum Hinzufügen von Parser-Antwortregeln
- binde neuen "Regeln Fallback"-Tab auf der Anlage2-Konfigurationsseite ein
- deaktiviere die fehlerhafte HTMX-Funktion vorübergehend

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68665efa0bb0832ba642e105f35fd004