### PR TITLE
Fix seed_test_data to create Anlage1Question entries

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -164,7 +164,21 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
     try:
         create_initial_data(django_apps, None)
     except LookupError:
-        pass
+        # Falls die Migrationsfunktion wegen entfernter Modelle
+        # fehlschlägt, legen wir die benötigten Objekte manuell an.
+        Anlage1QuestionModel = apps.get_model("core", "Anlage1Question")
+        Anlage1QuestionVariant = apps.get_model("core", "Anlage1QuestionVariant")
+        for idx, text in enumerate(ANLAGE1_QUESTIONS, start=1):
+            question, _ = Anlage1QuestionModel.objects.update_or_create(
+                num=idx,
+                defaults={
+                    "text": text,
+                    "enabled": True,
+                    "parser_enabled": True,
+                    "llm_enabled": True,
+                },
+            )
+            Anlage1QuestionVariant.objects.get_or_create(question=question, text=text)
     create_statuses()
 
     # Anlage1 Fragen aktualisieren


### PR DESCRIPTION
## Summary
- ensure `seed_test_data` recreates Anlage1Question objects when the old migration fails

## Testing
- `python manage.py makemigrations --check`
- `python manage.py shell -c "from core.tests.test_general import seed_test_data; seed_test_data(); from core.models import Anlage1Question; print('count', Anlage1Question.objects.count()); print('nums', list(Anlage1Question.objects.order_by('num').values_list('num', flat=True)))"`
- `python manage.py test core.tests.test_general -k test_check_anlage1_parser -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6874e38cd93c832bafd28a4c34d7eafe