### PR TITLE
Fix parse_anlage2_text import in tests

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -38,6 +38,7 @@ from .docx_utils import (
 )
 
 from . import text_parser
+from core.text_parser import parse_anlage2_text
 from .anlage4_parser import parse_anlage4
 
 from .parser_manager import parser_manager


### PR DESCRIPTION
## Summary
- import `parse_anlage2_text` directly in `core/tests.py`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: various errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a5fd66acc832b9e0ebace2c3a02c9