### PR TITLE
Fix template check test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -448,7 +448,7 @@ class BVProjectFileTests(NoesisTestCase):
             verification_task_id="tid",
         )
         self.client.login(username=self.user.username, password="pass")
-        with patch("django_q.tasks.fetch") as mock_fetch:
+        with patch("core.models.fetch") as mock_fetch:
             mock_fetch.return_value = SimpleNamespace(success=None)
             url = reverse("projekt_detail", args=[projekt.pk])
             resp = self.client.get(url)


### PR DESCRIPTION
## Summary
- mock the correct `fetch` function when verifying the disabled state

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_template_shows_disabled_state_when_task_running -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6874f4639008832bbca3395c9a6fee02