### PR TITLE
Fix lookup key creation for Anlage 2 rows

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -2377,6 +2377,15 @@ class Anlage2ReviewTests(NoesisTestCase):
         field = f"func{self.func.id}_technisch_vorhanden"
         self.assertTrue(resp.context["form"].initial[field])
 
+    def test_rows_include_lookup_key(self):
+        url = reverse("projekt_file_edit_json", args=[self.file.pk])
+        resp = self.client.get(url)
+        rows = resp.context["rows"]
+        self.assertEqual(rows[0]["verif_key"], self.func.name)
+        self.assertEqual(
+            rows[1]["verif_key"], f"{self.func.name}: {self.sub.frage_text}"
+        )
+
 
 class WorkerGenerateGutachtenTests(NoesisTestCase):
     def setUp(self):

--- a/core/views.py
+++ b/core/views.py
@@ -2654,15 +2654,16 @@ def projekt_file_edit_json(request, pk):
         fields_def = get_anlage2_fields()
 
         for func in Anlage2Function.objects.order_by("name"):
+            lookup_key = func.name
             debug_logger.info("--- Starte Prüfung für Funktion: '%s' ---", func.name)
-            if answers.get(func.name):
+            if answers.get(lookup_key):
                 debug_logger.info("-> Ergebnis: Im Dokument gefunden.")
             else:
                 debug_logger.info("-> Ergebnis: Nicht im Dokument gefunden.")
             rows.append(
                 _build_row_data(
                     func.name,
-                    func.name,
+                    lookup_key,
                     func.id,
                     f"func{func.id}_",
                     form,


### PR DESCRIPTION
## Summary
- ensure `lookup_key` is declared before being used when building Anlage‑2 rows
- test that the view populates lookup keys for rows

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: UNIQUE constraint failed ...)*

------
https://chatgpt.com/codex/tasks/task_e_686a6a6e48d0832ba8ab94ec40a5b932