### PR TITLE
Reset Anlage2Function in test setup

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2146,6 +2146,7 @@ class ModelSelectionTests(NoesisTestCase):
 
 class FunctionImportExportTests(NoesisTestCase):
     def setUp(self):
+        Anlage2Function.objects.all().delete()
         admin_group = Group.objects.create(name="admin")
         self.user = User.objects.create_user("adminie", password="pass")
         self.user.groups.add(admin_group)


### PR DESCRIPTION
## Summary
- clear Anlage2Function objects before creating admin user in FunctionImportExportTests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.FunctionImportExportTests.test_export_returns_json -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68749d27c024832b86b13dfc6767e593