### PR TITLE
Verbesserte Fehlerausgabe im Fallback

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1786,9 +1786,10 @@ def anlage2_config(request):
                 for obj in formset.deleted_objects:
                     obj.delete()
                 messages.success(request, "Antwortregeln gespeichert")
-            else:
-                messages.error(request, "Ungültige Eingaben")
-            return redirect(f"{reverse('anlage2_config')}?tab=rules2")
+                return redirect(f"{reverse('anlage2_config')}?tab=rules2")
+            messages.error(request, "Bitte korrigieren Sie die markierten Felder.")
+            rule_formset_fb = formset
+            active_tab = "rules2"
 
         if action == "save_general":
             admin_a2_logger.debug("Speichere Allgemeine Einstellungen")
@@ -1802,7 +1803,11 @@ def anlage2_config(request):
 
     cfg_form = cfg_form if 'cfg_form' in locals() else Anlage2ConfigForm(instance=cfg)
     rule_formset = RuleFormSet(queryset=rules_qs, prefix="rules")
-    rule_formset_fb = RuleFormSetFB(queryset=rules_qs, prefix="rules_fb")
+    rule_formset_fb = (
+        rule_formset_fb
+        if "rule_formset_fb" in locals()
+        else RuleFormSetFB(queryset=rules_qs, prefix="rules_fb")
+    )
     context = {
         "config": cfg,
         "config_form": cfg_form,

--- a/templates/partials/_response_rule_row_simple.html
+++ b/templates/partials/_response_rule_row_simple.html
@@ -1,9 +1,22 @@
 <tr class="border-b text-sm">
     {{ form.id }}
     {{ form.ORDER }}
-    <td class="py-1">{{ form.regel_name }}</td>
-    <td class="py-1">{{ form.erkennungs_phrase }}</td>
-    <td class="py-1">{{ form.ziel_feld }}</td>
-    <td class="py-1 text-center">{{ form.wert }}</td>
+    {{ form.non_field_errors }}
+    <td class="py-1">
+        {{ form.regel_name }}
+        {{ form.regel_name.errors }}
+    </td>
+    <td class="py-1">
+        {{ form.erkennungs_phrase }}
+        {{ form.erkennungs_phrase.errors }}
+    </td>
+    <td class="py-1">
+        {{ form.ziel_feld }}
+        {{ form.ziel_feld.errors }}
+    </td>
+    <td class="py-1 text-center">
+        {{ form.wert }}
+        {{ form.wert.errors }}
+    </td>
     <td class="py-1 text-center">{{ form.DELETE }}</td>
 </tr>

--- a/templates/partials/_response_rules_table_simple.html
+++ b/templates/partials/_response_rules_table_simple.html
@@ -1,4 +1,5 @@
 {{ formset.management_form }}
+{{ formset.non_form_errors }}
 <table class="min-w-full mb-4">
     <thead>
         <tr class="border-b text-left">


### PR DESCRIPTION
## Summary
- besseres Fehlermanagement beim Speichern der Fallback-Regeln
- Fehlermeldungen direkt in den Regelzeilen anzeigen

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(scheitert: diverse Tests schlagen fehl)*

------
https://chatgpt.com/codex/tasks/task_e_686671e20010832b9392ecd97f845944