### PR TITLE
fix: parse JSON replies in feature verification

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1418,6 +1418,14 @@ def worker_verify_feature(
             project_prompt=projekt.project_prompt,
         )
         ans = reply.strip()
+        try:
+            json_data = json.loads(ans)
+        except Exception:  # noqa: BLE001
+            json_data = None
+        if isinstance(json_data, dict) and "technisch_verfuegbar" in json_data:
+            val = json_data.get("technisch_verfuegbar")
+            individual_results.append(val if isinstance(val, bool) else None)
+            continue
         low = ans.lower()
         if low.startswith("ja"):
             individual_results.append(True)


### PR DESCRIPTION
## Summary
- support JSON replies in `worker_verify_feature`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py test core.tests.test_general.LLMTasksTests.test_check_anlage2_functions_stores_result`

------
https://chatgpt.com/codex/tasks/task_e_6875971529e0832bbe7b44391c1355f0