### PR TITLE
Fix popover init timing

### DIFF
--- a/static/js/popover.js
+++ b/static/js/popover.js
@@ -24,6 +24,7 @@
             }
         });
     }
+    window.attachCustomPopover = attach;
     window.initCustomPopovers = function(container=document){
         container.querySelectorAll('[data-popover-content]').forEach(el => {
             if(!el.dataset.popoverInit){
@@ -32,6 +33,4 @@
             }
         });
     };
-    document.addEventListener('DOMContentLoaded', () => initCustomPopovers());
-    document.body.addEventListener('htmx:afterSwap', e => initCustomPopovers(e.detail.target));
 })();

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -203,6 +203,9 @@ function updatePopoverContent(icon, input) {
     }
     const html = `Dokument: ${docVal}<br>KI-Check: ${aiVal}<br>Manuell: ${manualVal}`;
     icon.dataset.popoverContent = html;
+    if (window.attachCustomPopover) {
+        window.attachCustomPopover(icon);
+    }
 }
 
 function updateRowAppearance(row) {
@@ -361,17 +364,8 @@ function updateRowAppearance(row) {
     document.querySelectorAll("tbody tr[data-parsed-status]").forEach(r => updateRowAppearance(r));
     applyFilters();
 }
-function initDynamicElements(container) {
-    if (!container) return;
-    initCustomPopovers(container);
-}
-
-document.body.addEventListener('htmx:afterSwap', function(event) {
-    initDynamicElements(event.detail.target);
-});
 
 document.addEventListener('DOMContentLoaded', function() {
-    initDynamicElements(document);
     initAnlage2Review();
 });
 </script>


### PR DESCRIPTION
## Summary
- expose popover attach function globally
- attach popovers when setting popover content
- drop redundant popover initialization handlers

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878cd5b2bd8832ba33e8ab20f64eb97