### PR TITLE
Add async Anlage 2 check on prompt update

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2131,6 +2131,16 @@ class ModelSelectionTests(NoesisTestCase):
         self.assertEqual(resp.status_code, 200)
         mock_func.assert_called_with(self.projekt.pk, model_name="mf")
 
+    def test_prompt_save_triggers_async_check(self):
+        url = reverse("projekt_detail", args=[self.projekt.pk])
+        with patch("core.views.async_task") as mock_task:
+            resp = self.client.post(url, {"project_prompt": "Test"})
+        self.assertRedirects(resp, url)
+        mock_task.assert_called_with(
+            "core.llm_tasks.check_anlage2_functions",
+            self.projekt.pk,
+        )
+
 
 class FunctionImportExportTests(NoesisTestCase):
     def setUp(self):

--- a/core/views.py
+++ b/core/views.py
@@ -2331,6 +2331,7 @@ def projekt_detail(request, pk):
     if request.method == "POST" and "project_prompt" in request.POST:
         projekt.project_prompt = request.POST.get("project_prompt", "")
         projekt.save(update_fields=["project_prompt"])
+        async_task("core.llm_tasks.check_anlage2_functions", projekt.pk)
         messages.success(request, "Projekt-Prompt gespeichert")
         return redirect("projekt_detail", pk=projekt.pk)
     anh = projekt.anlagen.all()


### PR DESCRIPTION
## Summary
- trigger function checks when project prompts change
- call async verification for Anlage 2 functions from project detail
- test that saving a prompt schedules the async check

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError: 'NoneType' object has no attribute 'prompt_template')*

------
https://chatgpt.com/codex/tasks/task_e_687430f05e10832b9afb9ed4410d6ea6