### PR TITLE
Fix async task trigger for uploads

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -498,7 +498,7 @@ class ProjektFileUploadTests(NoesisTestCase):
         Anlage2Function.objects.create(name="Login")
 
         url = reverse("projekt_file_upload", args=[self.projekt.pk])
-        with patch("core.views.async_task") as mock_async:
+        with patch("core.models.async_task", return_value="tid1") as mock_async:
             resp = self.client.post(
                 url,
                 {"anlage_nr": 2, "upload": upload, "manual_comment": ""},
@@ -507,6 +507,7 @@ class ProjektFileUploadTests(NoesisTestCase):
         self.assertEqual(resp.status_code, 302)
         pf = self.projekt.anlagen.get(anlage_nr=2)
         self.assertIsNone(pf.analysis_json)
+        self.assertEqual(pf.verification_task_id, "tid1")
         mock_async.assert_called_with(
             "core.llm_tasks.check_anlage2_functions",
             self.projekt.pk,

--- a/core/views.py
+++ b/core/views.py
@@ -2523,14 +2523,6 @@ def projekt_file_upload(request, pk):
             obj.projekt = projekt
             obj.text_content = content
             obj.save()
-            if obj.anlage_nr == 2 and not obj.verification_task_id:
-                task_id = async_task(
-                    "core.llm_tasks.check_anlage2_functions",
-                    projekt.pk,
-                )
-                if task_id:
-                    obj.verification_task_id = str(task_id)
-                    obj.save(update_fields=["verification_task_id"])
             return redirect("projekt_detail", pk=projekt.pk)
     else:
         form = BVProjectFileForm()


### PR DESCRIPTION
## Summary
- remove duplicate async queue from `projekt_file_upload`
- adjust test to patch `core.models.async_task`

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6874d714ffd8832b98b741a8f5c81a4b