### PR TITLE
Implement refined review workflow

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -339,11 +339,6 @@ class Anlage2ReviewForm(forms.Form):
                 widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
             )
             self.initial[f"func{func.id}_gap_summary"] = f_data.get("gap_summary", "")
-            self.fields[f"func{func.id}_is_negotiable"] = forms.BooleanField(
-                required=False,
-                widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
-            )
-            self.initial[f"func{func.id}_is_negotiable"] = f_data.get("is_negotiable", False)
             for sub in func.anlage2subquestion_set.all().order_by("id"):
                 s_data = f_data.get("subquestions", {}).get(str(sub.id), {})
                 for field, _ in fields:
@@ -358,11 +353,6 @@ class Anlage2ReviewForm(forms.Form):
                     widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
                 )
                 self.initial[f"sub{sub.id}_gap_summary"] = s_data.get("gap_summary", "")
-                self.fields[f"sub{sub.id}_is_negotiable"] = forms.BooleanField(
-                    required=False,
-                    widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
-                )
-                self.initial[f"sub{sub.id}_is_negotiable"] = s_data.get("is_negotiable", False)
 
     def get_json(self) -> dict:
         out = {"functions": {}}
@@ -376,9 +366,6 @@ class Anlage2ReviewForm(forms.Form):
             item["gap_summary"] = self.cleaned_data.get(
                 f"func{func.id}_gap_summary", ""
             )
-            item["is_negotiable"] = self.cleaned_data.get(
-                f"func{func.id}_is_negotiable", False
-            )
             sub_dict: dict[str, dict] = {}
             for sub in func.anlage2subquestion_set.all().order_by("id"):
                 sub_item = {
@@ -387,9 +374,6 @@ class Anlage2ReviewForm(forms.Form):
                 }
                 sub_item["gap_summary"] = self.cleaned_data.get(
                     f"sub{sub.id}_gap_summary", ""
-                )
-                sub_item["is_negotiable"] = self.cleaned_data.get(
-                    f"sub{sub.id}_is_negotiable", False
                 )
                 sub_dict[str(sub.id)] = sub_item
             if sub_dict:

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -27,16 +27,22 @@
             <tr>
                 <th class="border px-2" rowspan="2">Funktion</th>
                 <th class="border px-2" rowspan="2">Aktion</th>
-                {% for label in labels %}
+                {% for field,label in field_pairs %}
+                {% if field in no_ai_fields %}
+                <th class="border px-2" rowspan="2">{{ label }}</th>
+                {% else %}
                 <th class="border px-2" colspan="2">{{ label }}</th>
+                {% endif %}
                 {% endfor %}
                 <th class="border px-2" rowspan="2">Verhandlungsfähig</th>
                 <th class="border px-2" rowspan="2">Gap</th>
             </tr>
             <tr>
-                {% for _ in labels %}
+                {% for field,label in field_pairs %}
+                {% if field not in no_ai_fields %}
                 <th class="border px-2">KI-Check</th>
                 <th class="border px-2">Review</th>
+                {% endif %}
                 {% endfor %}
             </tr>
         </thead>
@@ -106,7 +112,14 @@
                         <span class="status-badge status-unbekannt" data-bs-toggle="tooltip" title="Dok: {{ doc|get_item:'value' }}{% if note %} - {{ note }}{% endif %}">? Unbekannt</span>
                     {% endif %}
                 </td>
-                {% if field == 'technisch_vorhanden' and row.sub %}
+                {% if field in no_ai_fields %}
+                {% with f=row.form_fields|list_index:forloop.counter0 %}
+                <td class="border px-2 text-center">
+                    {{ f.widget }}
+                    {% if f.source %}<span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>{% endif %}
+                </td>
+                {% endwith %}
+                {% elif field == 'technisch_vorhanden' and row.sub %}
                 <td class="border px-2 text-center">
                     {% with parsed=row.doc_result|get_item:field %}
                     {% if parsed == True %}
@@ -123,6 +136,11 @@
                     {% if field == 'technisch_vorhanden' %}
                         <span class="tri-state-icon" data-input-id="{{ f.auto_id }}"></span>
                         {{ f.widget }}
+                        {% if f.origin == 'ai' %}
+                        <span title="KI bestätigt">✅</span>
+                        {% elif f.origin == 'manual' %}
+                        <span title="Manuell geändert">✏️</span>
+                        {% endif %}
                     {% else %}
                         {{ f.widget }}
                     {% endif %}
@@ -132,7 +150,13 @@
                 {% endwith %}
                 {% endif %}
                 {% endfor %}
-                <td class="border px-2 text-center">{{ row.negotiable_widget }}</td>
+                <td class="border px-2 text-center">
+                    {% if row.is_negotiable %}
+                    <span class="text-green-600">✓</span>
+                    {% else %}
+                    <span class="text-gray-400">–</span>
+                    {% endif %}
+                </td>
                 <td class="border px-2 text-center {% if row.has_preliminary_gap %}bg-purple-200{% endif %}">
                     <button type="button" class="gap-summary-btn" data-bs-toggle="collapse" data-bs-target="#gap-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}">
                         <i class="fa fa-comment-dots"></i>


### PR DESCRIPTION
## Summary
- update review logic for Anlage 2
- compute negotiable flag automatically
- show icons for review origin and negotiation status

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6874030b0d70832b92253b738ddcd7a7