### PR TITLE
Update README and admin hints for Anlage 4 parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,25 @@ erzeugt
 ]
 ```
 
+### Anlage 4 Parser konfigurieren
+
+Der optionale Parser für die vierte Anlage arbeitet ohne LLM-Extraktion. Er
+durchsucht den Freitext anhand konfigurierbarer Phrasen. Diese Phrasen werden
+als Liste im Feld `text_rules` gespeichert. Jede Regel enthält die Schlüssel
+`field` und `keyword`, die bestimmen, wo ein Abschnitt beginnt.
+
+Beispiel:
+
+```json
+[
+  {"field": "name_der_auswertung", "keyword": "Zweck"},
+  {"field": "gesellschaften", "keyword": "Gesellschaft"}
+]
+```
+
+Der Parser füllt die genannten Felder automatisch aus und überspringt den
+früheren LLM-Schritt zur Extraktion.
+
 ### Anlage‑2‑Konfiguration importieren/exportieren
 
 Unter `/projects-admin/anlage2/config/` lässt sich zusätzlich die gesamte

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -108,6 +108,11 @@
             </div>
             <div>
                 <label>{{ a4_parser_form.text_rules.label }}</label>
+                <p class="text-sm text-gray-600">
+                    Jede Regel benötigt <code>field</code> und <code>keyword</code>.
+                    Beispiel: <code>[{"field": "name_der_auswertung", "keyword": "Zweck"}]</code>.
+                    Der LLM-Extraktionsschritt entfällt.
+                </p>
                 {{ a4_parser_form.text_rules }}
                 {{ a4_parser_form.text_rules.errors }}
             </div>

--- a/templates/admin_anlage4_config.html
+++ b/templates/admin_anlage4_config.html
@@ -12,6 +12,11 @@
     </div>
     <div>
         <label>{{ form.text_rules.label }}</label>
+        <p class="text-sm text-gray-600">
+            Jede Regel besteht aus <code>field</code> und <code>keyword</code>.
+            Beispiel: <code>[{"field": "name_der_auswertung", "keyword": "Zweck"}]</code>.
+            Der LLM-Extraktionsschritt entfällt.
+        </p>
         {{ form.text_rules }}
         {{ form.text_rules.errors }}
     </div>


### PR DESCRIPTION
## Summary
- describe new text_rules structure in the README
- mention that the LLM extraction step is gone
- add explanatory notes in the admin templates

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686aa83a66d0832bbcdd1924d672953d