### PR TITLE
Update tests for KI check tasks

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2331,6 +2331,7 @@ def projekt_detail(request, pk):
     if request.method == "POST" and "project_prompt" in request.POST:
         projekt.project_prompt = request.POST.get("project_prompt", "")
         projekt.save(update_fields=["project_prompt"])
+        async_task("core.llm_tasks.check_anlage2_functions", projekt.pk)
         messages.success(request, "Projekt-Prompt gespeichert")
         return redirect("projekt_detail", pk=projekt.pk)
     anh = projekt.anlagen.all()
@@ -2514,7 +2515,10 @@ def projekt_file_upload(request, pk):
             obj.text_content = content
             obj.save()
             if obj.anlage_nr == 2:
-                run_anlage2_analysis(obj)
+                async_task(
+                    "core.llm_tasks.check_anlage2_functions",
+                    projekt.pk,
+                )
             return redirect("projekt_detail", pk=projekt.pk)
     else:
         form = BVProjectFileForm()


### PR DESCRIPTION
## Summary
- expect KI verification task on Anlage 2 upload
- ensure KI check reruns when changing project prompt
- update test coverage for ProjektFileCheck

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ProjektFileUploadTests.test_anlage2_upload_triggers_ki_check core.tests.test_general.ProjectPromptUpdateTests.test_prompt_change_triggers_ki_check`
- `python manage.py test` *(fails: IndexError, IntegrityError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687430f3d138832baa06d1c5320dd5b4