### PR TITLE
fix: zentralisiere Zeilendaten

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -319,7 +319,6 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
 
     function updateRowAppearance(rowElement) {
         if (!rowElement) return;
-        refreshRowData(rowElement);
 
         rowElement.querySelectorAll('.tri-state-icon').forEach(icon => {
             const input = document.getElementById(icon.dataset.inputId);
@@ -402,6 +401,7 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
                 }).then(r => r.json()).then(data => {
                     row.dataset.negotiable = data.is_negotiable ? 'true' : 'false';
                     row.dataset.manualOverride = data.is_negotiable_override === null ? '' : String(data.is_negotiable_override);
+                    refreshRowData(row);
                     updateRowAppearance(row);
                 });
             }
@@ -496,6 +496,7 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
                     row.dataset.negotiable = data.is_negotiable ? 'true' : 'false';
                     row.dataset.manualOverride = data.is_negotiable_override === null ? '' : String(data.is_negotiable_override);
                 }
+                refreshRowData(row);
                 const srcIcon = row.querySelector(`.source-icon[data-field-name="${fieldName}"]`);
                 if (srcIcon) {
                     srcIcon.innerHTML = '<i class="fas fa-user"></i>';
@@ -631,6 +632,7 @@ document.querySelectorAll('tr[data-ai]').forEach(row => {
                                     clickedButton.disabled = false;
                                     if (d.status === 'SUCCESS' && row) {
                                         row.dataset.ai = JSON.stringify(d.result || {});
+                                        refreshRowData(row);
                                         updateRowAppearance(row);
                                     }
                                 }


### PR DESCRIPTION
## Summary
- keep parsed ai/doc data per row
- refresh row state after saving and after polling results
- stop re-parsing in `updateRowAppearance`

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6877d53a9a30832b83049de2f12bb8b7