### PR TITLE
Implement binary negotiable status with manual override

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1576,10 +1576,22 @@ def worker_verify_feature(
     if isinstance(res.manual_result, dict):
         manual_val = res.manual_result.get("technisch_vorhanden")
 
+    doc_val = None
+    if isinstance(res.doc_result, dict):
+        doc_val = res.doc_result.get("technisch_verfuegbar")
+
     ai_val = verification_result.get("technisch_verfuegbar")
-    res.is_negotiable = (
-        manual_val is not None and ai_val is not None and manual_val == ai_val
+
+    auto_val = (
+        (ai_val is not None and doc_val is not None and ai_val == doc_val)
+        or (
+            manual_val is not None and doc_val is not None and manual_val == doc_val
+        )
     )
+
+    if res.is_negotiable_manual_override is None:
+        res.is_negotiable = auto_val
+
     res.save(update_fields=["ai_result", "is_negotiable"])
 
     if object_type == "function":

--- a/core/migrations/0025_rename_negotiable_override.py
+++ b/core/migrations/0025_rename_negotiable_override.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0024_anlage2functionresult_is_negotiable_override"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="anlage2functionresult",
+            old_name="is_negotiable_override",
+            new_name="is_negotiable_manual_override",
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -848,7 +848,7 @@ class Anlage2FunctionResult(models.Model):
     gap_summary = models.TextField(blank=True)
     gap_notiz = models.TextField(blank=True, null=True)
     is_negotiable = models.BooleanField(default=False)
-    is_negotiable_override = models.BooleanField(null=True, blank=True)
+    is_negotiable_manual_override = models.BooleanField(null=True, blank=True)
     source = models.CharField(max_length=10, default="llm")
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -861,9 +861,7 @@ class Anlage2FunctionResult(models.Model):
 
     @property
     def negotiable(self) -> bool:
-        """Endgültiger Verhandlungsstatus unter Berücksichtigung des Overrides."""
-        if self.is_negotiable_override is not None:
-            return self.is_negotiable_override
+        """Endgültiger Verhandlungsstatus, inkl. manuellem Override."""
         return self.is_negotiable
 
     def get_lookup_key(self) -> str:

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2680,7 +2680,7 @@ class FeatureVerificationTests(NoesisTestCase):
         ):
             worker_verify_feature(self.projekt.pk, "function", self.func.pk)
         res = Anlage2FunctionResult.objects.get(projekt=self.projekt, funktion=self.func)
-        self.assertFalse(res.negotiable)
+        self.assertTrue(res.negotiable)
 
     def test_negotiable_not_set_on_mismatch(self):
         Anlage2FunctionResult.objects.create(
@@ -3114,7 +3114,7 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
         )
         self.assertEqual(resp.status_code, 200)
         res = Anlage2FunctionResult.objects.get(projekt=self.projekt, funktion=self.func)
-        self.assertTrue(res.negotiable)
+        self.assertFalse(res.negotiable)
 
     def test_save_einsatz_telefonica(self):
         url = reverse("ajax_save_anlage2_review")
@@ -3194,7 +3194,7 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
         self.assertEqual(resp.status_code, 200)
         res = Anlage2FunctionResult.objects.get(projekt=self.projekt, funktion=self.func)
         self.assertTrue(res.negotiable)
-        self.assertTrue(res.is_negotiable_override)
+        self.assertTrue(res.is_negotiable_manual_override)
 
         self.client.post(
             url,
@@ -3206,6 +3206,6 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
             content_type="application/json",
         )
         res.refresh_from_db()
-        self.assertIsNone(res.is_negotiable_override)
+        self.assertIsNone(res.is_negotiable_manual_override)
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -525,7 +525,9 @@ def _build_row_data(
 
     result_obj = result_map.get(lookup_key)
     is_negotiable = result_obj.negotiable if result_obj else False
-    override_val = result_obj.is_negotiable_override if result_obj else None
+    override_val = (
+        result_obj.is_negotiable_manual_override if result_obj else None
+    )
     gap_widget = form[f"{form_prefix}gap_summary"]
     note_widget = form[f"{form_prefix}gap_notiz"]
     begr_md = ki_map.get((str(func_id), str(sub_id) if sub_id else None))
@@ -556,7 +558,7 @@ def _build_row_data(
         "initial": disp["values"],
         "form_fields": form_fields_map,
         "is_negotiable": is_negotiable,
-        "negotiable_override": override_val,
+        "negotiable_manual_override": override_val,
         "gap_summary_widget": gap_widget,
         "gap_notiz_widget": note_widget,
         "gap_notiz": result_obj.gap_notiz if result_obj else "",
@@ -3485,14 +3487,26 @@ def ajax_save_anlage2_review(request) -> JsonResponse:
             res.manual_result = manual
             update_fields.extend([attr, "raw_json", "manual_result", "source"])
 
-        if field_name == "technisch_vorhanden" and sub_id is None:
-            ai_val = None
-            if isinstance(res.ai_result, dict):
-                ai_val = res.ai_result.get("technisch_verfuegbar")
-            res.is_negotiable = (
-                ai_val is not None and status is not None and ai_val == status
+        doc_val = None
+        ai_val = None
+        if isinstance(res.doc_result, dict):
+            doc_val = res.doc_result.get("technisch_verfuegbar")
+        if isinstance(res.ai_result, dict):
+            ai_val = res.ai_result.get("technisch_verfuegbar")
+        manual_val = None
+        if isinstance(res.manual_result, dict):
+            manual_val = res.manual_result.get("technisch_vorhanden")
+        if field_name == "technisch_vorhanden":
+            manual_val = status
+
+        auto_val = (
+            (ai_val is not None and doc_val is not None and ai_val == doc_val)
+            or (
+                manual_val is not None
+                and doc_val is not None
+                and manual_val == doc_val
             )
-            update_fields.append("is_negotiable")
+        )
 
         if set_neg != "__missing__":
             if set_neg in (True, "True", "true", "1", 1):
@@ -3501,8 +3515,16 @@ def ajax_save_anlage2_review(request) -> JsonResponse:
                 override_val = False
             else:
                 override_val = None
-            res.is_negotiable_override = override_val
-            update_fields.append("is_negotiable_override")
+            res.is_negotiable_manual_override = override_val
+            if override_val is not None:
+                res.is_negotiable = override_val
+            else:
+                res.is_negotiable = auto_val
+            update_fields.extend(["is_negotiable_manual_override", "is_negotiable"])
+        elif field_name == "technisch_vorhanden" and sub_id is None:
+            if res.is_negotiable_manual_override is None:
+                res.is_negotiable = auto_val
+            update_fields.append("is_negotiable")
 
         res.save(update_fields=update_fields)
 
@@ -3541,7 +3563,7 @@ def ajax_save_anlage2_review(request) -> JsonResponse:
             "status": "success",
             "gap_summary": gap_text,
             "is_negotiable": res.negotiable,
-            "is_negotiable_override": res.is_negotiable_override,
+            "is_negotiable_override": res.is_negotiable_manual_override,
         })
     except Exception as exc:  # pragma: no cover - Schutz vor unerwarteten Fehlern
         logger.error(
@@ -3569,7 +3591,7 @@ def ajax_reset_all_reviews(request, pk: int) -> JsonResponse:
         ai_result=None,
         manual_result=None,
         is_negotiable=False,
-        is_negotiable_override=None,
+        is_negotiable_manual_override=None,
     )
     project_file.verification_json = {}
     project_file.manual_analysis_json = None
@@ -3619,7 +3641,7 @@ def projekt_file_delete_result(request, pk: int):
         project_file.verification_json = {}
         Anlage2FunctionResult.objects.filter(projekt=project_file.projekt).update(
             is_negotiable=False,
-            is_negotiable_override=None
+            is_negotiable_manual_override=None
         )
 
     project_file.analysis_json = None

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -54,7 +54,7 @@
                 data-ai="{{ row.ai_result|tojson|escapejs }}"
                 data-doc="{{ row.doc_result|tojson|escapejs }}"
                 data-negotiable="{{ row.is_negotiable|yesno:'true,false' }}"
-                data-negotiable-override="{{ row.negotiable_override|yesno:'true,false,' }}"
+                data-manual-override="{{ row.negotiable_override|yesno:'true,false,' }}"
                 data-func-id="{{ row.func_id }}" {% if row.sub %}data-sub-id="{{ row.sub_id }}"{% endif %}>
                 <td class="border px-2 {% if row.sub %}pl-8{% endif %}">
                     {% if not row.sub %}
@@ -113,9 +113,9 @@
                 {% endfor %}
                 <td class="border px-2 text-center negotiable-cell" data-field-name="is_negotiable" data-override="{{ row.negotiable_override|yesno:'true,false,' }}">
                     {% if row.is_negotiable %}
-                    <span class="text-green-600">✓</span>
+                    <span class="text-green-600">✅</span>
                     {% else %}
-                    <span class="text-gray-400">–</span>
+                    <span class="text-red-600">❌</span>
                     {% endif %}
                     {% if row.negotiable_override is not none %}
                     <span class="ms-1">👤</span>
@@ -353,7 +353,7 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
                 }).then(r => r.json()).then(data => {
                     updateNegotiableCell(negCell, data.is_negotiable, data.is_negotiable_override);
                     row.dataset.negotiable = data.is_negotiable ? 'true' : 'false';
-                    row.dataset.negotiableOverride = data.is_negotiable_override === null ? '' : String(data.is_negotiable_override);
+                    row.dataset.manualOverride = data.is_negotiable_override === null ? '' : String(data.is_negotiable_override);
                     row.classList.toggle('negotiated-row', data.is_negotiable);
                 });
             }
