### PR TITLE
Move parser and prompt configuration to project admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -16,7 +16,6 @@ from .models import (
     Anlage2FunctionResult,
     FormatBParserRule,
     AntwortErkennungsRegel,
-    Anlage4ParserConfig,
 )
 
 
@@ -211,21 +210,6 @@ class AntwortErkennungsRegelAdmin(admin.ModelAdmin):
     list_editable = ("ziel_feld", "wert", "prioritaet")
 
 
-
-
-class Anlage4ParserConfigForm(forms.ModelForm):
-    class Meta:
-        model = Anlage4ParserConfig
-        fields = "__all__"
-        widgets = {
-            "prompt_extraction": forms.Textarea(attrs={"rows": 4}),
-            "prompt_plausibility": forms.Textarea(attrs={"rows": 4}),
-        }
-
-
-@admin.register(Anlage4ParserConfig)
-class Anlage4ParserConfigAdmin(admin.ModelAdmin):
-    form = Anlage4ParserConfigForm
 
 
 # Registrierung der Modelle

--- a/core/forms.py
+++ b/core/forms.py
@@ -19,6 +19,7 @@ from .models import (
     FormatBParserRule,
     AntwortErkennungsRegel,
     Anlage4Config,
+    Anlage4ParserConfig,
 )
 from django.contrib.auth.models import Group
 from .parser_manager import parser_manager
@@ -667,6 +668,30 @@ class Anlage4ConfigForm(forms.ModelForm):
         fields = "__all__"
         widgets = {
             "prompt_template": forms.Textarea(attrs={"rows": 4}),
+        }
+
+
+class Anlage4ParserPromptForm(forms.ModelForm):
+    """Formular zum Bearbeiten der Anlage-4-Prompts."""
+
+    class Meta:
+        model = Anlage4ParserConfig
+        fields = ["prompt_extraction", "prompt_plausibility"]
+        widgets = {
+            "prompt_extraction": forms.Textarea(attrs={"rows": 4}),
+            "prompt_plausibility": forms.Textarea(attrs={"rows": 4}),
+        }
+
+
+class Anlage4ParserConfigForm(forms.ModelForm):
+    """Formular für die Anlage-4-Parser-Konfiguration."""
+
+    class Meta:
+        model = Anlage4ParserConfig
+        fields = ["table_columns", "text_rules"]
+        widgets = {
+            "table_columns": forms.Textarea(attrs={"rows": 4}),
+            "text_rules": forms.Textarea(attrs={"rows": 4}),
         }
 
 

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -16,6 +16,7 @@
         <button type="button" data-tab="general" class="tab-btn">Allgemein</button>
         <button type="button" data-tab="rules" class="tab-btn">Parser-Antwortregeln</button>
         <button type="button" data-tab="rules2" class="tab-btn">Regeln Fallback</button>
+        <button type="button" data-tab="a4" class="tab-btn">Anlage 4 Parser</button>
     </nav>
     <div id="tab-table" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Tabellen-Parser: Spaltenüberschriften (Alias)</h2>
@@ -96,6 +97,22 @@
             {% include 'partials/_response_rules_table_simple.html' with formset=rule_formset_fb %}
         </div>
         <button type="submit" name="action" value="save_rules_fb" class="mt-2 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+    </div>
+    <div id="tab-a4" class="tab-content">
+        <h2 class="text-xl font-semibold mb-2">Anlage 4 Parser</h2>
+        <div class="space-y-4">
+            <div>
+                <label>{{ a4_parser_form.table_columns.label }}</label>
+                {{ a4_parser_form.table_columns }}
+                {{ a4_parser_form.table_columns.errors }}
+            </div>
+            <div>
+                <label>{{ a4_parser_form.text_rules.label }}</label>
+                {{ a4_parser_form.text_rules }}
+                {{ a4_parser_form.text_rules.errors }}
+            </div>
+            <button type="submit" name="action" value="save_a4" class="px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+        </div>
     </div>
 </form>
 <script>

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -79,6 +79,30 @@
                     </form>
                 </td>
             </tr>
+            <tr class="border-b align-top text-sm">
+                <td class="py-1 font-semibold">Parser Prompt Extraktion</td>
+                <td colspan="4" class="py-1">
+                    <form method="post" class="space-y-2">
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="save_a4_parser_prompts">
+                        <input type="hidden" name="field" value="prompt_extraction">
+                        <textarea name="prompt_text" rows="4" class="border rounded p-2 w-full text-gray-900">{{ a4_parser.prompt_extraction }}</textarea>
+                        <button class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
+                    </form>
+                </td>
+            </tr>
+            <tr class="border-b align-top text-sm">
+                <td class="py-1 font-semibold">Parser Prompt Plausibilitätscheck</td>
+                <td colspan="4" class="py-1">
+                    <form method="post" class="space-y-2">
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="save_a4_parser_prompts">
+                        <input type="hidden" name="field" value="prompt_plausibility">
+                        <textarea name="prompt_text" rows="4" class="border rounded p-2 w-full text-gray-900">{{ a4_parser.prompt_plausibility }}</textarea>
+                        <button class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
+                    </form>
+                </td>
+            </tr>
         {% endif %}
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- integrate Anlage 4 parser prompts with project admin
- add forms to edit Anlage 4 parser configuration
- extend project admin views and templates
- remove old admin registration for parser config

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django_q')*


------
https://chatgpt.com/codex/tasks/task_e_68699098c108832b94b4e31540bc24ef