### PR TITLE
Add structured results to async Anlage4 analysis

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -993,7 +993,8 @@ def worker_anlage4_evaluate(
     analysis = pf.analysis_json or {"items": []}
     items = analysis.get("items") or []
     while len(items) <= index:
-        items.append({"text": item_text})
+        items.append({"text": item_text, "structured": {"name_der_auswertung": item_text}})
+    items[index]["structured"] = {"name_der_auswertung": item_text}
     items[index]["plausibility"] = data
     analysis["items"] = items
     pf.analysis_json = analysis
@@ -1075,7 +1076,10 @@ def analyse_anlage4_async(projekt_id: int, model_name: str | None = None) -> dic
     if use_dual:
         items = [{"structured": z} for z in auswertungen]
     else:
-        items = [{"text": z} for z in auswertungen]
+        items = [
+            {"text": z, "structured": {"name_der_auswertung": z}}
+            for z in auswertungen
+        ]
     anlage.analysis_json = {"items": items}
     anlage.save(update_fields=["analysis_json"])
     anlage4_logger.debug("Async initiales JSON gespeichert: %s", anlage.analysis_json)


### PR DESCRIPTION
## Summary
- ensure async Anlage4 parser adds `structured` data for standard parser
- store `structured` data in `worker_anlage4_evaluate`
- test async analysis for structured results
- add worker test for structured result saving

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: django errors)*

------
https://chatgpt.com/codex/tasks/task_e_686be17dfba4832bb9ba0d4ff7918323