### PR TITLE
Fix JSON editing for Anlage 4

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -26,6 +26,7 @@ from .models import (
     BVSoftware,
     Gutachten,
     FormatBParserRule,
+    AntwortErkennungsRegel,
     Anlage4Config,
 )
 from .docx_utils import (
@@ -38,6 +39,7 @@ from .docx_utils import (
 )
 
 from . import text_parser
+from .text_parser import parse_anlage2_text
 from .anlage4_parser import parse_anlage4
 
 from .parser_manager import parser_manager

--- a/core/views.py
+++ b/core/views.py
@@ -2708,11 +2708,18 @@ def projekt_file_edit_json(request, pk):
         if not items:
             items = []
         if request.method == "POST":
-            form = Anlage4ReviewForm(request.POST, items=items)
-            if form.is_valid():
-                anlage.manual_analysis_json = form.get_json()
-                anlage.save(update_fields=["manual_analysis_json"])
-                return redirect("projekt_detail", pk=anlage.projekt.pk)
+            if "analysis_json" in request.POST or "manual_analysis_json" in request.POST:
+                json_form = BVProjectFileJSONForm(request.POST, instance=anlage)
+                if json_form.is_valid():
+                    json_form.save()
+                    return redirect("projekt_detail", pk=anlage.projekt.pk)
+                form = json_form
+            else:
+                form = Anlage4ReviewForm(request.POST, items=items)
+                if form.is_valid():
+                    anlage.manual_analysis_json = form.get_json()
+                    anlage.save(update_fields=["manual_analysis_json"])
+                    return redirect("projekt_detail", pk=anlage.projekt.pk)
         else:
             form = Anlage4ReviewForm(initial=anlage.manual_analysis_json, items=items)
         template = "projekt_file_anlage4_review.html"

--- a/templates/projekt_file_anlage4_review.html
+++ b/templates/projekt_file_anlage4_review.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 {% load recording_extras %}
+{% block extra_head %}
+{{ block.super }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+{% endblock %}
 {% block title %}Anlage 4 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 4 Zwecke prüfen</h1>


### PR DESCRIPTION
## Summary
- import `parse_anlage2_text` and `AntwortErkennungsRegel` in tests
- allow JSON editing for Anlage 4 files
- show markdown editor on the Anlage 4 review page

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.ProjektFileJSONEditTests.test_edit_json_updates_and_reports core.tests.ProjektFileJSONEditTests.test_invalid_json_shows_error core.tests.ProjektFileJSONEditTests.test_edit_page_has_mde`

------
https://chatgpt.com/codex/tasks/task_e_686a60c28170832bba6d833c3e11ddfa