### PR TITLE
Implement Anlage4 prompt template config

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -16,7 +16,6 @@ from .models import (
     Anlage2FunctionResult,
     FormatBParserRule,
     AntwortErkennungsRegel,
-    Anlage4Config,
     Anlage4ParserConfig,
 )
 
@@ -212,18 +211,6 @@ class AntwortErkennungsRegelAdmin(admin.ModelAdmin):
     list_editable = ("ziel_feld", "wert", "prioritaet")
 
 
-class Anlage4ConfigForm(forms.ModelForm):
-    class Meta:
-        model = Anlage4Config
-        fields = "__all__"
-        widgets = {
-            "prompt_template": forms.Textarea(attrs={"rows": 4}),
-        }
-
-
-@admin.register(Anlage4Config)
-class Anlage4ConfigAdmin(admin.ModelAdmin):
-    form = Anlage4ConfigForm
 
 
 class Anlage4ParserConfigForm(forms.ModelForm):

--- a/core/forms.py
+++ b/core/forms.py
@@ -18,6 +18,7 @@ from .models import (
     Tile,
     FormatBParserRule,
     AntwortErkennungsRegel,
+    Anlage4Config,
 )
 from django.contrib.auth.models import Group
 from .parser_manager import parser_manager
@@ -656,6 +657,17 @@ class Anlage2ConfigImportForm(forms.Form):
         label="JSON-Datei",
         widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
     )
+
+
+class Anlage4ConfigForm(forms.ModelForm):
+    """Formular für die Anlage-4-Konfiguration."""
+
+    class Meta:
+        model = Anlage4Config
+        fields = "__all__"
+        widgets = {
+            "prompt_template": forms.Textarea(attrs={"rows": 4}),
+        }
 
 
 class AntwortErkennungsRegelForm(forms.ModelForm):

--- a/core/views.py
+++ b/core/views.py
@@ -76,6 +76,7 @@ from .models import (
     LLMRole,
     FormatBParserRule,
     AntwortErkennungsRegel,
+    Anlage4Config,
 )
 from .docx_utils import extract_text
 from .llm_utils import query_llm
@@ -1185,6 +1186,7 @@ def admin_prompts(request):
     """Verwaltet die gespeicherten Prompts."""
     prompts = list(Prompt.objects.all().order_by("name"))
     roles = list(LLMRole.objects.all().order_by("name"))
+    a4_cfg = Anlage4Config.objects.first() or Anlage4Config.objects.create()
     groups = {
         "general": [],
         "anlage1": [],
@@ -1214,6 +1216,10 @@ def admin_prompts(request):
     if request.method == "POST":
         pk = request.POST.get("pk")
         action = request.POST.get("action")
+        if action == "save_a4_config":
+            a4_cfg.prompt_template = request.POST.get("prompt_template", "")
+            a4_cfg.save(update_fields=["prompt_template"])
+            return redirect("admin_prompts")
         if pk:
             try:
                 prompt = Prompt.objects.get(pk=pk)
@@ -1241,7 +1247,7 @@ def admin_prompts(request):
 
     grouped = [(key, label, groups[key]) for key, label in labels]
 
-    context = {"grouped": grouped, "roles": roles}
+    context = {"grouped": grouped, "roles": roles, "a4_config": a4_cfg}
     return render(request, "admin_prompts.html", context)
 
 

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -67,6 +67,19 @@
         {% empty %}
             <tr><td colspan="4" class="py-2">Keine Prompts</td></tr>
         {% endfor %}
+        {% if key == 'anlage4' %}
+            <tr class="border-b align-top text-sm">
+                <td class="py-1 font-semibold">Prompt Template</td>
+                <td colspan="4" class="py-1">
+                    <form method="post" class="space-y-2">
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="save_a4_config">
+                        <textarea name="prompt_template" rows="4" class="border rounded p-2 w-full text-gray-900">{{ a4_config.prompt_template }}</textarea>
+                        <button class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
+                    </form>
+                </td>
+            </tr>
+        {% endif %}
         </tbody>
     </table>
     </div>


### PR DESCRIPTION
## Summary
- remove `Anlage4Config` admin registration
- move `Anlage4ConfigForm` into `forms.py`
- load Anlage4 config in `admin_prompts` view
- let `admin_prompts.html` edit the prompt template

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError & other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68698cba1de0832ba8712285cb905a3c