### PR TITLE
Fix NoReverseMatch on negotiable cells

### DIFF
--- a/templates/partials/negotiable_cell.html
+++ b/templates/partials/negotiable_cell.html
@@ -1,3 +1,4 @@
+{% if row.result_id %}
 <td class="border px-2 text-center negotiable-cell"
     hx-post="{% url 'hx_toggle_negotiable' result_id=row.result_id %}"
     hx-target="closest td" hx-swap="outerHTML">
@@ -10,3 +11,6 @@
     <span class="ms-1">👤</span>
     {% endif %}
 </td>
+{% else %}
+<td></td>
+{% endif %}


### PR DESCRIPTION
## Summary
- avoid URL lookup errors when `row.result_id` is missing by making negotiable cell conditional

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6878081587ac832b940b176c8ca4468c