### PR TITLE
Add debug output for Anlage4

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -946,6 +946,7 @@ def analyse_anlage4(projekt_id: int, model_name: str | None = None) -> dict:
     data = {"task": "analyse_anlage4", "items": items}
     anlage.analysis_json = data
     anlage.save(update_fields=["analysis_json"])
+    anlage4_logger.debug("A4 Sync Gesamtdaten: %s", data)
     return data
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -2199,6 +2199,8 @@ def anlage4_review(request, pk):
             }
         )
 
+    anlage4_logger.debug("Tabellenzeilen f\u00fcr Anlage4 Review: %s", rows)
+
     context = {
         "anlage": project_file,
         "rows": rows,


### PR DESCRIPTION
## Summary
- extend Anlage4 sync analysis logging with final dataset
- log table data before rendering Anlage4 review

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ImproperlyConfigured / test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686c19df0040832b8a39a105a2e8aa22