### PR TITLE
Fix missing Anlage4ReviewForm import

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -29,6 +29,7 @@ from .forms import (
     BVProjectFileJSONForm,
     Anlage1ReviewForm,
     Anlage2ReviewForm,
+    Anlage4ReviewForm,
     get_anlage2_fields,
     Anlage2FunctionForm,
     Anlage2FunctionImportForm,


### PR DESCRIPTION
## Summary
- include `Anlage4ReviewForm` in forms import list

## Testing
- `python manage.py makemigrations --check` *(fails: DJANGO_SECRET_KEY not set)*
- `python manage.py test` *(fails: DJANGO_SECRET_KEY not set)*


------
https://chatgpt.com/codex/tasks/task_e_686775b456b8832b9bc76362e79edaf0