### PR TITLE
Disable technical availability editing for sub questions

### DIFF
--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -504,7 +504,6 @@ class DocxExtractTests(NoesisTestCase):
             [
                 {
                     "funktion": "Analyse-/Reportingfunktionen - Bitte wähle zutreffendes aus",
-                    "technisch_verfuegbar": {"value": True, "note": None},
                 }
             ],
         )
@@ -683,7 +682,6 @@ class DocxExtractTests(NoesisTestCase):
                 },
                 {
                     "funktion": "Anwesenheit: Grund?",
-                    "technisch_verfuegbar": {"value": False, "note": None},
                 },
             ],
         )

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -369,6 +369,9 @@ def parse_anlage2_text(
             apply_tokens(entry, after or line, token_map, threshold)
             apply_rules(entry, after or line, rules, threshold)
 
+    for entry in sub_results.values():
+        entry.pop("technisch_verfuegbar", None)
+
     all_results = [
         entry for entry in main_results.values() if not entry.pop("_skip_output", False)
     ] + list(sub_results.values())

--- a/core/views.py
+++ b/core/views.py
@@ -478,20 +478,30 @@ def _build_row_data(
     rev_origin = {}
     for field, _ in fields_def:
         bf = form[f"{form_prefix}{field}"]
-        if field == "technisch_vorhanden" and sub_id is None:
-            initial_value = disp["values"].get(field)
-            state = (
-                "true"
-                if initial_value is True
-                else "false" if initial_value is False else "unknown"
-            )
-            bf.field.widget.attrs.update(
-                {
-                    "data-tristate": "true",
-                    "data-initial-state": state,
-                    "style": "display: none;",
-                }
-            )
+        if field == "technisch_vorhanden":
+            if sub_id is None:
+                initial_value = disp["values"].get(field)
+                state = (
+                    "true"
+                    if initial_value is True
+                    else "false" if initial_value is False else "unknown"
+                )
+                bf.field.widget.attrs.update(
+                    {
+                        "data-tristate": "true",
+                        "data-initial-state": state,
+                        "style": "display: none;",
+                    }
+                )
+            else:
+                bf.field.widget.attrs.update(
+                    {
+                        "data-tristate": "true",
+                        "data-initial-state": "unknown",
+                        "style": "display: none;",
+                        "disabled": "disabled",
+                    }
+                )
         if field == "technisch_vorhanden":
             man_val = manual_lookup.get(lookup_key, {}).get(field)
             ai_val = verification_lookup.get(lookup_key, {}).get(field)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -152,3 +152,15 @@ input[type="submit"]:hover {
     opacity: 0.5;
     pointer-events: none;
 }
+
+/* Deaktivierte Tri-State-Icons */
+.tri-state-icon.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+/* Deaktivierte Eingabefelder */
+input[disabled] {
+    opacity: 0.5;
+    pointer-events: none;
+}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -121,17 +121,18 @@
                 </td>
                 {% endwith %}
                 {% elif field == 'technisch_vorhanden' and row.sub %}
+                {% with f=row.form_fields|list_index:forloop.counter0 %}
                 <td class="border px-2 text-center">
-                    {% with parsed=row.doc_result|get_item:field %}
-                    {% if parsed == True %}
-                        <span class="status-badge status-ja" data-bs-toggle="tooltip" title="Dok: {{ doc|get_item:'value' }}{% if note %} - {{ note }}{% endif %}">✓ Vorhanden</span>
-                    {% elif parsed == False %}
-                        <span class="status-badge status-nein" data-bs-toggle="tooltip" title="Dok: {{ doc|get_item:'value' }}{% if note %} - {{ note }}{% endif %}">✗ Nicht vorhanden</span>
-                    {% else %}
-                        <span class="status-badge status-unbekannt" data-bs-toggle="tooltip" title="Dok: {{ doc|get_item:'value' }}{% if note %} - {{ note }}{% endif %}">? Unbekannt</span>
-                    {% endif %}
+                    <span class="tri-state-icon disabled" data-input-id="{{ f.auto_id }}"></span>
+                    {{ f.widget }}
+                    {% if f.source %}<span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>{% endif %}
+                    {% with parsed=row.doc_result|raw_item:field %}
+                    <span class="text-xs text-gray-500 ms-1">Parser-Ergebnis:
+                        {% if parsed == True %}Ja{% elif parsed == False %}Nein{% else %}Unbekannt{% endif %}
+                    </span>
                     {% endwith %}
                 </td>
+                {% endwith %}
                 {% else %}
                 <td class="border px-2 text-center">
                     {% if field == 'technisch_vorhanden' %}


### PR DESCRIPTION
## Summary
- disable tri-state input for sub questions in review table
- skip parsing `technisch_verfuegbar` for sub questions
- adjust styles for disabled elements
- update tests for new behavior

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_parsing.py::FuzzyTextParserTests::test_parse_anlage2_text_prefers_specific_subquestion core/tests/test_parsing.py::FuzzyTextParserTests::test_subquestion_processed_when_main_present -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_68764a2a7b84832bb8b4bcae25e4de3a