### PR TITLE
Handle newline-split Anlage‑1 questions

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -123,9 +123,9 @@ def parse_structured_anlage(text_content: str) -> dict | None:
 def _clean_text(text: str) -> str:
     """Bereinigt Sonderzeichen vor dem Parsen."""
     text = text.replace("\\n", " ")
-    text = text.replace("\n", " ").replace("\r", " ").replace("\t", " ")
+    text = re.sub(r"[\r\n\t]+", " ", text)
     text = text.replace("\u00b6", " ")
-    text = re.sub(r" {2,}", " ", text)
+    text = re.sub(r"\s{2,}", " ", text)
     return text.strip()
 
 
@@ -168,10 +168,11 @@ def parse_anlage1_questions(
             if m_start:
                 rest = m_start.group(1)
                 pattern = re.compile(
-                    r"Frage\s+\d+(?:\.\d+)?[:.]?\s*" + re.escape(_clean_text(rest))
+                    r"Frage\s+\d+(?:\.\d+)?[:.]?\s*" + re.escape(_clean_text(rest)),
+                    re.IGNORECASE | re.DOTALL,
                 )
             else:
-                pattern = re.compile(re.escape(clean_var))
+                pattern = re.compile(re.escape(clean_var), re.IGNORECASE | re.DOTALL)
             m = pattern.search(text_content)
             if m and (best is None or m.start() < best[0]):
                 best = (m.start(), m.end(), m.group(0))


### PR DESCRIPTION
## Summary
- improve `_clean_text` normalisation
- adjust regex patterns in `parse_anlage1_questions`
- ensure test data always creates Anlage 1 questions
- test parsing when questions are split across lines

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.LLMTasksTests.test_parse_anlage1_questions_with_newlines core.tests.test_general.LLMTasksTests.test_parse_anlage1_questions_split_lines -v 2 --keepdb`

------
https://chatgpt.com/codex/tasks/task_e_6874e38b6b2c832bb52fdc089e62c223