### PR TITLE
Use LLMConfig.get_instance in tests

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -377,6 +377,11 @@ class LLMConfig(models.Model):
         return "LLMConfig"
 
     @classmethod
+    def get_instance(cls) -> "LLMConfig":
+        """Liefert die einzige vorhandene Konfiguration oder legt sie an."""
+        return cls.objects.first() or cls.objects.create()
+
+    @classmethod
     def get_default(cls, kind: str = "default") -> str:
         """Gibt das Standardmodell für einen Typ zurück."""
         from django.conf import settings

--- a/core/tests.py
+++ b/core/tests.py
@@ -3090,7 +3090,10 @@ class ModelSelectionTests(NoesisTestCase):
             mock_func.return_value = {"task": "check_anlage1"}
             resp = self.client.post(url, {"model_category": "anlagen"})
         self.assertEqual(resp.status_code, 200)
-        mock_func.assert_called_with(self.projekt.pk, model_name="a")
+        mock_func.assert_called_with(
+            self.projekt.pk,
+            model_name=LLMConfig.get_instance().anlagen_model,
+        )
 
     def test_forms_show_categories(self):
         edit_url = reverse("projekt_edit", args=[self.projekt.pk])


### PR DESCRIPTION
## Summary
- add a `get_instance` helper to `LLMConfig`
- use the dynamic anlagen model in `ModelSelectionTests`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: failures=25, errors=13)*

------
https://chatgpt.com/codex/tasks/task_e_686a6d7e175c832b88abdf65e2e01aa0