### PR TITLE
Fix Anlage1 test data update

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -166,6 +166,20 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
         pass
     create_statuses()
 
+    # Anlage1 Fragen aktualisieren
+    Anlage1QuestionModel = apps.get_model("core", "Anlage1Question")
+    Anlage1QuestionVariant = apps.get_model("core", "Anlage1QuestionVariant")
+    for idx, text in enumerate(ANLAGE1_QUESTIONS, start=1):
+        try:
+            question = Anlage1QuestionModel.objects.get(num=idx)
+        except Anlage1QuestionModel.DoesNotExist:
+            continue
+        question.text = text
+        question.parser_enabled = True
+        question.llm_enabled = True
+        question.save()
+        Anlage1QuestionVariant.objects.get_or_create(question=question, text=text)
+
     if skip_prompts:
         return
 


### PR DESCRIPTION
## Summary
- aktualisiere `seed_test_data` damit die Anlage1-Fragen aus `ANLAGE1_QUESTIONS` genutzt werden
- setze `parser_enabled` und `llm_enabled` auf `True`

## Testing
- `python manage.py makemigrations --check` *(schlug fehl: Conflicting migrations detected; multiple leaf nodes in the migration graph)*
- `python manage.py makemigrations --merge --noinput`
- `python manage.py makemigrations --check`
- `python manage.py test` *(fehlgeschlagen)*

------
https://chatgpt.com/codex/tasks/task_e_6874a94a4740832b92b915157a512d0c