### PR TITLE
Fix AJAX review saving and unify buttons

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -478,28 +478,20 @@ def _build_row_data(
     rev_origin = {}
     for field, _ in fields_def:
         bf = form[f"{form_prefix}{field}"]
-        if field == "technisch_vorhanden" and sub_id is None:
-            initial_value = disp["values"].get(field)
-            state = (
-                "true"
-                if initial_value is True
-                else "false" if initial_value is False else "unknown"
-            )
-            bf.field.widget.attrs.update(
-                {
-                    "data-tristate": "true",
-                    "data-initial-state": state,
-                    "style": "display: none;",
-                }
-            )
-        elif field == "technisch_vorhanden" and sub_id is not None:
-            bf.field.widget.attrs.update({
-                "disabled": True,
-                "class": "disabled-field",
-                "style": "display: none;",
-                "data-tristate": "true",
-                "data-initial-state": "unknown",
-            })
+        initial_value = disp["values"].get(field)
+        state = (
+            "true"
+            if initial_value is True
+            else "false" if initial_value is False else "unknown"
+        )
+        attrs = {
+            "data-tristate": "true",
+            "data-initial-state": state,
+            "style": "display: none;",
+        }
+        if field == "technisch_vorhanden" and sub_id is not None:
+            attrs.update({"disabled": True, "class": "disabled-field", "data-initial-state": "unknown"})
+        bf.field.widget.attrs.update(attrs)
         if field == "technisch_vorhanden":
             man_val = manual_lookup.get(lookup_key, {}).get(field)
             ai_val = verification_lookup.get(lookup_key, {}).get(field)

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -116,6 +116,7 @@
                 {% if field in no_ai_fields %}
                 {% with f=row.form_fields|list_index:forloop.counter0 %}
                 <td class="border px-2 text-center">
+                    <span class="tri-state-icon" data-input-id="{{ f.auto_id }}"></span>
                     {{ f.widget }}
                     {% if f.source %}<span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>{% endif %}
                 </td>
@@ -127,23 +128,12 @@
                 </td>
                 {% else %}
                 <td class="border px-2 text-center">
+                    <span class="tri-state-icon{% if field == 'technisch_vorhanden' and row.sub %} disabled-field{% endif %}" data-input-id="{{ f.auto_id }}"></span>
+                    {{ f.widget }}
                     {% if field == 'technisch_vorhanden' %}
-                        <span class="tri-state-icon" data-input-id="{{ f.auto_id }}"></span>
-                        {{ f.widget }}
-                        {% if f.origin == 'ai' %}
-                        <span title="KI bestätigt">✅</span>
-                        {% elif f.origin == 'manual' %}
-                        <span title="Manuell geändert">✏️</span>
-                        {% endif %}
-                    {% else %}
-                        {{ f.widget }}
+                        {% if f.origin == 'ai' %}<span title="KI bestätigt">✅</span>{% elif f.origin == 'manual' %}<span title="Manuell geändert">✏️</span>{% endif %}
                     {% endif %}
                     {% if f.source %}<span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>{% endif %}
-                    {% with parsed=row.doc_result|raw_item:field %}
-                    <span class="text-xs text-gray-500 ms-1">Parser-Ergebnis:
-                        {% if parsed == True %}Ja{% elif parsed == False %}Nein{% else %}Unbekannt{% endif %}
-                    </span>
-                    {% endwith %}
                 </td>
                 {% endif %}
                 {% endwith %}
@@ -320,14 +310,21 @@ function initAnlage2Review() {
         return span;
     }
 
+    function getFieldName(name) {
+        let m = name.match(/^func\d+_(.+)$/);
+        if (m) { return m[1]; }
+        m = name.match(/^sub\d+_(.+)$/);
+        if (m) { return m[1]; }
+        return name;
+    }
+
     function autoSave(event) {
         const el = event.target;
         const row = el.closest('tr');
         if (!row || !formElem) { return; }
         const funcId = row.dataset.funcId;
         const subId = row.dataset.subId;
-        const parts = (el.name || '').split('_');
-        const fieldName = parts[parts.length - 1];
+        const fieldName = getFieldName(el.name || '');
         let status;
         if (el.dataset.tristate !== undefined) {
             const st = el.dataset.state;


### PR DESCRIPTION
## Summary
- generalize tri‑state setup in `core.views` for all review fields
- remove parser result text and use tri‑state buttons everywhere
- fix JS field name extraction so AJAX saves correct values

## Testing
- `python manage.py makemigrations --check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68764fbf8d34832bbe9249965dea963e