### PR TITLE
Handle secret key in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ pip install -r requirements-dev.txt
 
 Alternativ kann `./setup_env.sh` die gesamte Einrichtung übernehmen.
 
+Beim Testlauf wird `DJANGO_SECRET_KEY` automatisch auf `dummy_test_key` gesetzt,
+falls die Variable nicht gesetzt ist.
+
 ## Tests und Checks
 
 Vor jedem Commit müssen laut `AGENTS.md` folgende Befehle erfolgreich laufen:

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 from pathlib import Path
 import os
+import sys
 from dotenv import load_dotenv
 from django.core.exceptions import ImproperlyConfigured
 
@@ -26,9 +27,12 @@ load_dotenv(BASE_DIR / ".env")
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
-if not SECRET_KEY:
-    raise ImproperlyConfigured("DJANGO_SECRET_KEY muss in der Umgebung gesetzt sein")
+if "test" in sys.argv:
+    SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dummy_test_key")
+else:
+    SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
+    if not SECRET_KEY:
+        raise ImproperlyConfigured("DJANGO_SECRET_KEY muss in der Umgebung gesetzt sein")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## Summary
- set `DJANGO_SECRET_KEY` to a dummy value when running tests
- clarify in the README that tests auto-fill the secret key

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py test` *(fails: 25 failures, 16 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68749d33928c832b9796d83a62ed816e