### PR TITLE
Handle None config in Anlage4 parser

### DIFF
--- a/core/anlage4_parser.py
+++ b/core/anlage4_parser.py
@@ -109,11 +109,23 @@ def parse_anlage4(
 
 
 
-def parse_anlage4_dual(project_file: BVProjectFile) -> List[dict]:
-    """Parst Anlage 4 mit Dual-Strategie."""
+def parse_anlage4_dual(
+    project_file: BVProjectFile,
+    cfg: Anlage4ParserConfig | None = None,
+) -> List[dict]:
+    """Parst Anlage 4 mit Dual-Strategie.
+
+    Wenn keine Konfiguration vorhanden ist, wird ein leerer
+    Ergebnis-Liste zurückgegeben und eine Warnung protokolliert.
+    """
 
     logger.info("parse_anlage4_dual gestartet für Datei %s", project_file.pk)
-    cfg = project_file.anlage4_parser_config or Anlage4ParserConfig.objects.first()
+    if cfg is None:
+        cfg = project_file.anlage4_parser_config or Anlage4ParserConfig.objects.first()
+    if cfg is None:
+        logger.warning("Keine Anlage4ParserConfig vorhanden")
+        return []
+
     columns = [_normalize(c) for c in (cfg.table_columns if cfg else [])]
     delimiter_phrase = cfg.delimiter_phrase if cfg else ""
     ges_phrase = cfg.gesellschaften_phrase if cfg else ""

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -822,6 +822,18 @@ class Anlage4ParserTests(NoesisTestCase):
         )
         self.assertEqual(parse_anlage4_dual(pf), [])
 
+    def test_dual_parser_no_config(self):
+        pf = BVProjectFile.objects.create(
+            projekt=BVProject.objects.create(software_typen="A"),
+            anlage_nr=4,
+            upload=SimpleUploadedFile("x.txt", b""),
+            text_content="",
+        )
+        with self.assertLogs("anlage4_debug", level="WARNING") as cm:
+            items = parse_anlage4_dual(pf)
+        self.assertEqual(items, [])
+        self.assertIn("Keine Anlage4ParserConfig vorhanden", "".join(cm.output))
+
 
 class AnalyseAnlage4Tests(NoesisTestCase):
     def test_task_stores_json(self):


### PR DESCRIPTION
## Summary
- return empty list when Anlage4 dual parser config is missing
- test that missing config won't crash the dual parser

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: 'rich', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686b713ef9a8832b9f0ac20cc69407b2