### PR TITLE
Add negotiable state update for Anlage 2 review

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3303,7 +3303,11 @@ def ajax_save_anlage2_review(request) -> JsonResponse:
         anlage.manual_analysis_json = manual_data
         anlage.save(update_fields=["manual_analysis_json"])
 
-        return JsonResponse({"status": "success", "gap_summary": gap_text})
+        return JsonResponse({
+            "status": "success",
+            "gap_summary": gap_text,
+            "is_negotiable": res.is_negotiable,
+        })
     except Exception as exc:  # pragma: no cover - Schutz vor unerwarteten Fehlern
         logger.error("Fehler beim Speichern des manuellen Reviews: %s", exc)
         return JsonResponse({"status": "error", "message": str(exc)}, status=500)

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -150,7 +150,7 @@
                 {% endwith %}
                 {% endif %}
                 {% endfor %}
-                <td class="border px-2 text-center">
+                <td class="border px-2 text-center negotiable-cell">
                     {% if row.is_negotiable %}
                     <span class="text-green-600">✓</span>
                     {% else %}
@@ -354,6 +354,14 @@ function initAnlage2Review() {
                 if (data.gap_summary !== undefined) {
                     const gapField = row.querySelector('textarea[name$="_gap_summary"]');
                     if (gapField) { gapField.value = data.gap_summary; }
+                }
+                if (data.is_negotiable !== undefined) {
+                    const cell = row.querySelector('.negotiable-cell');
+                    if (cell) {
+                        cell.innerHTML = data.is_negotiable ?
+                            '<span class="text-green-600">✓</span>' :
+                            '<span class="text-gray-400">–</span>';
+                    }
                 }
                 setTimeout(() => indicator.textContent = '', 1500);
             })


### PR DESCRIPTION
## Summary
- return negotiation status in `ajax_save_anlage2_review`
- mark negotiation column in Anlage 2 review table
- update JS auto-save to refresh negotiation cell

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError and various assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_687416a1a6b0832b9274b0e7579f8ca5