### PR TITLE
Fix PDF save in tests

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -486,8 +486,8 @@ class ProjektFileUploadTests(NoesisTestCase):
         pdf = fitz.open()
         pdf.new_page()
         tmp = NamedTemporaryFile(delete=False, suffix=".pdf")
-        pdf.save(tmp.name)
         tmp.close()
+        pdf.save(tmp.name)
         with open(tmp.name, "rb") as fh:
             upload = SimpleUploadedFile("t.pdf", fh.read())
         Path(tmp.name).unlink(missing_ok=True)
@@ -1225,8 +1225,8 @@ class LLMTasksTests(NoesisTestCase):
         pdf = fitz.open()
         pdf.new_page()
         tmp = NamedTemporaryFile(delete=False, suffix=".pdf")
-        pdf.save(tmp.name)
         tmp.close()
+        pdf.save(tmp.name)
         with open(tmp.name, "rb") as fh:
             upload = SimpleUploadedFile("c.pdf", fh.read())
         Path(tmp.name).unlink(missing_ok=True)
@@ -1248,8 +1248,8 @@ class LLMTasksTests(NoesisTestCase):
         pdf.new_page()
         pdf.new_page()
         tmp = NamedTemporaryFile(delete=False, suffix=".pdf")
-        pdf.save(tmp.name)
         tmp.close()
+        pdf.save(tmp.name)
         with open(tmp.name, "rb") as fh:
             upload = SimpleUploadedFile("d.pdf", fh.read())
         Path(tmp.name).unlink(missing_ok=True)

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -46,8 +46,8 @@ class DocxExtractTests(NoesisTestCase):
         pdf = fitz.open()
         pdf.new_page()
         tmp = NamedTemporaryFile(delete=False, suffix=".pdf")
-        pdf.save(tmp.name)
         tmp.close()
+        pdf.save(tmp.name)
         try:
             count = get_pdf_page_count(Path(tmp.name))
         finally:
@@ -59,8 +59,8 @@ class DocxExtractTests(NoesisTestCase):
         pdf.new_page()
         pdf.new_page()
         tmp = NamedTemporaryFile(delete=False, suffix=".pdf")
-        pdf.save(tmp.name)
         tmp.close()
+        pdf.save(tmp.name)
         try:
             count = get_pdf_page_count(Path(tmp.name))
         finally:


### PR DESCRIPTION
## Summary
- close NamedTemporaryFile before saving PDFs to prevent permission errors

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6874fee28b94832b8fe5ec71558183f1