### PR TITLE
Fix Anlage2ConfigForm required fields

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -503,6 +503,37 @@ class Anlage2ConfigForm(forms.ModelForm):
         required=False,
     )
 
+    OPTIONAL_JSON_FIELDS = [
+        "text_technisch_verfuegbar_true",
+        "text_technisch_verfuegbar_false",
+        "text_einsatz_telefonica_true",
+        "text_einsatz_telefonica_false",
+        "text_zur_lv_kontrolle_true",
+        "text_zur_lv_kontrolle_false",
+        "text_ki_beteiligung_true",
+        "text_ki_beteiligung_false",
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for name in self.OPTIONAL_JSON_FIELDS:
+            self.fields[name].required = False
+        # Vorhandene Instanzwerte nutzen, falls nichts übergeben wurde
+        self.fields["parser_mode"].required = False
+
+    def save(self, commit: bool = True) -> Anlage2Config:
+        """Speichert nur übergebene Werte."""
+        instance = super().save(commit=False)
+        for name in self.OPTIONAL_JSON_FIELDS:
+            if self.cleaned_data.get(name) is None:
+                # Fehlender Wert: Ursprünglichen beibehalten
+                setattr(instance, name, getattr(self.instance, name))
+        if not self.cleaned_data.get("parser_mode"):
+            instance.parser_mode = self.instance.parser_mode
+        if commit:
+            instance.save()
+        return instance
+
     class Meta:
         model = Anlage2Config
 


### PR DESCRIPTION
## Summary
- allow partial updates in Anlage2ConfigForm
- preserve unchanged parser configuration fields

## Testing
- `python manage.py test core.tests.test_forms.Anlage2ConfigFormTests.test_parser_order_field -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6874fe8f6b5c832b957f6ff70b82db6e