### PR TITLE
Handle Anlage2Config multiline fields

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -54,6 +54,7 @@ from docx import Document
 import shutil
 from PIL import Image
 import fitz
+from django.conf import settings
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from ..forms import (
@@ -2973,6 +2974,22 @@ class Anlage2ConfigViewTests(NoesisTestCase):
         self.assertTrue(
             Anlage2ColumnHeading.objects.filter(text="Verfügbar?").exists()
         )
+
+    def test_multiline_phrases_saved(self):
+        url = reverse("anlage2_config")
+        resp = self.client.post(
+            url,
+            {
+                "text_technisch_verfuegbar_true": "ja\nokay\n",
+                "parser_mode": self.cfg.parser_mode,
+                "parser_order": self.cfg.parser_order,
+                "action": "save_general",
+                "active_tab": "general",
+            },
+        )
+        self.assertRedirects(resp, url + "?tab=general")
+        self.cfg.refresh_from_db()
+        self.assertEqual(self.cfg.text_technisch_verfuegbar_true, ["ja", "okay"])
 
 class AjaxAnlage2ReviewTests(NoesisTestCase):
     def setUp(self):

--- a/core/views.py
+++ b/core/views.py
@@ -2025,13 +2025,17 @@ def anlage2_config(request):
 
         if action == "save_general":
             admin_a2_logger.debug("Speichere Allgemeine Einstellungen")
-            cfg.enforce_subquestion_override = bool(
-                request.POST.get("enforce_subquestion_override")
-            )
-            cfg.parser_order = request.POST.getlist("parser_order")
-            cfg.save(update_fields=["enforce_subquestion_override", "parser_order"])
-            messages.success(request, "Einstellungen gespeichert")
-            return redirect(f"{reverse('anlage2_config')}?tab=general")
+            cfg_form = Anlage2ConfigForm(request.POST, instance=cfg)
+            if cfg_form.is_valid():
+                admin_a2_logger.debug(
+                    "Ge\u00e4nderte Felder: %r",
+                    {f: cfg_form.cleaned_data[f] for f in cfg_form.changed_data},
+                )
+                cfg_form.save()
+                messages.success(request, "Einstellungen gespeichert")
+                return redirect(f"{reverse('anlage2_config')}?tab=general")
+            messages.error(request, "Bitte korrigieren Sie die markierten Felder.")
+            active_tab = "general"
 
 
 


### PR DESCRIPTION
## Summary
- support newline phrase lists in `Anlage2ConfigForm`
- save optional text phrases correctly
- process form in view when saving general settings
- test multiline phrase posting

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test --noinput` *(fails: test_parser_manager_fallback, test_parser_manager_order, test_parser_manager_selects_best)*

------
https://chatgpt.com/codex/tasks/task_e_687507037c80832b967ba9a56ed58f13