### PR TITLE
Add fallback hint for missing sources

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -67,7 +67,11 @@
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
+                    {% if row.source_text and row.source_text != 'N/A' %}
                     <span class="text-muted small source-indicator">(Quelle: {{ row.source_text }})</span>
+                    {% elif row.source_text == 'N/A' %}
+                    <span class="text-muted small source-indicator">(keine Quelle)</span>
+                    {% endif %}
                 </td>
                 <td class="border px-2 text-center">
                     <button type="button" class="btn btn-sm btn-light verify-single-feature-btn"
@@ -99,7 +103,11 @@
                 {% with f=row.form_fields|list_index:forloop.counter0 %}
                 <td class="border px-2 text-center">
                     {{ f.widget }}
-                    {% if f.source %}<span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>{% endif %}
+                    {% if f.source and f.source != 'N/A' %}
+                    <span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>
+                    {% elif f.source == 'N/A' %}
+                    <span class="text-xs text-gray-500">(keine Quelle)</span>
+                    {% endif %}
                 </td>
                 {% endwith %}
                 {% else %}
@@ -118,7 +126,11 @@
                 <td class="border px-2 text-center">
                     <span class="tri-state-icon" data-input-id="{{ f.auto_id }}"></span>
                     {{ f.widget }}
-                    {% if f.source %}<span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>{% endif %}
+                    {% if f.source and f.source != 'N/A' %}
+                    <span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>
+                    {% elif f.source == 'N/A' %}
+                    <span class="text-xs text-gray-500">(keine Quelle)</span>
+                    {% endif %}
                 </td>
                 {% endwith %}
                 {% elif field == 'technisch_vorhanden' and row.sub %}
@@ -133,7 +145,11 @@
                     {% if field == 'technisch_vorhanden' %}
                         {% if f.origin == 'ai' %}<span title="KI bestätigt">✅</span>{% elif f.origin == 'manual' %}<span title="Manuell geändert">✏️</span>{% endif %}
                     {% endif %}
-                    {% if f.source %}<span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>{% endif %}
+                    {% if f.source and f.source != 'N/A' %}
+                    <span class="text-xs text-gray-500">(Quelle: {{ f.source }})</span>
+                    {% elif f.source == 'N/A' %}
+                    <span class="text-xs text-gray-500">(keine Quelle)</span>
+                    {% endif %}
                 </td>
                 {% endif %}
                 {% endwith %}


### PR DESCRIPTION
## Summary
- show hint `(keine Quelle)` if no source is present on Anlage 2 review page

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6876777f22c8832b955a82bdc9f5b706