### PR TITLE
Fix Anlage-2 analysis storage format

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -272,7 +272,7 @@ def _parse_anlage2(text_content: str, project_prompt: str | None = None) -> list
 def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]:
     """Parst eine Anlage 2-Datei anhand der Konfiguration.
 
-    Das Ergebnis wird als JSON-String im Feld ``analysis_json`` gespeichert,
+    Das Ergebnis wird als JSON-Objekt im Feld ``analysis_json`` gespeichert,
     damit die originale Struktur unverändert erhalten bleibt.
     """
 
@@ -292,7 +292,7 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
     else:
         analysis_result = parser_manager.parse_anlage2(project_file)
 
-    project_file.analysis_json = json.dumps(analysis_result, ensure_ascii=False)
+    project_file.analysis_json = {"functions": analysis_result}
     project_file.save(update_fields=["analysis_json"])
 
     # Dokumentergebnisse in Anlage2FunctionResult speichern

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -910,7 +910,7 @@ class LLMTasksTests(NoesisTestCase):
         res = Anlage2FunctionResult.objects.get(projekt=projekt, funktion=func)
         self.assertTrue(res.doc_result["technisch_verfuegbar"]["value"])
         self.assertEqual(result, expected)
-        self.assertEqual(json.loads(pf.analysis_json), expected)
+        self.assertEqual(pf.analysis_json["functions"], expected)
 
     def test_run_anlage2_analysis_sets_negotiable_on_match(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")


### PR DESCRIPTION
## Summary
- store Anlage-2 parser results directly as JSON object
- adapt tests to check new format

## Testing
- `python manage.py makemigrations --check`
- `pytest -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_6874edbd0e50832b9c3ae61804f22941