### PR TITLE
fix: stabilize free text log check

### DIFF
--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -786,7 +786,7 @@ class Anlage4ParserTests(NoesisTestCase):
         )
         with self.assertLogs("anlage4_debug", level="DEBUG") as cm:
             parse_anlage4(pf)
-        self.assertIn("free text found - 1 items", cm.output[0])
+        self.assertIn("free text found - 1 items", "".join(cm.output))
 
     def test_dual_parser_handles_invalid_rules(self):
         pcfg = Anlage4ParserConfig.objects.create(delimiter_phrase="")


### PR DESCRIPTION
## Summary
- make logging assertion flexible in `test_logs_free_text_detection`

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6874fe78a894832b858472c6bba85fb0