### PR TITLE
Add fields for gap summaries

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -334,6 +334,16 @@ class Anlage2ReviewForm(forms.Form):
                     widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
                 )
                 self.initial[name] = f_data.get(field, False)
+            self.fields[f"func{func.id}_gap_summary"] = forms.CharField(
+                required=False,
+                widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
+            )
+            self.initial[f"func{func.id}_gap_summary"] = f_data.get("gap_summary", "")
+            self.fields[f"func{func.id}_is_negotiable"] = forms.BooleanField(
+                required=False,
+                widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
+            )
+            self.initial[f"func{func.id}_is_negotiable"] = f_data.get("is_negotiable", False)
             for sub in func.anlage2subquestion_set.all().order_by("id"):
                 s_data = f_data.get("subquestions", {}).get(str(sub.id), {})
                 for field, _ in fields:
@@ -343,6 +353,16 @@ class Anlage2ReviewForm(forms.Form):
                         widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
                     )
                     self.initial[name] = s_data.get(field, False)
+                self.fields[f"sub{sub.id}_gap_summary"] = forms.CharField(
+                    required=False,
+                    widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
+                )
+                self.initial[f"sub{sub.id}_gap_summary"] = s_data.get("gap_summary", "")
+                self.fields[f"sub{sub.id}_is_negotiable"] = forms.BooleanField(
+                    required=False,
+                    widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
+                )
+                self.initial[f"sub{sub.id}_is_negotiable"] = s_data.get("is_negotiable", False)
 
     def get_json(self) -> dict:
         out = {"functions": {}}
@@ -353,12 +373,24 @@ class Anlage2ReviewForm(forms.Form):
             item: dict[str, object] = {}
             for field, _ in fields:
                 item[field] = self.cleaned_data.get(f"func{func.id}_{field}", False)
+            item["gap_summary"] = self.cleaned_data.get(
+                f"func{func.id}_gap_summary", ""
+            )
+            item["is_negotiable"] = self.cleaned_data.get(
+                f"func{func.id}_is_negotiable", False
+            )
             sub_dict: dict[str, dict] = {}
             for sub in func.anlage2subquestion_set.all().order_by("id"):
                 sub_item = {
                     field: self.cleaned_data.get(f"sub{sub.id}_{field}", False)
                     for field, _ in fields
                 }
+                sub_item["gap_summary"] = self.cleaned_data.get(
+                    f"sub{sub.id}_gap_summary", ""
+                )
+                sub_item["is_negotiable"] = self.cleaned_data.get(
+                    f"sub{sub.id}_is_negotiable", False
+                )
                 sub_dict[str(sub.id)] = sub_item
             if sub_dict:
                 item["subquestions"] = sub_dict

--- a/core/views.py
+++ b/core/views.py
@@ -476,6 +476,8 @@ def _build_row_data(
         }
         for field, _ in fields_def
     ]
+    negotiable_widget = form[f"{form_prefix}is_negotiable"]
+    gap_widget = form[f"{form_prefix}gap_summary"]
     begr_md = ki_map.get((str(func_id), str(sub_id) if sub_id else None))
     bet_val, bet_reason = beteilig_map.get(
         (str(func_id), str(sub_id) if sub_id else None), (None, "")
@@ -485,6 +487,8 @@ def _build_row_data(
         "analysis": answers.get(lookup_key, {}),
         "initial": disp["values"],
         "form_fields": widgets,
+        "negotiable_widget": negotiable_widget,
+        "gap_summary_widget": gap_widget,
         "sub": sub_id is not None,
         "func_id": func_id,
         "sub_id": sub_id,

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -33,6 +33,8 @@
                 {% for label in labels %}
                 <th class="border px-2">{{ label }} (Review)</th>
                 {% endfor %}
+                <th class="border px-2">Verhandlungsfähig</th>
+                <th class="border px-2">Gap Summary</th>
             </tr>
         </thead>
         <tbody>
@@ -96,6 +98,8 @@
                     {% if f.source %}<span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>{% endif %}
                 </td>
                 {% endfor %}
+                <td class="border px-2 text-center">{{ row.negotiable_widget }}</td>
+                <td class="border px-2">{{ row.gap_summary_widget }}</td>
             </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- extend `Anlage2ReviewForm` with gap_summary and is_negotiable per function and subquestion
- add negotiation and gap summary widgets in the review table

## Testing
- `python manage.py makemigrations --check` *(fails: conflicting migrations)*
- `python manage.py test` *(fails: conflicting migrations)*

------
https://chatgpt.com/codex/tasks/task_e_6870cebbe154832b8c708c8f5a847b5a