### PR TITLE
Add manual flag metadata for Anlage 2 review

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -727,6 +727,43 @@ class BuildRowDataTests(NoesisTestCase):
         )
         self.assertFalse(row["requires_manual_review"])
 
+    def test_manual_flags_propagated(self):
+        analysis = {}
+        verification = {}
+        manual = {"Testfunktion": {"technisch_vorhanden": True}}
+        row = _build_row_data(
+            "Testfunktion",
+            "Testfunktion",
+            self.func.id,
+            f"func{self.func.id}_",
+            self.form,
+            {},
+            {},
+            {},
+            analysis,
+            verification,
+            manual,
+            {},
+        )
+        self.assertTrue(row["manual_flags"]["technisch_vorhanden"])
+
+    def test_manual_flags_false_when_absent(self):
+        row = _build_row_data(
+            "Testfunktion",
+            "Testfunktion",
+            self.func.id,
+            f"func{self.func.id}_",
+            self.form,
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+        self.assertFalse(row["manual_flags"]["technisch_vorhanden"])
+
 
 class LLMTasksTests(NoesisTestCase):
     maxDiff = None

--- a/core/views.py
+++ b/core/views.py
@@ -479,6 +479,7 @@ def _get_display_data(
 
     values: dict[str, bool] = {}
     sources: dict[str, str] = {}
+    manual_flags: dict[str, bool] = {}
 
     for field, _ in fields:
         man_val = m_data.get(field)
@@ -488,12 +489,14 @@ def _get_display_data(
         val, src = _resolve_value(man_val, ai_val, doc_val, field, manual_exists)
         values[field] = val
         sources[field] = src
+        manual_flags[field] = manual_exists
 
     return {
         "values": values,
         "sources": sources,
         "status": values.get("technisch_vorhanden"),
         "source": sources.get("technisch_vorhanden"),
+        "manual_flags": manual_flags,
     }
 
 
@@ -585,6 +588,7 @@ def _build_row_data(
         "doc_result": _normalize_fields(answers.get(lookup_key, {})),
         "ai_result": _normalize_fields(verification_lookup.get(lookup_key, {})),
         "initial": disp["values"],
+        "manual_flags": disp["manual_flags"],
         "form_fields": form_fields_map,
         "is_negotiable": is_negotiable,
         "negotiable_manual_override": override_val,
@@ -3661,6 +3665,7 @@ def hx_update_review_cell(request, result_id: int, field_name: str):
             "result_id": result.id,
             "sub_id": sub_id,
         },
+        "is_manual": True,
     }
     return render(request, "partials/review_cell.html", context)
 

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -3,6 +3,7 @@
     {% if row.result_id %}
     <button class="tri-state-icon{% if field_name == 'technisch_vorhanden' and row.sub %} disabled-field{% endif %}"
             data-field-name="{{ field_name }}"
+            data-is-manual="{{ is_manual|yesno:'true,false' }}"
             hx-post="{% url 'hx_update_review_cell' result_id=row.result_id field_name=field_name %}{% if row.sub_id %}?sub_id={{ row.sub_id }}{% endif %}"
             hx-target="closest td" hx-swap="outerHTML">
         {% if state == True %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -90,7 +90,7 @@
                 </td>
                 {% for field in fields %}
                 {% with f=row.form_fields|get_item:field %}
-                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source %}
+                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field %}
                 {% endwith %}
                 {% endfor %}
                 {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_override %}
@@ -194,12 +194,9 @@ function updateTooltip(icon, input) {
     let aiVal = ai[aiKey];
     if (aiVal && typeof aiVal === 'object' && 'value' in aiVal) aiVal = aiVal.value;
     let manualVal = null;
-    if (input && input.dataset && 'state' in input.dataset) {
+    if (icon.dataset.isManual === 'true' && input && input.dataset && 'state' in input.dataset) {
         const st = input.dataset.state;
         manualVal = st === 'true' ? true : st === 'false' ? false : null;
-    } else {
-        const txt = icon.textContent.trim();
-        manualVal = txt.startsWith('✓') ? true : (txt.startsWith('✗') ? false : null);
     }
     const txt = `Dokument: ${docVal}\nKI-Check: ${aiVal}\nManuell: ${manualVal}`;
     icon.setAttribute('title', txt);
@@ -223,6 +220,7 @@ function updateRowAppearance(row) {
         const icon = row.querySelector(`.tri-state-icon[data-field-name="${f}"]`);
         if (!icon) return;
         const manual = textToState(icon.textContent);
+        icon.dataset.isManual = manual !== null ? 'true' : 'false';
         const docKey = f === 'technisch_vorhanden' && doc.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : f;
         const aiKey = f === 'technisch_vorhanden' && ai.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : f;
         let docVal = doc[docKey];


### PR DESCRIPTION
## Summary
- track whether manual values exist in `_get_display_data`
- propagate manual flags in `_build_row_data`
- add `data-is-manual` attribute to review buttons
- read `isManual` in `updateTooltip()`
- adjust JS to update manual flags dynamically
- extend tests for manual flag handling

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68789db6c214832b928127f2c99bedb3