### PR TITLE
Implementiertes Status-Farbsystem im Review

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -506,7 +506,6 @@ def _build_row_data(
         }
         if field == "technisch_vorhanden" and sub_id is not None:
             attrs.update({"disabled": True, "class": "disabled-field", "data-initial-state": "unknown"})
-        bf.field.widget.attrs.update(attrs)
         if field == "technisch_vorhanden":
             man_val = manual_lookup.get(lookup_key, {}).get(field)
             ai_val = verification_lookup.get(lookup_key, {}).get(field)
@@ -516,6 +515,8 @@ def _build_row_data(
                 rev_origin[field] = "ai"
             else:
                 rev_origin[field] = "none"
+            attrs["data-origin"] = rev_origin[field]
+        bf.field.widget.attrs.update(attrs)
         form_fields_map[field] = {
             "widget": bf,
             "source": disp["sources"][field],

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,10 @@
 :root {
     --color-primary: #2563eb; /* blue-600 */
     --color-primary-dark: #1e40af; /* blue-800 */
+    --status-ok: #28a745;
+    --status-konflikt: #dc3545;
+    --status-manuell-abweichung: #ffc107;
+    --status-unbekannt: #6c757d;
 }
 
 /* Custom styles for card hover effects */
@@ -26,8 +30,25 @@
 .status-nein {
     background-color: #6c757d;
 }
+
+.status-ok {
+    background-color: var(--status-ok);
+    color: white;
+}
+
+.status-konflikt {
+    background-color: var(--status-konflikt);
+    color: white;
+}
+
+.status-manuell-abweichung {
+    background-color: var(--status-manuell-abweichung);
+    color: black;
+}
+
 .status-unbekannt {
-    background-color: #6c757d;
+    background-color: var(--status-unbekannt);
+    color: white;
 }
 
 /* Einfaches Collapse-Verhalten für Tabellenzeilen */

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -15,6 +15,10 @@
             <input type="checkbox" id="show-relevant-only-filter" class="form-check-input mr-2">
             Nur als "vorhanden" markierte Funktionen anzeigen
         </label>
+        <label class="ml-4">
+            <input type="checkbox" id="show-conflicts-only-filter" class="form-check-input mr-2">
+            Nur Konflikte anzeigen
+        </label>
         <button type="button" id="btn-verify-all" class="bg-green-600 text-white px-2 py-1 rounded ml-4">Alle Funktionen prüfen 🤖</button>
         <button type="submit" name="run_parser" value="1" class="bg-blue-600 text-white px-2 py-1 rounded ml-4">Parser-Analyse starten</button>
     </div>
@@ -194,22 +198,7 @@ function initAnlage2Review() {
         });
     }
 
-document.querySelectorAll('tr[data-ai]').forEach(row => {
-    let ai = {};
-    let doc = {};
-    try { ai = JSON.parse(row.dataset.ai || '{}'); } catch (e) { ai = {}; }
-    try { doc = JSON.parse(row.dataset.doc || '{}'); } catch (e) { doc = {}; }
-    row.querySelectorAll('.tri-state-icon').forEach(icon => {
-        const key = icon.dataset.fieldName;
-        const aiVal = ai[key] ? ai[key].value : undefined;
-        const docVal = doc[key] ? doc[key].value : undefined;
-        if (aiVal !== undefined || docVal !== undefined) {
-            const txt = `Dok: ${docVal} / KI: ${aiVal}`;
-            icon.setAttribute('data-bs-toggle', 'tooltip');
-            icon.setAttribute('title', txt);
-        }
-    });
-});
+
 
     const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
     tooltipTriggerList.forEach(el => new bootstrap.Tooltip(el));
@@ -217,18 +206,47 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
     const popoverList = [...popoverTriggerList].map(el => new bootstrap.Popover(el));
 
     function updateTriState(icon, input) {
+        const row = icon.closest('tr');
         const state = input.dataset.state;
-        icon.classList.remove('status-ja', 'status-nein', 'status-unbekannt');
+        const manualVal = state === 'true' ? true : (state === 'false' ? false : null);
+        const parserStr = row.dataset.parsedStatus;
+        const parserVal = parserStr === 'True' ? true : (parserStr === 'False' ? false : null);
+        let aiVal;
+        try {
+            const ai = JSON.parse(row.dataset.ai || '{}');
+            aiVal = ai.technisch_vorhanden;
+        } catch (e) { aiVal = undefined; }
+        const hasManual = input.dataset.origin === 'manual';
+
+        let cls = 'status-unbekannt';
+        if (hasManual && manualVal !== null && manualVal !== parserVal) {
+            cls = 'status-manuell-abweichung';
+        } else if (!hasManual && parserVal !== null && aiVal !== undefined && parserVal !== aiVal) {
+            cls = 'status-konflikt';
+        } else if ((manualVal !== null && manualVal === parserVal) || (!hasManual && aiVal === parserVal)) {
+            cls = 'status-ok';
+        }
+
+        icon.classList.remove('status-badge', 'status-ja', 'status-nein', 'status-unbekannt', 'status-ok', 'status-konflikt', 'status-manuell-abweichung');
+        icon.classList.add('status-badge', cls);
+
         if (state === 'true') {
             icon.textContent = '✓ Vorhanden';
-            icon.classList.add('status-badge', 'status-ja');
         } else if (state === 'false') {
             icon.textContent = '✗ Nicht vorhanden';
-            icon.classList.add('status-badge', 'status-nein');
         } else {
             icon.textContent = '? Unbekannt';
-            icon.classList.add('status-badge', 'status-unbekannt');
         }
+
+        row.classList.remove('status-ok', 'status-konflikt', 'status-manuell-abweichung', 'status-unbekannt');
+        row.classList.add(cls);
+
+        const tip = `Dok: ${parserVal} / KI: ${aiVal} / Manuell: ${manualVal}`;
+        icon.setAttribute('data-bs-toggle', 'tooltip');
+        icon.setAttribute('title', tip);
+        const t = bootstrap.Tooltip.getInstance(icon);
+        if (t) { t.dispose(); }
+        new bootstrap.Tooltip(icon);
     }
 
     function toggleSubRows(funcId, enabled) {
@@ -466,6 +484,7 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
     });
 
     const filterCheckbox = document.getElementById('show-relevant-only-filter');
+    const conflictCheckbox = document.getElementById('show-conflicts-only-filter');
 
     if (filterCheckbox) {
         filterCheckbox.addEventListener('change', function() {
@@ -478,6 +497,24 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
 
                 if (showOnlyAvailable) {
                     if (isAvailable) {
+                        row.classList.remove('filter-hidden');
+                    } else {
+                        row.classList.add('filter-hidden');
+                    }
+                } else {
+                    row.classList.remove('filter-hidden');
+                }
+            });
+        });
+    }
+
+    if (conflictCheckbox) {
+        conflictCheckbox.addEventListener('change', function() {
+            const onlyConflicts = this.checked;
+            const rows = document.querySelectorAll('tbody tr');
+            rows.forEach(row => {
+                if (onlyConflicts) {
+                    if (row.classList.contains('status-konflikt') || row.classList.contains('status-manuell-abweichung')) {
                         row.classList.remove('filter-hidden');
                     } else {
                         row.classList.add('filter-hidden');


### PR DESCRIPTION
## Summary
- erweitere Styles um Farbkodierung fuer Status
- fuege Datenattribut `data-origin` im Backend hinzu
- neue Filteroption fuer Konflikte im Review-Template
- passe Tri-State-Logik und Tooltip im JS an

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68775c974a4c832b99a1bc0bfacd1ca2