### PR TITLE
fix: parse LLM JSON replies

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -934,6 +934,8 @@ def analyse_anlage4(projekt_id: int, model_name: str | None = None) -> dict:
         prompt_obj = Prompt(name="tmp", text=prompt_text)
         reply = query_llm(prompt_obj, {}, model_name=model_name, model_type="anlagen")
         anlage4_logger.debug("A4 Sync Raw Response #%s: %s", idx, reply)
+        if "```json" in reply:
+            reply = reply.split("```json", 1)[1].split("```")[0]
         try:
             result = json.loads(reply)
         except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- sanitize JSON replies in `analyse_anlage4`

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686bd92f6b98832b95b84f5e9c8c6fcb