### PR TITLE
Improve Anlage4 dual parser regex

### DIFF
--- a/core/anlage4_parser.py
+++ b/core/anlage4_parser.py
@@ -178,14 +178,15 @@ def parse_anlage4_dual(
             logger.error("Negative pattern erkannt: %s", pat.pattern)
             return []
 
-    block_aliases = [delimiter_phrase] if delimiter_phrase else []
-    block_aliases.extend(name_aliases)
-    if not any(block_aliases):
+    block_aliases: list[str] = []
+    if delimiter_phrase:
+        block_aliases.append(r"\s*" + delimiter_phrase)
+    block_aliases.extend(_phrase_pattern(a) for a in name_aliases)
+    if not block_aliases:
         logger.warning("Keine delimiter_phrase definiert")
         return []
 
-    escaped = [_phrase_pattern(p) for p in block_aliases]
-    pattern_block = re.compile(r"^(?:" + "|".join(escaped) + ")", re.I | re.M)
+    pattern_block = re.compile(r"^(?:" + "|".join(block_aliases) + ")", re.I | re.M)
     matches = list(pattern_block.finditer(text))
     logger.debug("Gefundene Blöcke: %s", len(matches))
     if not matches:
@@ -199,13 +200,13 @@ def parse_anlage4_dual(
 
     if ges_phrase or ges_aliases:
         patterns = ([ges_phrase] if ges_phrase else []) + ges_aliases
-        escaped = [_phrase_pattern(p) for p in patterns]
+        escaped = [r"\s*" + _phrase_pattern(p) for p in patterns]
         reg_ges = re.compile(r"^(?:" + "|".join(escaped) + ")", re.I | re.M)
     else:
         reg_ges = None
     if fach_phrase or fach_aliases:
         patterns = ([fach_phrase] if fach_phrase else []) + fach_aliases
-        escaped = [_phrase_pattern(p) for p in patterns]
+        escaped = [r"\s*" + _phrase_pattern(p) for p in patterns]
         reg_fach = re.compile(r"^(?:" + "|".join(escaped) + ")", re.I | re.M)
     else:
         reg_fach = None

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -805,6 +805,34 @@ class Anlage4ParserTests(NoesisTestCase):
             ],
         )
 
+    def test_dual_parser_default_config_example(self):
+        pcfg = Anlage4ParserConfig.objects.create()
+        text = (
+            "Name der 1. Auswertung\n"
+            "Alpha\n"
+            "   Gesellschaften, in denen die Auswertung verwendet wird: Foo\n"
+            "   Fachbereiche, in denen die Auswertung eingesetzt wird: Bar\n"
+            "Name der 2. Auswertung\n"
+            "Beta\n"
+            "   Gesellschaften, in denen die Auswertung verwendet wird: Baz\n"
+            "   Fachbereiche, in denen die Auswertung eingesetzt wird: Qux"
+        )
+        pf = BVProjectFile.objects.create(
+            projekt=BVProject.objects.create(software_typen="A"),
+            anlage_nr=4,
+            upload=SimpleUploadedFile("x.txt", b""),
+            text_content=text,
+            anlage4_parser_config=pcfg,
+        )
+        items = parse_anlage4_dual(pf)
+        self.assertEqual(
+            items,
+            [
+                {"name_der_auswertung": "Alpha", "gesellschaften": "Foo", "fachbereiche": "Bar"},
+                {"name_der_auswertung": "Beta", "gesellschaften": "Baz", "fachbereiche": "Qux"},
+            ],
+        )
+
     def test_dual_parser_negative_pattern(self):
         pcfg = Anlage4ParserConfig.objects.create(
             name_aliases=["Name"],


### PR DESCRIPTION
## Summary
- support whitespace before delimiter phrase
- make gesellschaften and fachbereiche patterns handle leading spaces
- add testcase for default config text example

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py test` *(fails: AttributeError: 'NoneType' object has no attribute 'prompt_plausibility')*

------
https://chatgpt.com/codex/tasks/task_e_686b7cc66c6c832ba54eb871a7fcb7a4