### PR TITLE
Fix lookup_key initialization in projekt_file_edit_json

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2683,10 +2683,10 @@ def projekt_file_edit_json(request, pk):
                     debug_logger.info("-> Ergebnis: Im Dokument gefunden.")
                 else:
                     debug_logger.info("-> Ergebnis: Nicht im Dokument gefunden.")
-            rows.append(
-                _build_row_data(
-                    sub.frage_text,
-                    lookup_key,
+                rows.append(
+                    _build_row_data(
+                        sub.frage_text,
+                        lookup_key,
                         func.id,
                         f"sub{sub.id}_",
                         form,
@@ -2695,10 +2695,10 @@ def projekt_file_edit_json(request, pk):
                         beteilig_map,
                         analysis_lookup,
                         verification_lookup,
-                    manual_lookup,
-                    sub_id=sub.id,
+                        manual_lookup,
+                        sub_id=sub.id,
+                    )
                 )
-            )
     elif anlage.anlage_nr == 4:
         items = []
         if anlage.analysis_json:


### PR DESCRIPTION
## Summary
- ensure `lookup_key` is assigned for every subquestion
- indent code properly inside the loop

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: UnboundLocalError, missing prompts, and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686a5c1310dc832bb58ee278761df15f