### PR TITLE
Fix is_negotiable calculation

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -444,22 +444,8 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
             defaults={"doc_result": row},
         )
 
-        doc_val = None
-        col = row.get("technisch_verfuegbar")
-        if isinstance(col, dict):
-            doc_val = col.get("value")
-        elif isinstance(col, bool):
-            doc_val = col
-
-        ai_val = None
-        if isinstance(res.ai_result, dict):
-            ai_val = res.ai_result.get("technisch_verfuegbar")
-
-        res.is_negotiable = (
-            doc_val is not None and ai_val is not None and doc_val == ai_val
-        )
         res.doc_result = row
-        res.save(update_fields=["doc_result", "is_negotiable"])
+        res.save(update_fields=["doc_result"])
 
     return results
 
@@ -1586,15 +1572,14 @@ def worker_verify_feature(
         defaults={"ai_result": verification_result},
     )
 
-    doc_val = None
-    if isinstance(res.doc_result, dict):
-        d = res.doc_result.get("technisch_verfuegbar")
-        if isinstance(d, dict):
-            doc_val = d.get("value")
-        elif isinstance(d, bool):
-            doc_val = d
+    manual_val = None
+    if isinstance(res.manual_result, dict):
+        manual_val = res.manual_result.get("technisch_vorhanden")
+
     ai_val = verification_result.get("technisch_verfuegbar")
-    res.is_negotiable = doc_val is not None and ai_val is not None and doc_val == ai_val
+    res.is_negotiable = (
+        manual_val is not None and ai_val is not None and manual_val == ai_val
+    )
     res.save(update_fields=["ai_result", "is_negotiable"])
 
     if object_type == "function":

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -944,7 +944,7 @@ class LLMTasksTests(NoesisTestCase):
         run_anlage2_analysis(pf)
 
         res = Anlage2FunctionResult.objects.get(projekt=projekt, funktion=func)
-        self.assertTrue(res.is_negotiable)
+        self.assertFalse(res.is_negotiable)
 
     def test_parser_manager_fallback(self):
         class FailParser(AbstractParser):
@@ -2680,7 +2680,7 @@ class FeatureVerificationTests(NoesisTestCase):
         ):
             worker_verify_feature(self.projekt.pk, "function", self.func.pk)
         res = Anlage2FunctionResult.objects.get(projekt=self.projekt, funktion=self.func)
-        self.assertTrue(res.is_negotiable)
+        self.assertFalse(res.is_negotiable)
 
     def test_negotiable_not_set_on_mismatch(self):
         Anlage2FunctionResult.objects.create(
@@ -3100,6 +3100,12 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
         self.assertEqual(res.gap_summary, "Abweichung")
 
     def test_manual_sets_negotiable(self):
+        Anlage2FunctionResult.objects.create(
+            projekt=self.projekt,
+            funktion=self.func,
+            ai_result={"technisch_verfuegbar": True},
+        )
+
         url = reverse("ajax_save_anlage2_review")
         resp = self.client.post(
             url,

--- a/core/views.py
+++ b/core/views.py
@@ -3460,9 +3460,16 @@ def ajax_save_anlage2_review(request) -> JsonResponse:
         manual[field_name] = status
         res.manual_result = manual
         update_fields = [attr, "raw_json", "manual_result", "source"]
-        if sub_id is None and not res.is_negotiable:
-            res.is_negotiable = True
+
+        if field_name == "technisch_vorhanden" and sub_id is None:
+            ai_val = None
+            if isinstance(res.ai_result, dict):
+                ai_val = res.ai_result.get("technisch_verfuegbar")
+            res.is_negotiable = (
+                ai_val is not None and status is not None and ai_val == status
+            )
             update_fields.append("is_negotiable")
+
         res.save(update_fields=update_fields)
 
         gap_text = res.gap_summary


### PR DESCRIPTION
## Summary
- adjust negotiation flag logic
- update Ajax review to recalc negotiation state
- fix tests for new behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.LLMTasksTests.test_run_anlage2_analysis_sets_negotiable_on_match -v 2`
- `python manage.py test core.tests.test_general.FeatureVerificationTests.test_negotiable_set_on_match -v 2`
- `python manage.py test core.tests.test_general.AjaxAnlage2ReviewTests.test_manual_sets_negotiable -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6876b0477024832b823254143908af85