### PR TITLE
Fix Anlage 4 table parsing

### DIFF
--- a/core/anlage4_parser.py
+++ b/core/anlage4_parser.py
@@ -49,24 +49,21 @@ def parse_anlage4(
         try:
             doc = Document(str(path))
             for table in doc.tables:
-                headers = [cell.text.strip().lower() for cell in table.rows[0].cells]
-                logger.debug(
-                    "Vergleiche Tabellen-Header %s mit Konfig %s", headers, columns
-                )
-                match_cols = [i for i, h in enumerate(headers) if h in columns]
-                if not match_cols:
-                    continue
-                structure = "table detected"
-                idx = match_cols[0]
-                logger.debug(
-                    "Nutze Spalte %s (%s)", idx, headers[idx]
-                )
-                for row in table.rows[1:]:
-                    val = row.cells[idx].text.strip()
-                    if val:
-                        logger.debug("Gefundener Tabellenwert: %s", val)
-                        items.append(val)
-                if items:
+                logger.debug("Prüfe Tabelle mit %s Zeilen", len(table.rows))
+                found = False
+                for row in table.rows:
+                    if len(row.cells) < 2:
+                        continue
+                    key = row.cells[0].text.strip().lower()
+                    if key in columns:
+                        value = row.cells[1].text.strip()
+                        if value:
+                            if not found:
+                                structure = "table detected"
+                                found = True
+                            logger.debug("Gefundenes Paar %s: %s", key, value)
+                            items.append(value)
+                if found and items:
                     logger.debug("%s - %s items", structure, len(items))
                     return items
         except Exception as exc:  # pragma: no cover - ungültige Datei
@@ -107,16 +104,17 @@ def parse_anlage4_dual(project_file: BVProjectFile) -> List[str]:
         try:
             doc = Document(str(path))
             for table in doc.tables:
-                headers = [cell.text.strip().lower() for cell in table.rows[0].cells]
-                match_cols = [i for i, h in enumerate(headers) if h in columns]
-                if not match_cols:
-                    continue
-                idx = match_cols[0]
+                logger.debug("Dual Parser prüft Tabelle mit %s Zeilen", len(table.rows))
                 items = []
-                for row in table.rows[1:]:
-                    val = row.cells[idx].text.strip()
-                    if val:
-                        items.append(val)
+                for row in table.rows:
+                    if len(row.cells) < 2:
+                        continue
+                    key = row.cells[0].text.strip().lower()
+                    if key in columns:
+                        value = row.cells[1].text.strip()
+                        if value:
+                            logger.debug("Dual Parser gefundenes Paar %s: %s", key, value)
+                            items.append(value)
                 if items:
                     logger.debug("Tabelle erkannt - %s Items", len(items))
                     return items

--- a/core/tests.py
+++ b/core/tests.py
@@ -3687,9 +3687,9 @@ class Anlage4ParserTests(NoesisTestCase):
             regex_patterns=[r"Zweck: (.+)"]
         )
         doc = Document()
-        table = doc.add_table(rows=2, cols=1)
+        table = doc.add_table(rows=1, cols=2)
         table.cell(0, 0).text = "Zweck"
-        table.cell(1, 0).text = "A"
+        table.cell(0, 1).text = "A"
         tmp = NamedTemporaryFile(delete=False, suffix=".docx")
         doc.save(tmp.name)
         tmp.close()
@@ -3709,9 +3709,9 @@ class Anlage4ParserTests(NoesisTestCase):
     def test_logs_table_detection(self):
         cfg = Anlage4Config.objects.create(table_columns=["zweck"])
         doc = Document()
-        table = doc.add_table(rows=2, cols=1)
+        table = doc.add_table(rows=1, cols=2)
         table.cell(0, 0).text = "Zweck"
-        table.cell(1, 0).text = "A"
+        table.cell(0, 1).text = "A"
         tmp = NamedTemporaryFile(delete=False, suffix=".docx")
         doc.save(tmp.name)
         tmp.close()


### PR DESCRIPTION
## Summary
- update the parser for Anlage 4 to read vertical tables
- adapt the dual parser to the same format
- adjust parser tests to match vertical layout

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: errors=13, failures=25)*

------
https://chatgpt.com/codex/tasks/task_e_686a73373b40832b8e325625b7af5de9