### PR TITLE
feat: kompaktes Parser-Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ python manage.py test
 ## Logging
 
 Alle Debug-Ausgaben des Projekts werden zusätzlich in `debug.log` im Projektverzeichnis gespeichert. Diese Datei ist über `.gitignore` vom Versionskontrollsystem ausgenommen.
-Parserbezogene Informationen landen in `parser-debug.log` im selben Verzeichnis. Das Log protokolliert alle Schritte beim Einlesen der Tabelle.
+Parserbezogene Informationen landen in `parser-debug.log` im selben Verzeichnis. Das Log fasst gefundene Funktionen zusammen und vermerkt nur kurz nicht erkannte Zeilen.
 Während der Entwicklung schreibt jede Anlage ihr eigenes Debug-Log. Die Dateien
 `anlage1-debug.log` bis `anlage5-debug.log` enthalten detaillierte Meldungen der
 jeweiligen Analysefunktionen. Durch den Eintrag `*.log` im `.gitignore` werden
@@ -124,8 +124,8 @@ Extrahieren berücksichtigt.
 
 Beim Hochladen einer Anlage 2 startet automatisch die KI‑Prüfung. Zuerst
 analysiert der Parser das Dokument, anschließend bewertet das LLM alle
-gefundenen Funktionen. Die Ergebnisse landen wie gewohnt in der Logdatei
-`parser-debug.log`.
+gefundenen Funktionen. Die Ergebnisse werden kompakt in `parser-debug.log`
+gespeichert.
 
 In der Projektübersicht stehen zwei Schaltflächen bereit. Über **Prüfen** wird
 der Parser erneut ausgeführt, um aktualisierte Dateien einzulesen. Mit

--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -244,6 +244,8 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
     logger.debug("Erzeugtes Header-Mapping: %s", header_map)
 
     results: list[dict[str, object]] = []
+    found: list[str] = []
+    skipped = 0
     if not doc.tables:
         logger.debug("Keine Tabellen im Dokument gefunden")
         parser_logger.debug("Keine Tabellen im Dokument gefunden")
@@ -315,6 +317,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
                     "Zeile %s: Keine verarbeitbare Funktion gefunden, übersprungen",
                     row_idx,
                 )
+                skipped += 1
                 continue
 
             for col_name, idx in col_indices.items():
@@ -322,6 +325,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
                     row_data[col_name] = _parse_cell_value(row.cells[idx].text)
 
             parser_logger.debug("Verarbeite Zeile %s: %s", row_idx, row_data)
+            found.append(row_data["funktion"])
             logger.debug(
                 "Zeile %s: Funktion '%s' Daten %s",
                 row_idx,
@@ -336,6 +340,10 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
             break
 
     logger.debug(f"Endgültige Ergebnisse: {results}")
+    if found:
+        parser_logger.info("Gefundene Funktionen: %s", ", ".join(found))
+    if skipped:
+        parser_logger.info("Übersprungene Zeilen: %s", skipped)
     parser_logger.info("parse_anlage2_table beendet: %s", path)
     return results
 

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -134,6 +134,7 @@ def parse_anlage2_text(text: str, threshold: int = 80) -> List[dict[str, object]
 
     results: Dict[Tuple[int, int | None], Dict[str, object]] = {}
     unmatched: List[Dict[str, object]] = []
+    found: List[str] = []
     last_key: Tuple[int, int | None] | None = None
 
     for raw in text.splitlines():
@@ -223,7 +224,7 @@ def parse_anlage2_text(text: str, threshold: int = 80) -> List[dict[str, object]
                 name = func.name if sub is None else f"{func.name}: {sub.frage_text}"
                 entry = {"funktion": name}
                 results[key] = entry
-                parser_logger.debug("Neuer Eintrag für '%s'", name)
+                found.append(name)
             _apply_tokens(entry, after or line)
             _apply_rules(entry, after or line)
             last_key = key
@@ -237,7 +238,6 @@ def parse_anlage2_text(text: str, threshold: int = 80) -> List[dict[str, object]
             _apply_tokens(entry, after or line)
             _apply_rules(entry, after or line)
         else:
-            parser_logger.warning("Keine Funktion gefunden für Zeile: %s", line)
             entry = {"funktion": before}
             _apply_tokens(entry, after or line)
             _apply_rules(entry, after or line)
@@ -245,6 +245,10 @@ def parse_anlage2_text(text: str, threshold: int = 80) -> List[dict[str, object]
             unmatched.append(entry)
 
     all_results = list(results.values()) + unmatched
+    if found:
+        parser_logger.info("Gefundene Funktionen: %s", ", ".join(found))
+    if unmatched:
+        parser_logger.info("Zeilen ohne Treffer: %s", len(unmatched))
     parser_logger.info(
         "parse_anlage2_text beendet: %s Einträge", len(all_results)
     )

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -268,7 +268,7 @@ LOGGING = {
         },
         "parser_debug": {
             "handlers": ["parser_file"],
-            "level": "DEBUG",
+            "level": "INFO",
             "propagate": False,
         },
         "anlage1_debug": {


### PR DESCRIPTION
## Summary
- Protokollierung des Parsers reduziert und nur noch Ergebnisse sichtbar
- Parser-Loglevel auf INFO gesetzt
- Dokumentation zum verkürzten Log angepasst

## Testing
- `python manage.py makemigrations --check` *(fails: Migration core.0019_merge_20250714_0907 dependencies reference nonexistent parent node ('core', '0018_zweckkategoriea'))*

------
https://chatgpt.com/codex/tasks/task_e_6874c2a51a14832bba440c10ce124e09