### PR TITLE
Fix negotiable row updates

### DIFF
--- a/templates/partials/negotiable_cell.html
+++ b/templates/partials/negotiable_cell.html
@@ -8,7 +8,7 @@
     <span class="text-red-600">❌</span>
     {% endif %}
     {% if override is not none %}
-    <span class="ms-1">👤</span>
+    <span class="ms-1" title="Manueller Override">👤</span>
     {% endif %}
 </td>
 {% else %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -206,24 +206,30 @@ function updateRowAppearance(row) {
         }
     });
     const techIcon = row.querySelector('.tri-state-icon[data-field-name="technisch_vorhanden"]');
+    let techState = null;
     if (techIcon && !row.classList.contains('subquestion-row')) {
-        const state = textToState(techIcon.textContent);
-        toggleSubRows(row.dataset.funcId, state === true);
+        techState = textToState(techIcon.textContent);
+        toggleSubRows(row.dataset.funcId, techState === true);
         const aiVal = ai.technisch_vorhanden;
         const gapCell = row.querySelector('[id^="gap-cell-"]');
         if (gapCell) {
-            if (aiVal !== undefined && state !== null && aiVal !== state) gapCell.classList.add('has-gap');
+            if (aiVal !== undefined && techState !== null && aiVal !== techState) gapCell.classList.add('has-gap');
             else gapCell.classList.remove('has-gap');
         }
     }
     const negCell = row.querySelector('.negotiable-cell');
     if (negCell) {
-        const val = row.dataset.negotiable === 'true';
-        const ovRaw = row.dataset.manualOverride;
-        let ov = null;
-        if (ovRaw === 'true') ov = true; else if (ovRaw === 'false') ov = false;
-        updateNegotiableCell(negCell, val, ov);
-        row.classList.toggle('negotiated-row', val);
+        let cellVal = negCell.textContent.trim().startsWith('✅');
+        const hasUser = negCell.textContent.includes('👤');
+        let override = null;
+        if (hasUser) override = cellVal;
+        row.dataset.manualOverride = override !== null ? String(override) : '';
+        if (override === null && techState !== null) {
+            cellVal = techState;
+        }
+        row.dataset.negotiable = cellVal ? 'true' : 'false';
+        updateNegotiableCell(negCell, cellVal, override);
+        row.classList.toggle('negotiated-row', cellVal);
     }
     row.dataset.requiresReview = needsReview ? 'true' : 'false';
     const indicator = row.querySelector('.text-danger.text-sm');


### PR DESCRIPTION
## Summary
- update row appearance when technical availability changes
- show tooltip on manual negotiable overrides

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_687815d74438832b820a140a9c6e2c3a