### PR TITLE
Update styles for subquestion and negotiated rows

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -180,10 +180,11 @@ input[type="submit"]:hover {
 
 /* Unterfragen leicht hervorheben */
 .subquestion-row td {
-    background-color: #f8f9fa;
+    /* Gut sichtbarer Hintergrund für Unterfragen */
+    background-color: #fffae6;
 }
 
-/* Bereits verhandelte Zeilen ausgrauen */
+/* Bereits verhandelte Zeilen deutlich ausgrauen */
 .negotiated-row {
-    opacity: 0.7;
+    opacity: 0.4;
 }

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -47,7 +47,7 @@
         </thead>
         <tbody id="anlage2-table-body">
         {% for row in rows %}
-            <tr class="{% if row.sub %}subquestion-row hidden-row subquestions-for-{{ row.func_id }}{% endif %}"
+            <tr class="{% if row.sub %}subquestion-row hidden-row subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}negotiated-row{% endif %}"
                 data-relevant="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'true,false,unknown' }}"
                 data-parsed-status="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'True,False,None' }}"
                 data-parsed-notes="{{ row.doc_result|raw_item:'technisch_vorhanden'|get_item:'note' }}"


### PR DESCRIPTION
## Summary
- highlight subquestion rows with a yellow background
- reduce opacity for negotiated rows
- set negotiated row class in Anlage 2 review template

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687815d2c87c832ba821a0d8dcef2de7