### PR TITLE
Implement Tri-State widget backend attributes

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -468,13 +468,24 @@ def _build_row_data(
         lookup_key, analysis_lookup, verification_lookup, manual_lookup
     )
     fields_def = get_anlage2_fields()
-    widgets = [
-        {
-            "widget": form[f"{form_prefix}{field}"],
-            "source": disp["sources"][field],
-        }
-        for field, _ in fields_def
-    ]
+    widgets = []
+    for field, _ in fields_def:
+        bf = form[f"{form_prefix}{field}"]
+        if field == "technisch_vorhanden" and sub_id is None:
+            initial_value = disp["values"].get(field)
+            state = (
+                "true"
+                if initial_value is True
+                else "false" if initial_value is False else "unknown"
+            )
+            bf.field.widget.attrs.update(
+                {
+                    "data-tristate": "true",
+                    "data-initial-state": state,
+                    "style": "display: none;",
+                }
+            )
+        widgets.append({"widget": bf, "source": disp["sources"][field]})
     negotiable_widget = form[f"{form_prefix}is_negotiable"]
     gap_widget = form[f"{form_prefix}gap_summary"]
     begr_md = ki_map.get((str(func_id), str(sub_id) if sub_id else None))

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -122,7 +122,7 @@
                 <td class="border px-2 text-center">
                     {% if field == 'technisch_vorhanden' %}
                         <span class="tri-state-icon" data-input-id="{{ f.auto_id }}"></span>
-                        {{ f.as_widget(attrs={'data-tristate':'1','style':'display:none'}) }}
+                        {{ f.widget }}
                     {% else %}
                         {{ f.widget }}
                     {% endif %}
@@ -247,8 +247,8 @@ document.addEventListener('DOMContentLoaded', function() {
     document.querySelectorAll('.tri-state-icon').forEach(icon => {
         const input = document.getElementById(icon.dataset.inputId);
         if (!input) return;
-        input.dataset.tristate = '1';
-        input.dataset.state = input.dataset.state || (input.checked ? 'true' : 'unknown');
+        input.dataset.tristate = 'true';
+        input.dataset.state = input.dataset.initialState || (input.checked ? 'true' : 'unknown');
         updateTriState(icon, input);
         icon.addEventListener('click', () => {
             let st = input.dataset.state;


### PR DESCRIPTION
## Summary
- update `_build_row_data` to set tri-state widget attributes on the backend
- render prepared widget for `technisch_vorhanden` in the review template
- adapt JS to read `data-initial-state` and keep subquestion output static

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68717a431920832ba2d1d9c95bc89111