### PR TITLE
Implement full Anlage2 config export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,12 +239,20 @@ nach und nach in `analysis_json` ergänzt.
 ### Anlage‑2‑Konfiguration importieren/exportieren
 
 Unter `/projects-admin/anlage2/config/` lässt sich zusätzlich die gesamte
-Konfiguration sichern. Die exportierte JSON-Datei enthält zwei Listen:
+Konfiguration sichern. Die exportierte JSON-Datei enthält nun alle
+bearbeitbaren Bereiche:
 
 ```json
 {
-  "column_headings": [{"field_name": "technisch_vorhanden", "text": "Verfügbar?"}],
-  "global_phrases": [{"phrase_type": "technisch_verfuegbar_true", "phrase_text": "ja"}]
+  "config": {"parser_order": ["table"]},
+  "alias_headings": [{"field_name": "technisch_vorhanden", "text": "Verfügbar?"}],
+  "answer_rules": [{
+    "regel_name": "Standard",
+    "erkennungs_phrase": "ja",
+    "ziel_feld": "technisch_verfuegbar",
+    "wert": true
+  }],
+  "a4_parser": {"delimiter_phrase": "Name der"}
 }
 ```
 


### PR DESCRIPTION
## Summary
- extend export/import of Anlage2 configuration
- describe JSON structure in README
- test new import/export functions

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ConfigImportExportTests.test_export_contains_headings_and_phrases -v 2`
- `python manage.py test core.tests.test_general.Anlage2ConfigImportExportTests.test_import_creates_headings -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68765add0698832b99ac8d7e137a7911