### PR TITLE
feat: generate gap summary asynchronously

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -218,7 +218,14 @@ document.addEventListener('DOMContentLoaded', function() {
             body: JSON.stringify(payload)
         })
             .then(r => r.json())
-            .then(() => { indicator.textContent = '✓ Gespeichert'; setTimeout(() => indicator.textContent = '', 1500); })
+            .then(data => {
+                indicator.textContent = '✓ Gespeichert';
+                if (data.gap_summary !== undefined) {
+                    const gapField = row.querySelector('textarea[name$="_gap_summary"]');
+                    if (gapField) { gapField.value = data.gap_summary; }
+                }
+                setTimeout(() => indicator.textContent = '', 1500);
+            })
             .catch(() => { indicator.textContent = '⚠️'; });
     }
 


### PR DESCRIPTION
## Summary
- start async gap-summary task when manual review differs
- implement `worker_generate_gap_summary`
- update JS to fill gap field from response
- test automatic gap creation

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68713c49b928832baac3f3130b62fb45