### PR TITLE
Fix parse_anlage2_table patch

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -854,7 +854,9 @@ class LLMTasksTests(NoesisTestCase):
         cfg.parser_order = ["p1", "p2"]
         cfg.save()
 
-        with patch("core.llm_tasks.parse_anlage2_table") as m_tab, patch(
+        with patch(
+            "core.llm_tasks.parse_anlage2_table", return_value=[]
+        ) as m_tab, patch(
             "core.llm_tasks.parse_anlage2_text", return_value=[]
         ) as m_text:
             run_anlage2_analysis(pf)


### PR DESCRIPTION
## Summary
- avoid MagicMock in json.dumps by setting `return_value=[]` for `parse_anlage2_table` in tests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: TemplateSyntaxError and others)*

------
https://chatgpt.com/codex/tasks/task_e_68718524deb0832b957b98731c7caea2