### PR TITLE
Überarbeitete Verhandlungsfähig-Logik

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1576,9 +1576,25 @@ def worker_verify_feature(
     if isinstance(res.manual_result, dict):
         manual_val = res.manual_result.get("technisch_vorhanden")
 
+    doc_val = None
+    if isinstance(res.doc_result, dict):
+        entry = res.doc_result.get("technisch_verfuegbar")
+        if isinstance(entry, dict):
+            doc_val = entry.get("value")
+
     ai_val = verification_result.get("technisch_verfuegbar")
+
+    auto_val = False
+    if doc_val is not None:
+        if (ai_val is not None and ai_val == doc_val) or (
+            manual_val is not None and manual_val == doc_val
+        ):
+            auto_val = True
+
     res.is_negotiable = (
-        manual_val is not None and ai_val is not None and manual_val == ai_val
+        res.is_negotiable_manual_override
+        if res.is_negotiable_manual_override is not None
+        else auto_val
     )
     res.save(update_fields=["ai_result", "is_negotiable"])
 

--- a/core/migrations/0025_rename_negotiable_override.py
+++ b/core/migrations/0025_rename_negotiable_override.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0024_anlage2functionresult_is_negotiable_override"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="anlage2functionresult",
+            old_name="is_negotiable_override",
+            new_name="is_negotiable_manual_override",
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -848,7 +848,7 @@ class Anlage2FunctionResult(models.Model):
     gap_summary = models.TextField(blank=True)
     gap_notiz = models.TextField(blank=True, null=True)
     is_negotiable = models.BooleanField(default=False)
-    is_negotiable_override = models.BooleanField(null=True, blank=True)
+    is_negotiable_manual_override = models.BooleanField(null=True, blank=True)
     source = models.CharField(max_length=10, default="llm")
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -861,9 +861,7 @@ class Anlage2FunctionResult(models.Model):
 
     @property
     def negotiable(self) -> bool:
-        """Endgültiger Verhandlungsstatus unter Berücksichtigung des Overrides."""
-        if self.is_negotiable_override is not None:
-            return self.is_negotiable_override
+        """Endgültiger Verhandlungsstatus."""
         return self.is_negotiable
 
     def get_lookup_key(self) -> str:

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -944,7 +944,7 @@ class LLMTasksTests(NoesisTestCase):
         run_anlage2_analysis(pf)
 
         res = Anlage2FunctionResult.objects.get(projekt=projekt, funktion=func)
-        self.assertFalse(res.negotiable)
+        self.assertTrue(res.negotiable)
 
     def test_parser_manager_fallback(self):
         class FailParser(AbstractParser):
@@ -2680,7 +2680,7 @@ class FeatureVerificationTests(NoesisTestCase):
         ):
             worker_verify_feature(self.projekt.pk, "function", self.func.pk)
         res = Anlage2FunctionResult.objects.get(projekt=self.projekt, funktion=self.func)
-        self.assertFalse(res.negotiable)
+        self.assertTrue(res.negotiable)
 
     def test_negotiable_not_set_on_mismatch(self):
         Anlage2FunctionResult.objects.create(
@@ -3114,7 +3114,7 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
         )
         self.assertEqual(resp.status_code, 200)
         res = Anlage2FunctionResult.objects.get(projekt=self.projekt, funktion=self.func)
-        self.assertTrue(res.negotiable)
+        self.assertFalse(res.negotiable)
 
     def test_save_einsatz_telefonica(self):
         url = reverse("ajax_save_anlage2_review")
@@ -3194,7 +3194,7 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
         self.assertEqual(resp.status_code, 200)
         res = Anlage2FunctionResult.objects.get(projekt=self.projekt, funktion=self.func)
         self.assertTrue(res.negotiable)
-        self.assertTrue(res.is_negotiable_override)
+        self.assertTrue(res.is_negotiable_manual_override)
 
         self.client.post(
             url,
@@ -3206,6 +3206,6 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
             content_type="application/json",
         )
         res.refresh_from_db()
-        self.assertIsNone(res.is_negotiable_override)
+        self.assertIsNone(res.is_negotiable_manual_override)
 
 

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -54,7 +54,7 @@
                 data-ai="{{ row.ai_result|tojson|escapejs }}"
                 data-doc="{{ row.doc_result|tojson|escapejs }}"
                 data-negotiable="{{ row.is_negotiable|yesno:'true,false' }}"
