### PR TITLE
Create dedicated view for Gap notes

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -258,6 +258,11 @@ urlpatterns = [
         name="hx_toggle_negotiable",
     ),
     path(
+        "anlage2/notizen/<int:result_id>/",
+        views.edit_gap_notes,
+        name="edit_gap_notes",
+    ),
+    path(
         "ajax/start-gutachten/<int:project_id>/",
         views.ajax_start_gutachten_generation,
         name="ajax_start_gutachten_generation",

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -189,12 +189,10 @@ input[type="submit"]:hover {
     opacity: 0.4;
 }
 
-/* Icon für Popover-Editor */
+/* Icon für Notiz-Bearbeitung */
 .gap-note-icon {
     cursor: pointer;
 }
-
-/* Breiteres Layout im Popover */
-.gap-popover textarea {
-    width: 100%;
+.gap-note-icon.filled {
+    color: #2563eb;
 }

--- a/templates/gap_notes_form.html
+++ b/templates/gap_notes_form.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block title %}Notizen bearbeiten{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Notizen für {{ result.funktion.name }} bearbeiten</h1>
+<form method="post">
+    {% csrf_token %}
+    <div class="mb-4">
+        <label for="id_gap_summary" class="block font-semibold">(Extern) Anmerkungen für den Fachbereich</label>
+        <textarea id="id_gap_summary" name="gap_summary" rows="6" class="border rounded w-full p-2">{{ result.gap_summary }}</textarea>
+    </div>
+    <div class="mb-4">
+        <label for="id_gap_notiz" class="block font-semibold">Interne Arbeitsanmerkung (Gap-Analyse)</label>
+        <textarea id="id_gap_notiz" name="gap_notiz" rows="6" class="border rounded w-full p-2">{{ result.gap_notiz }}</textarea>
+    </div>
+    <div class="space-x-2">
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+        {% if project_file %}
+        <a href="{% url 'projekt_file_edit_json' project_file.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück</a>
+        {% else %}
+        <a href="{% url 'projekt_detail' result.projekt.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück</a>
+        {% endif %}
+    </div>
+</form>
+{% endblock %}
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+{% endblock %}
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    new EasyMDE({ element: document.getElementById('id_gap_summary') });
+    new EasyMDE({ element: document.getElementById('id_gap_notiz') });
+  });
+</script>
+{% endblock %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -96,38 +96,15 @@
                 {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_override %}
                 <td id="gap-cell-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}"
                     class="border px-2 text-center {% if row.has_preliminary_gap %}has-gap{% endif %}">
-                    <span id="gap-note-icon-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}"
-                          class="gap-note-icon" role="button" tabindex="0"
-                          data-bs-toggle="popover"
-                          data-bs-content-selector="#gap-popover-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}">🗒️</span>
+                    {% if row.result_id %}
+                    <a href="{% url 'edit_gap_notes' row.result_id %}"
+                       class="gap-note-icon {% if row.has_notes %}text-blue-600{% endif %}">🗒️</a>
+                    {% else %}
+                    <span class="gap-note-icon">🗒️</span>
+                    {% endif %}
                     {% if row.requires_manual_review %}
                     <div class="text-danger text-sm">Manueller Review erforderlich</div>
                     {% endif %}
-                    <div id="gap-popover-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}" class="d-none">
-                        <ul class="nav nav-tabs" role="tablist">
-                            <li class="nav-item" role="presentation">
-                                <button class="nav-link active" data-bs-toggle="tab"
-                                        data-bs-target="#intern-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}"
-                                        type="button" role="tab">Intern</button>
-                            </li>
-                            <li class="nav-item" role="presentation">
-                                <button class="nav-link" data-bs-toggle="tab"
-                                        data-bs-target="#extern-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}"
-                                        type="button" role="tab">Extern</button>
-                            </li>
-                        </ul>
-                        <div class="tab-content mt-2 gap-popover">
-                            <div class="tab-pane fade show active" id="intern-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}" role="tabpanel">
-                                {{ row.gap_notiz_widget }}
-                            </div>
-                            <div class="tab-pane fade" id="extern-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}" role="tabpanel">
-                                {{ row.gap_summary_widget }}
-                            </div>
-                        </div>
-                        <button type="button" class="btn btn-primary btn-save-gap mt-2"
-                                data-function-id="{{ row.func_id }}"{% if row.sub %} data-sub-id="{{ row.sub_id }}"{% endif %}
-                                data-trigger-id="gap-note-icon-{{ row.func_id }}{% if row.sub %}-{{ row.sub_id }}{% endif %}">Speichern</button>
-                    </div>
                 </td>
             </tr>
         {% endfor %}
@@ -339,32 +316,6 @@ function updateRowAppearance(row) {
         });
     });
 
-    document.querySelectorAll('.btn-save-gap').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const pop = this.closest('.popover');
-            const textareas = pop ? pop.querySelectorAll('textarea') : [];
-            const intern = textareas[0] ? textareas[0].value : '';
-            const extern = textareas[1] ? textareas[1].value : '';
-            const payload = {
-                project_file_id: document.querySelector('form[data-anlage-id]').dataset.anlageId,
-                function_id: this.dataset.functionId,
-                gap_notiz: intern,
-                gap_summary: extern
-            };
-            if (this.dataset.subId) payload.subquestion_id = this.dataset.subId;
-            fetch("{% url 'ajax_save_anlage2_review' %}", {
-                method: 'POST',
-                headers: { 'X-CSRFToken': getCookie('csrftoken'), 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload)
-            }).then(() => {
-                const trigger = document.getElementById(this.dataset.triggerId);
-                if (trigger) {
-                    const inst = bootstrap.Popover.getInstance(trigger);
-                    if (inst) inst.hide();
-                }
-            });
-        });
-    });
     document.body.addEventListener('htmx:afterSwap', e => {
         const r = e.target.closest("tr[data-parsed-status]");
         if (r) updateRowAppearance(r);
@@ -375,16 +326,6 @@ function updateRowAppearance(row) {
 function initDynamicElements(container) {
     if (!container) return;
     container.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
-    container.querySelectorAll('[data-bs-toggle="popover"]').forEach(el => {
-        const sel = el.dataset.bsContentSelector;
-        const opts = {html: true};
-        if (sel) {
-            const cont = document.querySelector(sel);
-            opts.content = cont ? cont.innerHTML : '';
-            opts.sanitize = false;
-        }
-        new bootstrap.Popover(el, opts);
-    });
 }
 
 document.body.addEventListener('htmx:afterSwap', function(event) {


### PR DESCRIPTION
## Summary
- add `edit_gap_notes` view and route
- create `gap_notes_form.html` for note editing
- link Gap column to the new view
- simplify JS and CSS now that popovers are gone

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django_q')*

------
https://chatgpt.com/codex/tasks/task_e_68781d27f0ac832bbe7fa9d167e538ad