### PR TITLE
Fix deletion handling in anlage2 config

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1758,8 +1758,8 @@ def anlage2_config(request):
                     obj = form.save(commit=False)
                     obj.prioritaet = idx
                     obj.save()
-                for obj in formset.deleted_objects:
-                    obj.delete()
+                for form in formset.deleted_forms:
+                    form.instance.delete()
                 messages.success(request, "Antwortregeln gespeichert")
             else:
                 messages.error(request, "Ungültige Eingaben")
@@ -1783,8 +1783,8 @@ def anlage2_config(request):
                     obj = form.save(commit=False)
                     obj.prioritaet = idx
                     obj.save()
-                for obj in formset.deleted_objects:
-                    obj.delete()
+                for form in formset.deleted_forms:
+                    form.instance.delete()
                 messages.success(request, "Antwortregeln gespeichert")
                 return redirect(f"{reverse('anlage2_config')}?tab=rules2")
             messages.error(request, "Bitte korrigieren Sie die markierten Felder.")


### PR DESCRIPTION
## Summary
- handle deleted forms using `deleted_forms`

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686680772dc0832baf157365da9532c4