### PR TITLE
Update parser manager tests for new parser_mode

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -967,6 +967,7 @@ class LLMTasksTests(NoesisTestCase):
         parser_manager.register(DummyParser)
         cfg = Anlage2Config.get_instance()
         cfg.parser_order = ["fail", "dummy"]
+        cfg.parser_mode = "manager"
         cfg.save()
 
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -990,6 +991,7 @@ class LLMTasksTests(NoesisTestCase):
             parser_manager._parsers.pop("fail")
             parser_manager._parsers.pop("dummy")
             cfg.parser_order = ["table"]
+            cfg.parser_mode = "auto"
             cfg.save()
 
         self.assertEqual(result, [{"funktion": "Dummy"}])
@@ -1011,6 +1013,7 @@ class LLMTasksTests(NoesisTestCase):
         parser_manager.register(P2)
         cfg = Anlage2Config.get_instance()
         cfg.parser_order = ["two", "one"]
+        cfg.parser_mode = "manager"
         cfg.save()
 
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -1033,6 +1036,7 @@ class LLMTasksTests(NoesisTestCase):
             parser_manager._parsers.pop("one")
             parser_manager._parsers.pop("two")
             cfg.parser_order = ["table"]
+            cfg.parser_mode = "auto"
             cfg.save()
 
         self.assertEqual(result, [{"val": 2}])
@@ -1058,6 +1062,7 @@ class LLMTasksTests(NoesisTestCase):
         parser_manager.register(P2)
         cfg = Anlage2Config.get_instance()
         cfg.parser_order = ["p1", "p2"]
+        cfg.parser_mode = "manager"
         cfg.save()
 
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -1086,10 +1091,11 @@ class LLMTasksTests(NoesisTestCase):
             parser_manager._parsers.pop("p1", None)
             parser_manager._parsers.pop("p2", None)
             cfg.parser_order = ["table"]
+            cfg.parser_mode = "auto"
             cfg.save()
 
         m_tab.assert_not_called()
-        m_text.assert_called_once()
+        m_text.assert_not_called()
 
     def test_run_anlage2_analysis_auto_prefers_table(self):
 


### PR DESCRIPTION
## Summary
- make parser manager tests self-sufficient
- ensure `run_anlage2_analysis` uses the manager mode in these tests
- adjust assertions accordingly

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.LLMTasksTests.test_parser_manager_selects_best core.tests.test_general.LLMTasksTests.test_parser_manager_order core.tests.test_general.LLMTasksTests.test_parser_manager_fallback`

------
https://chatgpt.com/codex/tasks/task_e_6875048a1a68832ba137ab9904d1677e