### PR TITLE
Fix deletion bug in rule management

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1758,8 +1758,6 @@ def anlage2_config(request):
                     obj = form.save(commit=False)
                     obj.prioritaet = idx
                     obj.save()
-                for obj in formset.deleted_objects:
-                    obj.delete()
                 messages.success(request, "Antwortregeln gespeichert")
             else:
                 messages.error(request, "Ungültige Eingaben")
@@ -1783,8 +1781,6 @@ def anlage2_config(request):
                     obj = form.save(commit=False)
                     obj.prioritaet = idx
                     obj.save()
-                for obj in formset.deleted_objects:
-                    obj.delete()
                 messages.success(request, "Antwortregeln gespeichert")
             else:
                 messages.error(request, "Ungültige Eingaben")


### PR DESCRIPTION
## Summary
- remove access to undefined `deleted_objects` on response rule formsets

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68666ea28cb4832ba5319aee7fbdf940