### PR TITLE
Enhance review UI with popovers and gap highlighting

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -481,6 +481,19 @@ def _build_row_data(
     bet_val, bet_reason = beteilig_map.get(
         (str(func_id), str(sub_id) if sub_id else None), (None, "")
     )
+    has_gap = False
+    for field, _ in fields_def:
+        doc_val = analysis_lookup.get(lookup_key, {}).get(field)
+        ai_val = verification_lookup.get(lookup_key, {}).get(field)
+        manual_val = manual_lookup.get(lookup_key, {}).get(field)
+        if (
+            doc_val is not None
+            and ai_val is not None
+            and doc_val != ai_val
+            and manual_val is None
+        ):
+            has_gap = True
+            break
     return {
         "name": display_name,
         "doc_result": answers.get(lookup_key, {}),
@@ -499,6 +512,7 @@ def _build_row_data(
         "ki_begruendung_html": markdownify(begr_md) if begr_md else "",
         "ki_beteiligt": bet_val,
         "ki_beteiligt_begruendung": bet_reason,
+        "has_preliminary_gap": has_gap,
     }
 
 

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -79,7 +79,12 @@
                     {% endif %}
                     {% endwith %}
                     {% if row.ki_beteiligt_begruendung %}
-                    <i class="fa fa-info-circle ms-1" data-bs-toggle="tooltip" title="{{ row.ki_beteiligt_begruendung }}"></i>
+                    <i class="fas fa-info-circle text-muted ms-1"
+                       data-bs-toggle="popover"
+                       data-bs-trigger="focus"
+                       tabindex="0"
+                       title="Informationsquelle"
+                       data-bs-content="{{ row.ki_beteiligt_begruendung }}"></i>
                     {% endif %}
                 </td>
                 {% with f=row.form_fields|list_index:forloop.counter0 %}
@@ -107,7 +112,7 @@
                 {% endif %}
                 {% endfor %}
                 <td class="border px-2 text-center">{{ row.negotiable_widget }}</td>
-                <td class="border px-2 text-center">
+                <td class="border px-2 text-center {% if row.has_preliminary_gap %}bg-purple-200{% endif %}">
                     <button type="button" class="gap-summary-btn" data-bs-toggle="collapse" data-bs-target="#gap-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}">
                         <i class="fa fa-comment-dots"></i>
                     </button>
@@ -178,6 +183,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
     tooltipTriggerList.forEach(el => new bootstrap.Tooltip(el));
+    const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]');
+    const popoverList = [...popoverTriggerList].map(el => new bootstrap.Popover(el));
 
     const formElem = document.querySelector('form[data-anlage-id]');
     const saveUrl = "{% url 'ajax_save_anlage2_review' %}";


### PR DESCRIPTION
## Summary
- replace tooltip info icon with Bootstrap popover
- highlight the gap column when document and AI results conflict
- initialize Bootstrap popovers on the review page
- compute flag for preliminary gaps in backend

## Testing
- `python manage.py makemigrations --check` *(fails: unexpected character after line continuation)*
- `python manage.py test` *(fails: unexpected character after line continuation)*

------
https://chatgpt.com/codex/tasks/task_e_687162c11c9c832b9c816b047d8ec1e6