### PR TITLE
Trigger Anlage2 auto analysis on view

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -1670,6 +1670,25 @@ class Anlage2ReviewTests(NoesisTestCase):
             rows[1]["verif_key"], f"{self.func.name}: {self.sub.frage_text}"
         )
 
+    def test_auto_analysis_runs_once_for_new_file(self):
+        pf = BVProjectFile.objects.create(
+            projekt=self.projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("n.txt", b"x"),
+            text_content="t",
+        )
+        url = reverse("projekt_file_edit_json", args=[pf.pk])
+
+        def _fake(obj):
+            obj.analysis_json = {"functions": []}
+            obj.save(update_fields=["analysis_json"])
+            return []
+
+        with patch("core.views.run_anlage2_analysis", side_effect=_fake) as mock_func:
+            self.client.get(url)
+            self.client.get(url)
+        self.assertEqual(mock_func.call_count, 1)
+
 
 class WorkerGenerateGutachtenTests(NoesisTestCase):
     def setUp(self):

--- a/core/views.py
+++ b/core/views.py
@@ -2664,6 +2664,10 @@ def projekt_file_edit_json(request, pk):
     except BVProjectFile.DoesNotExist:
         raise Http404
 
+    if anlage.anlage_nr == 2 and not anlage.analysis_json:
+        run_anlage2_analysis(anlage)
+        anlage.refresh_from_db()
+
     if anlage.anlage_nr == 1:
         if request.method == "POST":
             form = Anlage1ReviewForm(request.POST)


### PR DESCRIPTION
## Summary
- call `run_anlage2_analysis` from `projekt_file_edit_json` when needed
- ensure idempotence in new unit test

## Testing
- `python manage.py makemigrations --check --merge` *(fails: multiple leaf nodes)*
- `python manage.py test core.tests.test_general.Anlage2ReviewTests.test_auto_analysis_runs_once_for_new_file -v 2` *(fails: conflicting migrations)*

------
https://chatgpt.com/codex/tasks/task_e_6874ab33254c832b989d155d844f6ae9