### PR TITLE
Fix result lookup for subquestions

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -553,6 +553,10 @@ def _build_row_data(
         }
 
     result_obj = result_map.get(lookup_key)
+    # Fallback: Bei Unterfragen ggf. Ergebnis der Hauptfunktion verwenden
+    if result_obj is None and sub_id is not None:
+        parent_key = lookup_key.split(":", 1)[0].strip()
+        result_obj = result_map.get(parent_key)
     is_negotiable = result_obj.negotiable if result_obj else False
     override_val = (
         result_obj.is_negotiable_manual_override if result_obj else None


### PR DESCRIPTION
## Summary
- ensure subquestion rows reuse parent result data when no specific result is stored

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'pypandoc')*

------
https://chatgpt.com/codex/tasks/task_e_68789db632d4832b84eb0365afbbdd85