### PR TITLE
Import parse_anlage2_table

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -37,6 +37,7 @@ from .docx_utils import (
     extract_images,
     get_docx_page_count,
     get_pdf_page_count,
+    parse_anlage2_table,
 )
 from .parser_manager import parser_manager
 from .anlage4_parser import parse_anlage4, parse_anlage4_dual


### PR DESCRIPTION
## Summary
- add missing `parse_anlage2_table` import in llm_tasks
- ran migrations check
- executed tests (failures unrelated to import)

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: AttributeError: module 'fitz' has no attribute 'open', etc.)*
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68750108e37c832ba600e97670a6ceeb