### PR TITLE
Fix failing setUpTestData

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -176,9 +176,6 @@ class NoesisTestCase(TestCase):
         )
 
 
-        self.assertIsNone(self.projekt.classification_json)
-
-
 class BVProjectFileTests(NoesisTestCase):
     def test_create_project_with_files(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")


### PR DESCRIPTION
## Summary
- remove stray instance attribute assertion from `NoesisTestCase.setUpTestData`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError and AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_686a88637844832bb024f8ea8520d1a0