### PR TITLE
Fix Token Parsing

### DIFF
--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -145,6 +145,8 @@ def parse_anlage2_text(text: str, threshold: int = 80) -> List[dict[str, object]
         lower = text_part.lower()
         parser_logger.debug("Prüfe Tokens in '%s'", text_part)
         for field, value, phrases in token_map:
+            if field in entry:
+                continue
             for phrase in phrases:
                 if phrase in lower:
                     parser_logger.debug(


### PR DESCRIPTION
## Summary
- ensure parse_anlage2_text does not override previously applied tokens

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_parsing.py::DocxExtractTests::test_subquestion_processed_when_main_present -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fe68e9c8832b98982e1f161be168