### PR TITLE
Implement async analysis for Anlage 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ bearbeitet werden können. Folgende Felder bestimmen das Parsing:
 Der Parser füllt die genannten Felder automatisch aus und überspringt den
 früheren LLM-Schritt zur Extraktion.
 
+Die anschließende Plausibilitätsprüfung läuft asynchron. Die
+geparsten Werte stehen sofort bereit und die LLM-Ergebnisse werden
+nach und nach in `analysis_json` ergänzt.
+
 
 ### Anlage‑2‑Konfiguration importieren/exportieren
 

--- a/core/management/commands/analyse_anlage4.py
+++ b/core/management/commands/analyse_anlage4.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from core.llm_tasks import analyse_anlage4
+from core.llm_tasks import analyse_anlage4_async
 from core.cli_utils import print_markdown
 import json
 
@@ -11,6 +11,6 @@ class Command(BaseCommand):
         parser.add_argument("--model", dest="model", default=None)
 
     def handle(self, projekt_id, model=None, **options):
-        data = analyse_anlage4(projekt_id, model_name=model)
+        data = analyse_anlage4_async(projekt_id, model_name=model)
         text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
         print_markdown(text)

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1046,7 +1046,7 @@ class ProjektFileAnalyseAnlage4ViewTests(NoesisTestCase):
 
     def test_get_runs_analysis_and_redirects(self):
         url = reverse("projekt_file_analyse_anlage4", args=[self.file.pk])
-        with patch("core.views.analyse_anlage4") as mock_func:
+        with patch("core.views.analyse_anlage4_async") as mock_func:
             mock_func.return_value = {}
             resp = self.client.get(url)
         self.assertRedirects(resp, reverse("anlage4_review", args=[self.file.pk]))
@@ -1054,7 +1054,7 @@ class ProjektFileAnalyseAnlage4ViewTests(NoesisTestCase):
 
     def test_post_runs_analysis_and_redirects(self):
         url = reverse("projekt_file_analyse_anlage4", args=[self.file.pk])
-        with patch("core.views.analyse_anlage4") as mock_func:
+        with patch("core.views.analyse_anlage4_async") as mock_func:
             mock_func.return_value = {}
             resp = self.client.post(url)
         self.assertRedirects(resp, reverse("anlage4_review", args=[self.file.pk]))

--- a/core/views.py
+++ b/core/views.py
@@ -91,6 +91,7 @@ from .llm_tasks import (
     check_anlage2,
     check_anlage3_vision,
     analyse_anlage4,
+    analyse_anlage4_async,
     check_anlage6,
     check_anlage2_functions,
     run_anlage2_analysis,
@@ -2423,7 +2424,7 @@ def projekt_file_analyse_anlage4(request, pk):
     anlage = get_object_or_404(BVProjectFile, pk=pk)
     if anlage.anlage_nr != 4:
         raise Http404
-    analyse_anlage4(anlage.projekt_id)
+    analyse_anlage4_async(anlage.projekt_id)
     return redirect("anlage4_review", pk=pk)
 
 


### PR DESCRIPTION
## Summary
- trigger `analyse_anlage4_async` when analysing attachment 4
- update management command to use async version
- document asynchronous evaluation in the README
- adjust tests to patch new function

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError, assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_686c05a25e94832bac879dc833d37d3f