### PR TITLE
Add fuzzy token tests

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -31,7 +31,12 @@ from .models import (
     SoftwareKnowledge,
     Gutachten,
 )
-from .text_parser import build_token_map, apply_tokens, apply_rules
+from .text_parser import (
+    build_token_map,
+    apply_tokens,
+    apply_rules,
+    parse_anlage2_text,
+)
 from .llm_utils import query_llm, query_llm_with_images
 from .docx_utils import (
     extract_text,
@@ -39,6 +44,7 @@ from .docx_utils import (
     extract_images,
     get_docx_page_count,
     get_pdf_page_count,
+    parse_anlage2_table,
 )
 from thefuzz import fuzz
 from .parser_manager import parser_manager

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -563,6 +563,41 @@ class DocxExtractTests(NoesisTestCase):
             ],
         )
 
+    def test_parse_anlage2_text_fuzzy_token_phrase(self):
+        func = Anlage2Function.objects.create(name="Login")
+        cfg = Anlage2Config.get_instance()
+        cfg.text_technisch_verfuegbar_true = ["ja bitte"]
+        cfg.save()
+        data = parse_anlage2_text("Lgin: ja bitte")
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Login",
+                    "technisch_verfuegbar": {"value": True, "note": None},
+                }
+            ],
+        )
+
+    def test_parse_anlage2_text_fuzzy_rule_phrase(self):
+        func = Anlage2Function.objects.create(name="Login")
+        AntwortErkennungsRegel.objects.create(
+            regel_name="aktiv",
+            erkennungs_phrase="aktivv",
+            ziel_feld="einsatz_telefonica",
+            wert=True,
+        )
+        data = parse_anlage2_text("Lgin: aktivv")
+        self.assertEqual(
+            data,
+            [
+                {
+                    "funktion": "Login",
+                    "einsatz_telefonica": {"value": True, "note": None},
+                }
+            ],
+        )
+
     def test_parse_anlage2_text_multiple_rules_priority(self):
         func = Anlage2Function.objects.create(name="Login")
         AntwortErkennungsRegel.objects.create(


### PR DESCRIPTION
## Summary
- add tests with altered token and rule phrases
- expose parsing helpers in llm_tasks for patching

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: failures=5, errors=1)*

------
https://chatgpt.com/codex/tasks/task_e_68761514be84832ba5f3fc92b377308b