### PR TITLE
Implement alias management for Anlage 2 forms

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -424,24 +424,70 @@ class Anlage4ReviewForm(forms.Form):
 class Anlage2FunctionForm(forms.ModelForm):
     """Formular für eine Funktion aus Anlage 2."""
 
+    name_aliases = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": 3}), required=False
+    )
+
     class Meta:
         model = Anlage2Function
-        fields = ["name"]
+        fields = ["name", "name_aliases"]
         widgets = {
             "name": forms.TextInput(attrs={"class": "border rounded p-2"}),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        aliases = []
+        if self.instance and self.instance.detection_phrases:
+            aliases = self.instance.detection_phrases.get("name_aliases", [])
+        if not self.is_bound:
+            self.initial["name_aliases"] = "\n".join(aliases)
+
+    def save(self, name_aliases: list[str] | None = None, commit: bool = True):
+        if name_aliases is None:
+            value = self.cleaned_data.get("name_aliases", "")
+            alias_list = [v.strip() for v in value.splitlines() if v.strip()]
+        else:
+            alias_list = [v.strip() for v in name_aliases if v.strip()]
+        data = dict(self.instance.detection_phrases or {})
+        data["name_aliases"] = alias_list
+        self.instance.detection_phrases = data
+        return super().save(commit=commit)
 
 
 class Anlage2SubQuestionForm(forms.ModelForm):
     """Formular für eine Unterfrage zu Anlage 2."""
 
+    name_aliases = forms.CharField(
+        widget=Textarea(attrs={"rows": 3}), required=False
+    )
+
     class Meta:
         model = Anlage2SubQuestion
-        fields = ["frage_text"]
+        fields = ["frage_text", "name_aliases"]
         labels = {"frage_text": "Frage"}
         widgets = {
             "frage_text": Textarea(attrs={"class": "border rounded p-2", "rows": 3}),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        aliases = []
+        if self.instance and self.instance.detection_phrases:
+            aliases = self.instance.detection_phrases.get("name_aliases", [])
+        if not self.is_bound:
+            self.initial["name_aliases"] = "\n".join(aliases)
+
+    def save(self, name_aliases: list[str] | None = None, commit: bool = True):
+        if name_aliases is None:
+            value = self.cleaned_data.get("name_aliases", "")
+            alias_list = [v.strip() for v in value.splitlines() if v.strip()]
+        else:
+            alias_list = [v.strip() for v in name_aliases if v.strip()]
+        data = dict(self.instance.detection_phrases or {})
+        data["name_aliases"] = alias_list
+        self.instance.detection_phrases = data
+        return super().save(commit=commit)
 
 
 class Anlage2FunctionImportForm(forms.Form):

--- a/core/views.py
+++ b/core/views.py
@@ -2242,14 +2242,17 @@ def anlage2_function_form(request, pk=None):
     form = Anlage2FunctionForm(request.POST or None, instance=funktion)
 
     if request.method == "POST" and form.is_valid():
-        funktion = form.save()
+        aliases = request.POST.getlist("name_aliases")
+        funktion = form.save(name_aliases=aliases)
         return redirect("anlage2_function_edit", funktion.pk)
 
     subquestions = list(funktion.anlage2subquestion_set.all()) if funktion else []
+    aliases = funktion.detection_phrases.get("name_aliases", []) if funktion else []
     context = {
         "form": form,
         "funktion": funktion,
         "subquestions": subquestions,
+        "aliases": aliases,
     }
     return render(request, "anlage2/function_form.html", context)
 
@@ -2333,13 +2336,16 @@ def anlage2_subquestion_form(request, function_pk=None, pk=None):
     form = Anlage2SubQuestionForm(request.POST or None, instance=subquestion)
 
     if request.method == "POST" and form.is_valid():
-        subquestion = form.save()
+        aliases = request.POST.getlist("name_aliases")
+        subquestion = form.save(name_aliases=aliases)
         return redirect("anlage2_function_edit", funktion.pk)
 
+    aliases = subquestion.detection_phrases.get("name_aliases", []) if pk else []
     context = {
         "form": form,
         "funktion": funktion,
         "subquestion": subquestion if pk else None,
+        "aliases": aliases,
     }
     return render(request, "anlage2/subquestion_form.html", context)
 

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -10,9 +10,50 @@
         {{ form.name }}
         {{ form.name.errors }}
     </div>
+    <div>
+        <label>Aliasnamen</label>
+        <div id="alias-container">
+            {% for val in aliases %}
+            <div class="flex mb-2">
+                <input type="text" name="name_aliases" value="{{ val }}" class="form-control flex-grow">
+                <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+            </div>
+            {% endfor %}
+            <div class="flex mb-2">
+                <input type="text" name="name_aliases" class="form-control flex-grow">
+                <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+            </div>
+        </div>
+        <button type="button" id="add-alias-btn" class="btn btn-sm btn-secondary mt-1">+ Alias hinzufügen</button>
+    </div>
     <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded mt-4">Speichern</button>
 </form>
 <script>
+document.addEventListener('DOMContentLoaded', () => {
+    const addBtn = document.getElementById('add-alias-btn');
+    const container = document.getElementById('alias-container');
+    if (!addBtn || !container) return;
+    container.querySelectorAll('.remove-btn').forEach(b => {
+        b.addEventListener('click', () => b.parentElement.remove());
+    });
+    addBtn.addEventListener('click', () => {
+        const wrap = document.createElement('div');
+        wrap.className = 'flex mb-2';
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.name = 'name_aliases';
+        input.className = 'form-control flex-grow';
+        const del = document.createElement('button');
+        del.type = 'button';
+        del.textContent = 'x';
+        del.className = 'btn btn-sm btn-secondary ml-2 remove-btn';
+        del.addEventListener('click', () => wrap.remove());
+        wrap.appendChild(input);
+        wrap.appendChild(del);
+        container.appendChild(wrap);
+        input.focus();
+    });
+});
 </script>
 {% if funktion %}
 <h2 class="text-xl font-semibold mt-8 mb-2">Unterfragen</h2>

--- a/templates/anlage2/subquestion_form.html
+++ b/templates/anlage2/subquestion_form.html
@@ -10,7 +10,48 @@
         {{ form.frage_text }}
         {{ form.frage_text.errors }}
     </div>
+    <div>
+        <label>Aliasnamen</label>
+        <div id="alias-container">
+            {% for val in aliases %}
+            <div class="flex mb-2">
+                <input type="text" name="name_aliases" value="{{ val }}" class="form-control flex-grow">
+                <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+            </div>
+            {% endfor %}
+            <div class="flex mb-2">
+                <input type="text" name="name_aliases" class="form-control flex-grow">
+                <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+            </div>
+        </div>
+        <button type="button" id="add-alias-btn" class="btn btn-sm btn-secondary mt-1">+ Alias hinzufügen</button>
+    </div>
     <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const addBtn = document.getElementById('add-alias-btn');
+        const container = document.getElementById('alias-container');
+        if (!addBtn || !container) return;
+        container.querySelectorAll('.remove-btn').forEach(b => {
+            b.addEventListener('click', () => b.parentElement.remove());
+        });
+        addBtn.addEventListener('click', () => {
+            const wrap = document.createElement('div');
+            wrap.className = 'flex mb-2';
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.name = 'name_aliases';
+            input.className = 'form-control flex-grow';
+            const del = document.createElement('button');
+            del.type = 'button';
+            del.textContent = 'x';
+            del.className = 'btn btn-sm btn-secondary ml-2 remove-btn';
+            del.addEventListener('click', () => wrap.remove());
+            wrap.appendChild(input);
+            wrap.appendChild(del);
+            container.appendChild(wrap);
+            input.focus();
+        });
+    });
     </script>
     <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
 </form>


### PR DESCRIPTION
## Summary
- allow alias lists for `Anlage2Function` and `Anlage2SubQuestion`
- handle alias input in views
- extend form templates with dynamic alias fields

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68766d66b7ec832bad17e6546a6a7651