### PR TITLE
Implement bedingte Prüfung für Anlage2

### DIFF
--- a/core/management/commands/check_anlage2_functions.py
+++ b/core/management/commands/check_anlage2_functions.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from core.llm_tasks import check_anlage2_functions
+from core.llm_tasks import run_conditional_anlage2_check
 from core.cli_utils import print_markdown
 import json
 
@@ -12,6 +12,5 @@ class Command(BaseCommand):
         parser.add_argument("--model", dest="model", default=None)
 
     def handle(self, projekt_id, model=None, **options):
-        data = check_anlage2_functions(projekt_id, model_name=model)
-        text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
-        print_markdown(text)
+        run_conditional_anlage2_check(projekt_id, model_name=model)
+        print_markdown("Prüfung abgeschlossen")


### PR DESCRIPTION
## Summary
- neue Funktion `run_conditional_anlage2_check` führt Funktionsprüfungen nur bei positivem Hauptcheck aus
- Upload und Button "Alle Funktionen prüfen" nutzen nun diese Funktion
- Tests und Management-Command angepasst

## Testing
- `python manage.py makemigrations --check`
- `pytest -q` *(fehlschlag: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_68756dcbb86c832bb0ec9c9007ea26f9