### PR TITLE
Improve Anlage4 dual parser validation

### DIFF
--- a/core/anlage4_parser.py
+++ b/core/anlage4_parser.py
@@ -125,7 +125,14 @@ def parse_anlage4_dual(project_file: BVProjectFile) -> List[str]:
     logger.debug("Rohtext f\u00fcr Dual-Parser (%s Zeichen): %s", len(text), text)
     blocks: list[str] = []
     current: list[str] = []
-    name_keys = [r["keyword"] for r in rules if r.get("field") == "name_der_auswertung"]
+    name_keys = [
+        r["keyword"]
+        for r in rules
+        if isinstance(r, dict) and r.get("field") == "name_der_auswertung"
+    ]
+    for r in rules:
+        if not isinstance(r, dict):
+            logger.warning("Ungültige Regel: %r", r)
     for line in text.splitlines():
         stripped = line.strip()
         if not stripped:

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.forms import Textarea, modelformset_factory
+import json
 from pathlib import Path
 from .models import (
     Recording,
@@ -693,6 +694,23 @@ class Anlage4ParserConfigForm(forms.ModelForm):
             "table_columns": forms.Textarea(attrs={"rows": 4}),
             "text_rules": forms.Textarea(attrs={"rows": 4}),
         }
+
+    def clean_text_rules(self):
+        """Validiert die Text-Regeln."""
+        value = self.cleaned_data.get("text_rules")
+        if isinstance(value, str):
+            try:
+                value = json.loads(value or "[]")
+            except json.JSONDecodeError as exc:
+                raise forms.ValidationError("Ungültiges JSON") from exc
+        if not isinstance(value, list):
+            raise forms.ValidationError("Erwartet eine Liste")
+        for item in value:
+            if not isinstance(item, dict) or "field" not in item or "keyword" not in item:
+                raise forms.ValidationError(
+                    "Jede Regel muss ein Objekt mit 'field' und 'keyword' sein"
+                )
+        return value
 
 
 class AntwortErkennungsRegelForm(forms.ModelForm):

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1,4 +1,7 @@
 from .test_general import *
+from ..anlage4_parser import parse_anlage4_dual
+from ..models import Anlage4ParserConfig
+from ..docx_utils import _normalize_header_text
 
 class DocxExtractTests(NoesisTestCase):
     def test_extract_text(self):
@@ -737,6 +740,18 @@ class Anlage4ParserTests(NoesisTestCase):
         with self.assertLogs("anlage4_debug", level="DEBUG") as cm:
             parse_anlage4(pf)
         self.assertIn("free text found - 1 items", cm.output[0])
+
+    def test_dual_parser_handles_invalid_rules(self):
+        pcfg = Anlage4ParserConfig.objects.create(text_rules=["Zweck"])
+        pf = BVProjectFile.objects.create(
+            projekt=BVProject.objects.create(software_typen="A"),
+            anlage_nr=4,
+            upload=SimpleUploadedFile("x.txt", b""),
+            text_content="",
+            anlage4_parser_config=pcfg,
+        )
+        items = parse_anlage4_dual(pf)
+        self.assertEqual(items, [])
 
 
 class AnalyseAnlage4Tests(NoesisTestCase):


### PR DESCRIPTION
## Summary
- ignore malformed entries in Anlage4 dual parser rules
- validate JSON in `Anlage4ParserConfigForm`
- ensure invalid `text_rules` don't break `parse_anlage4_dual`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: failures=25, errors=16)*

------
https://chatgpt.com/codex/tasks/task_e_686a91b01eac832bb57fe2bf92e31ad5