### PR TITLE
Disable tech field for subquestions

### DIFF
--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -300,6 +300,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
             )
 
             row_data: dict[str, object] | None = None
+            is_sub = False
 
             if main_col_text and "Wenn die Funktion technisch" not in main_col_text:
                 current_main_function_name = main_col_text
@@ -311,6 +312,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
                 full_name = f"{current_main_function_name}: {sub_col_text}"
                 parser_logger.debug("Unterfrage erkannt: %s", full_name)
                 row_data = {"funktion": full_name}
+                is_sub = True
 
             if row_data is None:
                 logger.debug(
@@ -322,6 +324,8 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
 
             for col_name, idx in col_indices.items():
                 if idx is not None:
+                    if is_sub and col_name == "technisch_verfuegbar":
+                        continue
                     row_data[col_name] = _parse_cell_value(row.cells[idx].text)
 
             parser_logger.debug("Verarbeite Zeile %s: %s", row_idx, row_data)

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -386,10 +386,7 @@ class DocxExtractTests(NoesisTestCase):
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "ki_beteiligung": {"value": False, "note": None},
                 },
-                {
-                    "funktion": "Login: Warum?",
-                    "technisch_verfuegbar": {"value": False, "note": None},
-                },
+                {"funktion": "Login: Warum?"},
             ],
         )
 
@@ -414,10 +411,7 @@ class DocxExtractTests(NoesisTestCase):
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "ki_beteiligung": {"value": False, "note": None},
                 },
-                {
-                    "funktion": "Login: Warum?",
-                    "technisch_verfuegbar": {"value": False, "note": None},
-                },
+                {"funktion": "Login: Warum?"},
             ],
         )
 
@@ -444,10 +438,7 @@ class DocxExtractTests(NoesisTestCase):
                     "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                 },
-                {
-                    "funktion": "Anmelden: Grund?",
-                    "technisch_verfuegbar": {"value": False, "note": None},
-                },
+                {"funktion": "Anmelden: Grund?"},
             ],
         )
 
@@ -504,7 +495,6 @@ class DocxExtractTests(NoesisTestCase):
             [
                 {
                     "funktion": "Analyse-/Reportingfunktionen - Bitte wähle zutreffendes aus",
-                    "technisch_verfuegbar": {"value": True, "note": None},
                 }
             ],
         )
@@ -681,10 +671,7 @@ class DocxExtractTests(NoesisTestCase):
                     "funktion": "Anwesenheit",
                     "technisch_verfuegbar": {"value": True, "note": None},
                 },
-                {
-                    "funktion": "Anwesenheit: Grund?",
-                    "technisch_verfuegbar": {"value": False, "note": None},
-                },
+                {"funktion": "Anwesenheit: Grund?"},
             ],
         )
 

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -312,6 +312,7 @@ def parse_anlage2_text(
                 sub_results[key] = sub_entry
                 apply_tokens(sub_entry, after or line, token_map, threshold)
                 apply_rules(sub_entry, after or line, rules, threshold)
+                sub_entry.pop("technisch_verfuegbar", None)
                 continue
 
             entry = main_results.get(current_func_id)
@@ -368,6 +369,7 @@ def parse_anlage2_text(
                 sub_results[key] = entry
             apply_tokens(entry, after or line, token_map, threshold)
             apply_rules(entry, after or line, rules, threshold)
+            entry.pop("technisch_verfuegbar", None)
 
     all_results = [
         entry for entry in main_results.values() if not entry.pop("_skip_output", False)

--- a/core/views.py
+++ b/core/views.py
@@ -492,6 +492,14 @@ def _build_row_data(
                     "style": "display: none;",
                 }
             )
+        elif field == "technisch_vorhanden" and sub_id is not None:
+            bf.field.widget.attrs.update({
+                "disabled": True,
+                "class": "disabled-field",
+                "style": "display: none;",
+                "data-tristate": "true",
+                "data-initial-state": "unknown",
+            })
         if field == "technisch_vorhanden":
             man_val = manual_lookup.get(lookup_key, {}).get(field)
             ai_val = verification_lookup.get(lookup_key, {}).get(field)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -152,3 +152,9 @@ input[type="submit"]:hover {
     opacity: 0.5;
     pointer-events: none;
 }
+
+/* Generische Stilklasse für ausgegraute Formfelder */
+.disabled-field {
+    opacity: 0.5;
+    pointer-events: none;
+}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -122,15 +122,8 @@
                 {% endwith %}
                 {% elif field == 'technisch_vorhanden' and row.sub %}
                 <td class="border px-2 text-center">
-                    {% with parsed=row.doc_result|get_item:field %}
-                    {% if parsed == True %}
-                        <span class="status-badge status-ja" data-bs-toggle="tooltip" title="Dok: {{ doc|get_item:'value' }}{% if note %} - {{ note }}{% endif %}">✓ Vorhanden</span>
-                    {% elif parsed == False %}
-                        <span class="status-badge status-nein" data-bs-toggle="tooltip" title="Dok: {{ doc|get_item:'value' }}{% if note %} - {{ note }}{% endif %}">✗ Nicht vorhanden</span>
-                    {% else %}
-                        <span class="status-badge status-unbekannt" data-bs-toggle="tooltip" title="Dok: {{ doc|get_item:'value' }}{% if note %} - {{ note }}{% endif %}">? Unbekannt</span>
-                    {% endif %}
-                    {% endwith %}
+                    <span class="tri-state-icon disabled-field" data-input-id="{{ f.auto_id }}"></span>
+                    {{ f.widget }}
                 </td>
                 {% else %}
                 <td class="border px-2 text-center">


### PR DESCRIPTION
## Summary
- deactivate tech availability input for subquestions in UI
- skip technical availability parsing for subquestions
- adjust parser tests
- add CSS helper class for disabled fields

## Testing
- `python manage.py makemigrations --check`
- `pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68764a2a7b84832bb8b4bcae25e4de3a