### PR TITLE
Fix frontend initialization and JSON handling

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -178,8 +178,17 @@ def _deep_update(base: dict, extra: dict) -> dict:
     return base
 
 
-def _normalize_fields(data: dict | None) -> dict:
-    """Passt die Feldernamen an ``FIELD_RENAME`` an."""
+def _normalize_fields(data: dict | str | None) -> dict:
+    """Passt die Feldernamen an ``FIELD_RENAME`` an.
+
+    Behandelt auch JSON-Strings robust."""
+    if data is None:
+        return {}
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except Exception:  # pragma: no cover - ungültiger JSON-Input
+            return {}
     if not isinstance(data, dict):
         return {}
     return {FIELD_RENAME.get(k, k): v for k, v in data.items()}

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -138,6 +138,10 @@ STATICFILES_DIRS = [BASE_DIR / "static"]
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 
+# Cookies explizit auf SameSite=Lax setzen
+SESSION_COOKIE_SAMESITE = "Lax"
+CSRF_COOKIE_SAMESITE = "Lax"
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,3 +1,15 @@
+function safeJsonParse(jsonString) {
+    if (!jsonString || jsonString.trim() === "") {
+        return {};
+    }
+    try {
+        return JSON.parse(jsonString);
+    } catch (e) {
+        console.error("Fehler beim Parsen von JSON:", jsonString, e);
+        return {};
+    }
+}
+
 function showSpinner(buttonElement, spinnerText = 'Wird geladen...') {
     if (!buttonElement) return;
     buttonElement.dataset.originalHtml = buttonElement.innerHTML;

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,9 +11,11 @@
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script>
-    document.body.addEventListener('htmx:configRequest', (event) => {
-        event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
-    })
+    document.addEventListener('DOMContentLoaded', function() {
+        document.body.addEventListener('htmx:configRequest', (event) => {
+            event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
+        });
+    });
     </script>
     {% block extra_head %}{% endblock %}
 </head>


### PR DESCRIPTION
## Summary
- initialize htmx config after DOM load
- parse potential JSON strings safely in backend
- provide a `safeJsonParse` helper in utils.js
- set SameSite=Lax for cookies

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68788d9c34e8832b910b881de5d22050