-                data-negotiable-override="{{ row.negotiable_override|yesno:'true,false,' }}"
+                data-negotiable-manual="{{ row.negotiable_manual_override|yesno:'true,false,' }}"
                 data-func-id="{{ row.func_id }}" {% if row.sub %}data-sub-id="{{ row.sub_id }}"{% endif %}>
                 <td class="border px-2 {% if row.sub %}pl-8{% endif %}">
                     {% if not row.sub %}
@@ -111,13 +111,13 @@
                 </td>
                 {% endwith %}
                 {% endfor %}
-                <td class="border px-2 text-center negotiable-cell" data-field-name="is_negotiable" data-override="{{ row.negotiable_override|yesno:'true,false,' }}">
+                <td class="border px-2 text-center negotiable-cell" data-field-name="is_negotiable" data-override="{{ row.negotiable_manual_override|yesno:'true,false,' }}">
                     {% if row.is_negotiable %}
-                    <span class="text-green-600">✓</span>
+                    <span class="text-green-600">✅</span>
                     {% else %}
-                    <span class="text-gray-400">–</span>
+                    <span class="text-red-600">❌</span>
                     {% endif %}
-                    {% if row.negotiable_override is not none %}
+                    {% if row.negotiable_manual_override is not none %}
                     <span class="ms-1">👤</span>
                     {% endif %}
                 </td>
@@ -339,11 +339,8 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
                 if (!row || !formElem) return;
                 const funcId = row.dataset.funcId;
                 const subId = row.dataset.subId;
-                let override = negCell.dataset.override;
-                let next;
-                if (override === 'true') next = false;
-                else if (override === 'false') next = null;
-                else next = true;
+                const override = negCell.dataset.override;
+                const next = override === 'true' ? false : true;
                 const payload = { project_file_id: formElem.dataset.anlageId, function_id: funcId, set_negotiable: next };
                 if (subId) payload.subquestion_id = subId;
                 fetch(saveUrl, {
@@ -351,9 +348,9 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
                     headers: { 'X-CSRFToken': csrftoken, 'Content-Type': 'application/json' },
                     body: JSON.stringify(payload)
                 }).then(r => r.json()).then(data => {
-                    updateNegotiableCell(negCell, data.is_negotiable, data.is_negotiable_override);
+                    updateNegotiableCell(negCell, data.is_negotiable, data.is_negotiable_manual_override);
                     row.dataset.negotiable = data.is_negotiable ? 'true' : 'false';
-                    row.dataset.negotiableOverride = data.is_negotiable_override === null ? '' : String(data.is_negotiable_override);
+                    row.dataset.negotiableManual = data.is_negotiable_manual_override === null ? '' : String(data.is_negotiable_manual_override);
                     row.classList.toggle('negotiated-row', data.is_negotiable);
                 });
             }
@@ -403,8 +400,8 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
     function updateNegotiableCell(cell, value, override) {
         if (!cell) return;
         cell.innerHTML = value ?
-            '<span class="text-green-600">✓</span>' :
-            '<span class="text-gray-400">–</span>';
+            '<span class="text-green-600">✅</span>' :
+            '<span class="text-red-600">❌</span>';
         if (override !== null && override !== undefined) {
             cell.innerHTML += '<span class="ms-1">👤</span>';
         }
@@ -453,10 +450,10 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
                 if (data.is_negotiable !== undefined) {
                     const cell = row.querySelector('.negotiable-cell');
                     if (cell) {
-                        updateNegotiableCell(cell, data.is_negotiable, data.is_negotiable_override);
+                        updateNegotiableCell(cell, data.is_negotiable, data.is_negotiable_manual_override);
                     }
                     row.dataset.negotiable = data.is_negotiable ? 'true' : 'false';
-                    row.dataset.negotiableOverride = data.is_negotiable_override === null ? '' : String(data.is_negotiable_override);
+                    row.dataset.negotiableManual = data.is_negotiable_manual_override === null ? '' : String(data.is_negotiable_manual_override);
                     row.classList.toggle('negotiated-row', data.is_negotiable);
                 }
                 const srcIcon = row.querySelector(`.source-icon[data-field-name="${fieldName}"]`);


### PR DESCRIPTION
## Summary
- rename negotiable override field and add migration
- adjust models to use final `is_negotiable` with optional manual override
- update AJAX view logic and JS to handle binary negotiable state
- adjust templates to display ✅/❌ and manual indicator
- update task logic for negotiable calculation
- fix tests

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68776157b510832bb76e8829ea7ca8c1