### PR TITLE
Fix colon stripping in dual parser

### DIFF
--- a/core/anlage4_parser.py
+++ b/core/anlage4_parser.py
@@ -232,7 +232,9 @@ def parse_anlage4_dual(
         anchors_found.sort(key=lambda x: x[1])
 
         end_pos = len(seg)
-        entry["name_der_auswertung"] = seg[: anchors_found[0][1] if anchors_found else end_pos].strip()
+        name = seg[: anchors_found[0][1] if anchors_found else end_pos].strip()
+        name = re.sub(r'^[:\s]+', '', name)
+        entry["name_der_auswertung"] = name
         for idx, (field, start, anchor_end) in enumerate(anchors_found):
             next_start = anchors_found[idx + 1][1] if idx + 1 < len(anchors_found) else end_pos
             entry[field] = seg[anchor_end:next_start].strip()

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -805,6 +805,22 @@ class Anlage4ParserTests(NoesisTestCase):
             ],
         )
 
+    def test_dual_parser_strips_colon(self):
+        pcfg = Anlage4ParserConfig.objects.create(
+            delimiter_phrase="Zweck",
+            gesellschaften_phrase="",
+            fachbereiche_phrase="",
+        )
+        pf = BVProjectFile.objects.create(
+            projekt=BVProject.objects.create(software_typen="A"),
+            anlage_nr=4,
+            upload=SimpleUploadedFile("x.txt", b""),
+            text_content="Zweck: Logdaten",
+            anlage4_parser_config=pcfg,
+        )
+        items = parse_anlage4_dual(pf)
+        self.assertEqual(items[0]["name_der_auswertung"], "Logdaten")
+
     def test_dual_parser_default_config_example(self):
         pcfg = Anlage4ParserConfig.objects.create()
         text = (


### PR DESCRIPTION
## Summary
- clean extracted name in `parse_anlage4_dual`
- verify colon stripping in parser tests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError and assertion errors)*
- `python manage.py test core.tests.test_parsing.Anlage4ParserTests.test_dual_parser_strips_colon -v 2`

------
https://chatgpt.com/codex/tasks/task_e_686b8908c4a8832bb11fe670840b2560