### PR TITLE
Fix test by exporting parse_anlage2_table and using auto fallback

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -37,6 +37,7 @@ from .docx_utils import (
     extract_images,
     get_docx_page_count,
     get_pdf_page_count,
+    parse_anlage2_table,
 )
 from .parser_manager import parser_manager
 from .anlage4_parser import parse_anlage4, parse_anlage4_dual
@@ -290,6 +291,14 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
             project_file.text_content,
         )
         analysis_result = parse_anlage2_text(project_file.text_content)
+    elif mode == "auto":
+        analysis_result = parse_anlage2_table(Path(project_file.upload.path))
+        if not analysis_result:
+            parser_logger.debug(
+                "Textinhalt vor Text-Parser:\n%s",
+                project_file.text_content,
+            )
+            analysis_result = parse_anlage2_text(project_file.text_content)
     else:
         analysis_result = parser_manager.parse_anlage2(project_file)
 


### PR DESCRIPTION
## Summary
- expose `parse_anlage2_table` in `llm_tasks`
- prefer table parser when analysing Anlage 2 in auto mode

## Testing
- `python manage.py test core.tests.test_general.LLMTasksTests.test_run_anlage2_analysis_auto_prefers_table -v 2`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6874feab4a48832bbd621c1f946420d1