### PR TITLE
Fix redirect for Anlage 4 analysis

### DIFF
--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -956,3 +956,32 @@ class Anlage4ReviewViewTests(NoesisTestCase):
             self.file.manual_analysis_json,
             {"0": {"ok": True, "note": "gut"}, "1": {"ok": False, "note": "schlecht"}},
         )
+
+
+class ProjektFileAnalyseAnlage4ViewTests(NoesisTestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("a4user", password="pass")
+        self.client.login(username="a4user", password="pass")
+        self.projekt = BVProject.objects.create(software_typen="A")
+        self.file = BVProjectFile.objects.create(
+            projekt=self.projekt,
+            anlage_nr=4,
+            upload=SimpleUploadedFile("a.txt", b""),
+            text_content="Zwecke",
+        )
+
+    def test_get_runs_analysis_and_redirects(self):
+        url = reverse("projekt_file_analyse_anlage4", args=[self.file.pk])
+        with patch("core.views.analyse_anlage4") as mock_func:
+            mock_func.return_value = {}
+            resp = self.client.get(url)
+        self.assertRedirects(resp, reverse("anlage4_review", args=[self.file.pk]))
+        mock_func.assert_called_with(self.projekt.pk)
+
+    def test_post_runs_analysis_and_redirects(self):
+        url = reverse("projekt_file_analyse_anlage4", args=[self.file.pk])
+        with patch("core.views.analyse_anlage4") as mock_func:
+            mock_func.return_value = {}
+            resp = self.client.post(url)
+        self.assertRedirects(resp, reverse("anlage4_review", args=[self.file.pk]))
+        mock_func.assert_called_with(self.projekt.pk)

--- a/core/views.py
+++ b/core/views.py
@@ -2432,7 +2432,7 @@ def projekt_file_analyse_anlage4(request, pk):
     if anlage.anlage_nr != 4:
         raise Http404
     analyse_anlage4(anlage.projekt_id)
-    return redirect("projekt_file_edit_json", pk=pk)
+    return redirect("anlage4_review", pk=pk)
 
 
 @login_required


### PR DESCRIPTION
## Summary
- redirect analysing of Anlage 4 directly to the review page
- add tests for the redirect behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ad0729f8c832b85b9189470591b95