### PR TITLE
Fix automatic analysis for new Anlage 2 files

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2670,6 +2670,12 @@ def projekt_file_edit_json(request, pk):
         anlage = BVProjectFile.objects.get(pk=pk)
     except BVProjectFile.DoesNotExist:
         raise Http404
+    if (
+        request.method == "GET" and anlage.anlage_nr == 2 and not anlage.analysis_json
+    ):
+        run_anlage2_analysis(anlage)
+        anlage.refresh_from_db()
+
 
 
     if anlage.anlage_nr == 1:


### PR DESCRIPTION
## Summary
- trigger parser when opening an unanalysed Anlage 2 file the first time

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ReviewTests.test_auto_analysis_runs_once_for_new_file -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6875971b14dc832b9ce8d582835419c6