### PR TITLE
Fix value resolution fallback

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -412,6 +412,8 @@ def _resolve_value(
             return manual_val, "Manuell"
         if ai_val is not None:
             return ai_val, "KI-Prüfung"
+        if doc_val is not None:
+            return doc_val, "Dokumenten-Analyse"
         return None, "N/A"
 
     if field in {"einsatz_bei_telefonica", "zur_lv_kontrolle"}:


### PR DESCRIPTION
## Summary
- ensure `_resolve_value` checks document analysis results as a fallback for `technisch_vorhanden`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ReviewTests.test_prefill_from_analysis -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6875007516c8832b97b8b05e5e49a9d0