### PR TITLE
Add config parameter for Anlage4 parser

### DIFF
--- a/core/anlage4_parser.py
+++ b/core/anlage4_parser.py
@@ -11,10 +11,13 @@ from thefuzz import fuzz
 logger = logging.getLogger("anlage4_debug")
 
 
-def parse_anlage4(project_file: BVProjectFile) -> List[str]:
+def parse_anlage4(
+    project_file: BVProjectFile, cfg: Anlage4Config | None = None
+) -> List[str]:
     """Parst Anlage 4 anhand der Konfiguration."""
     logger.info("parse_anlage4 gestartet für Datei %s", project_file.pk)
-    cfg = project_file.anlage4_config or Anlage4Config.objects.first()
+    if cfg is None:
+        cfg = project_file.anlage4_config or Anlage4Config.objects.first()
     columns = [c.lower() for c in (cfg.table_columns if cfg else [])]
     neg_patterns = [re.compile(p, re.I) for p in (cfg.negative_patterns if cfg else [])]
     patterns = [re.compile(p, re.I) for p in (cfg.regex_patterns if cfg else [])]

--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -895,9 +895,9 @@ def analyse_anlage4(projekt_id: int, model_name: str | None = None) -> dict:
     except BVProjectFile.DoesNotExist as exc:  # pragma: no cover - selten
         raise ValueError("Anlage 4 fehlt") from exc
 
-    zwecke = parse_anlage4(anlage)
-    anlage4_logger.debug("Gefundene Zwecke: %s", zwecke)
     cfg = anlage.anlage4_config or Anlage4Config.objects.first()
+    zwecke = parse_anlage4(anlage, cfg)
+    anlage4_logger.debug("Gefundene Zwecke: %s", zwecke)
     template = (
         cfg.prompt_template
         if cfg and cfg.prompt_template
@@ -1069,7 +1069,8 @@ def analyse_anlage4_async(projekt_id: int, model_name: str | None = None) -> dic
     except BVProjectFile.DoesNotExist as exc:  # pragma: no cover - selten
         raise ValueError("Anlage 4 fehlt") from exc
 
-    zwecke = parse_anlage4(anlage)
+    cfg = anlage.anlage4_config or Anlage4Config.objects.first()
+    zwecke = parse_anlage4(anlage, cfg)
     anlage4_logger.debug("Async gefundene Zwecke: %s", zwecke)
     items = [{"text": z} for z in zwecke]
     anlage.analysis_json = {"zwecke": items}


### PR DESCRIPTION
## Summary
- extend `parse_anlage4` with optional config parameter
- use this config in `analyse_anlage4` and `analyse_anlage4_async`
- adjust tests and add test for config forwarding

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: UnboundLocalError and other failures)*


------
https://chatgpt.com/codex/tasks/task_e_6869a32fa6dc832bb879c3f32c689feb