### PR TITLE
Improve Anlage4 logging details

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -931,10 +931,11 @@ def worker_anlage4_evaluate(
     """Bewertet einen Zweck aus Anlage 4 im Hintergrund."""
 
     anlage4_logger.info(
-        "worker_anlage4_evaluate gestartet für Datei %s Index %s",
+        "worker_anlage4_evaluate gestartet f\u00fcr Datei %s Index %s",
         project_file_id,
         index,
     )
+    anlage4_logger.debug("Pr\u00fcfe Zweck #%s: %s", index, item_text)
 
     pf = BVProjectFile.objects.get(pk=project_file_id)
     cfg = pf.anlage4_config or Anlage4Config.objects.first()
@@ -957,6 +958,7 @@ def worker_anlage4_evaluate(
     except Exception:  # noqa: BLE001
         data = {"raw": reply}
     anlage4_logger.debug("Anlage4 Parsed JSON #%s: %s", index, data)
+    anlage4_logger.debug("Ergebnis f\u00fcr Zweck #%s: %s", index, data)
 
     analysis = pf.analysis_json or {}
     zwecke = analysis.get("zwecke") or []


### PR DESCRIPTION
## Summary
- add configuration and pattern matching logs for Anlage 4 parser
- log the checked item and result in `worker_anlage4_evaluate`

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6867a83c0444832b8ff26f1d273e2fea