### PR TITLE
Queue Anlage‑2 KI check

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -386,7 +386,7 @@ class ProjektFileUploadTests(NoesisTestCase):
         file_obj = self.projekt.anlagen.get(anlage_nr=3)
         self.assertEqual(file_obj.text_content, "")
 
-    def test_anlage2_upload_runs_parser(self):
+    def test_anlage2_upload_queues_check(self):
         doc = Document()
         table = doc.add_table(rows=2, cols=2)
         table.cell(0, 0).text = "Funktion"
@@ -403,17 +403,19 @@ class ProjektFileUploadTests(NoesisTestCase):
         Anlage2Function.objects.create(name="Login")
 
         url = reverse("projekt_file_upload", args=[self.projekt.pk])
-        resp = self.client.post(
-            url,
-            {"anlage_nr": 2, "upload": upload, "manual_comment": ""},
-            format="multipart",
-        )
+        with patch("core.views.async_task") as mock_async:
+            resp = self.client.post(
+                url,
+                {"anlage_nr": 2, "upload": upload, "manual_comment": ""},
+                format="multipart",
+            )
         self.assertEqual(resp.status_code, 302)
         pf = self.projekt.anlagen.get(anlage_nr=2)
-        self.assertIsNotNone(pf.analysis_json)
-        res = Anlage2FunctionResult.objects.get(projekt=self.projekt, funktion__name="Login")
-        self.assertIsNotNone(res.doc_result)
-        self.assertIsNone(res.ai_result)
+        self.assertIsNone(pf.analysis_json)
+        mock_async.assert_called_with(
+            "core.llm_tasks.check_anlage2_functions",
+            self.projekt.pk,
+        )
 
 
 class AutoApprovalTests(NoesisTestCase):

--- a/core/views.py
+++ b/core/views.py
@@ -2329,8 +2329,12 @@ def projekt_list(request):
 def projekt_detail(request, pk):
     projekt = get_object_or_404(BVProject, pk=pk)
     if request.method == "POST" and "project_prompt" in request.POST:
-        projekt.project_prompt = request.POST.get("project_prompt", "")
+        new_prompt = request.POST.get("project_prompt", "")
+        changed = projekt.project_prompt != new_prompt
+        projekt.project_prompt = new_prompt
         projekt.save(update_fields=["project_prompt"])
+        if changed:
+            async_task("core.llm_tasks.check_anlage2_functions", projekt.pk)
         messages.success(request, "Projekt-Prompt gespeichert")
         return redirect("projekt_detail", pk=projekt.pk)
     anh = projekt.anlagen.all()
@@ -2514,7 +2518,7 @@ def projekt_file_upload(request, pk):
             obj.text_content = content
             obj.save()
             if obj.anlage_nr == 2:
-                run_anlage2_analysis(obj)
+                async_task("core.llm_tasks.check_anlage2_functions", projekt.pk)
             return redirect("projekt_detail", pk=projekt.pk)
     else:
         form = BVProjectFileForm()


### PR DESCRIPTION
## Summary
- trigger KI background check when uploading Anlage‑2 files
- start the same check when the project prompt changes
- update tests for new behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_687430aa65c0832b85ef5d3eb5029b3e