### PR TITLE
fix parser fallback logic

### DIFF
--- a/core/parser_manager.py
+++ b/core/parser_manager.py
@@ -39,11 +39,14 @@ class ParserManager:
                 continue
             try:
                 result = parser.parse(project_file)
+                count = _count_technisch_true(result)
             except Exception as exc:  # pragma: no cover - Fehlkonfiguration
                 logger.error("Parser '%s' Fehler: %s", name, exc)
                 result = []
-            count = _count_technisch_true(result)
-            if count > best_count:
+                count = -1
+            if count > best_count or (
+                count == best_count and len(result) > len(best_result)
+            ):
                 best_result = result
                 best_count = count
         return best_result


### PR DESCRIPTION
## Summary
- set count to -1 on parser errors so empty results don't win
- prefer longer results when the number of `technisch_verfuegbar` matches

## Testing
- `python manage.py makemigrations --check` *(fails: conflicting migrations)*
- `python manage.py test core.tests.test_general.LLMTasksTests.test_parser_manager_fallback -v 2` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_6874a94c4538832b8a28dcc4cfeb127a