### PR TITLE
Fix failing Anlage4 review test

### DIFF
--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1200,7 +1200,10 @@ class Anlage4ReviewViewTests(NoesisTestCase):
         self.file.refresh_from_db()
         self.assertEqual(
             self.file.manual_analysis_json,
-            {"0": {"ok": True, "note": "gut"}, "1": {"ok": False, "note": "schlecht"}},
+            {
+                "0": {"ok": True, "nego": False, "note": "gut"},
+                "1": {"ok": False, "nego": False, "note": "schlecht"},
+            },
         )
 
 


### PR DESCRIPTION
## Summary
- update expectations for manual review data in Anlage4ReviewViewTests

## Testing
- `python manage.py test core.tests.test_parsing.Anlage4ReviewViewTests.test_post_saves_manual_review -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6874f46e5da4832b9ef8dbd44f4bd1f8