@@ -403,8 +403,8 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
     function updateNegotiableCell(cell, value, override) {
         if (!cell) return;
         cell.innerHTML = value ?
-            '<span class="text-green-600">✓</span>' :
-            '<span class="text-gray-400">–</span>';
+            '<span class="text-green-600">✅</span>' :
+            '<span class="text-red-600">❌</span>';
         if (override !== null && override !== undefined) {
             cell.innerHTML += '<span class="ms-1">👤</span>';
         }
@@ -452,11 +452,11 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
                 }
                 if (data.is_negotiable !== undefined) {
                     const cell = row.querySelector('.negotiable-cell');
-                    if (cell) {
+                    if (cell && !row.dataset.manualOverride) {
                         updateNegotiableCell(cell, data.is_negotiable, data.is_negotiable_override);
                     }
                     row.dataset.negotiable = data.is_negotiable ? 'true' : 'false';
-                    row.dataset.negotiableOverride = data.is_negotiable_override === null ? '' : String(data.is_negotiable_override);
+                    row.dataset.manualOverride = data.is_negotiable_override === null ? '' : String(data.is_negotiable_override);
                     row.classList.toggle('negotiated-row', data.is_negotiable);
                 }
                 const srcIcon = row.querySelector(`.source-icon[data-field-name="${fieldName}"]`);


### PR DESCRIPTION
## Summary
- add `is_negotiable_manual_override` and store final negotiable state
- compute negotiable state in views and tasks based on document vs. checks
- expose manual override to templates and AJAX
- update negotiable column UI with ✅/❌ icons
- adjust tests for new behaviour

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68776157b510832bb76e8829ea7ca8c1