### PR TITLE
Add status popover for tri-state icons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -196,3 +196,13 @@ input[type="submit"]:hover {
 .gap-note-icon.filled {
     color: #2563eb;
 }
+.status-popover {
+    position: absolute;
+    background: white;
+    border: 1px solid #d1d5db;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    padding: 0.5rem;
+    font-size: 0.875rem;
+    z-index: 1000;
+    display: none;
+}

--- a/templates/partials/status_popover.html
+++ b/templates/partials/status_popover.html
@@ -1,0 +1,1 @@
+<div class="status-popover"></div>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -116,6 +116,7 @@
         <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-black px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>
     </div>
 </form>
+{% include 'partials/status_popover.html' %}
 </div>
 {% endblock %}
 {% block extra_js %}
@@ -181,7 +182,7 @@ function updateNegotiableCell(cell, value, override) {
     }
 }
 
-function updateTooltip(icon, input) {
+function updateTooltip(icon) {
     const row = icon.closest('tr');
     if (!row) return;
     const doc = safeJsonParse(row.dataset.doc);
@@ -193,23 +194,19 @@ function updateTooltip(icon, input) {
     if (docVal && typeof docVal === 'object' && 'value' in docVal) docVal = docVal.value;
     let aiVal = ai[aiKey];
     if (aiVal && typeof aiVal === 'object' && 'value' in aiVal) aiVal = aiVal.value;
-    let manualVal = null;
-    if (input && input.dataset && 'state' in input.dataset) {
-        const st = input.dataset.state;
-        manualVal = st === 'true' ? true : st === 'false' ? false : null;
-    } else {
-        const txt = icon.textContent.trim();
-        manualVal = txt.startsWith('✓') ? true : (txt.startsWith('✗') ? false : null);
-    }
-    const txt = `Dokument: ${docVal}\nKI-Check: ${aiVal}\nManuell: ${manualVal}`;
-    icon.setAttribute('title', txt);
-    icon.dataset.bsToggle = 'tooltip';
-    const inst = bootstrap.Tooltip.getInstance(icon);
-    if (inst) {
-        inst.setContent({ '.tooltip-inner': txt });
-    } else {
-        new bootstrap.Tooltip(icon);
-    }
+    const txt = icon.textContent.trim();
+    const manualVal = txt.startsWith('\u2713') ? true : (txt.startsWith('\u2717') ? false : null);
+    const pop = document.querySelector('.status-popover');
+    if (!pop) return;
+    pop.innerHTML = `Dokument: ${docVal}<br>KI-Check: ${aiVal}<br>Manuell: ${manualVal}`;
+    const rect = icon.getBoundingClientRect();
+    pop.style.top = `${rect.bottom + window.scrollY + 4}px`;
+    pop.style.left = `${rect.left + window.scrollX}px`;
+    pop.style.display = 'block';
+}
+function hideTooltip() {
+    const pop = document.querySelector('.status-popover');
+    if (pop) pop.style.display = 'none';
 }
 
 function updateRowAppearance(row) {
@@ -240,7 +237,6 @@ function updateRowAppearance(row) {
             cls = docVal === aiVal ? 'status-ok' : 'status-konflikt';
         }
         icon.classList.add(cls);
-        updateTooltip(icon, {dataset: {state: manual === true ? 'true' : manual === false ? 'false' : 'unknown'}});
         if (docVal !== undefined && aiVal !== undefined && docVal !== aiVal && manual === null) {
             needsReview = true;
         }
@@ -367,9 +363,17 @@ function updateRowAppearance(row) {
     document.querySelectorAll("tbody tr[data-parsed-status]").forEach(r => updateRowAppearance(r));
     applyFilters();
 }
+function attachStatusListeners(container) {
+    if (!container) return;
+    container.querySelectorAll(".tri-state-icon").forEach(btn => {
+        btn.addEventListener("mouseenter", () => updateTooltip(btn));
+        btn.addEventListener("mouseleave", hideTooltip);
+    });
+}
 function initDynamicElements(container) {
     if (!container) return;
-    container.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
+    container.querySelectorAll("[data-bs-toggle="tooltip"]").forEach(el => new bootstrap.Tooltip(el));
+    attachStatusListeners(container);
 }
 
 document.body.addEventListener('htmx:afterSwap', function(event) {


### PR DESCRIPTION
## Summary
- add CSS for status popover
- include popover partial in Anlage 2 review page
- implement custom tooltip logic and listeners

## Testing
- `python3 manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68789db756a4832b98417cfab62cd2fa