### PR TITLE
Fix Anlage2 negotiation logic

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1575,22 +1575,7 @@ def worker_verify_feature(
         defaults={"ai_result": verification_result},
     )
 
-    manual_val = None
-    if isinstance(res.manual_result, dict):
-        manual_val = res.manual_result.get("technisch_vorhanden")
-
-    doc_val = None
-    if isinstance(res.doc_result, dict):
-        doc_val = res.doc_result.get("technisch_verfuegbar")
-
-    ai_val = verification_result.get("technisch_verfuegbar")
-
-    auto_val = (
-        (ai_val is not None and doc_val is not None and ai_val == doc_val)
-        or (
-            manual_val is not None and doc_val is not None and manual_val == doc_val
-        )
-    )
+    auto_val = _calc_auto_negotiable(res.doc_result, verification_result)
 
     if res.is_negotiable_manual_override is None:
         res.is_negotiable = auto_val

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -275,8 +275,13 @@ function updateRowAppearance(row) {
         let override = null;
         if (hasUser) override = cellVal;
         row.dataset.manualOverride = override !== null ? String(override) : '';
-        if (override === null && techState !== null) {
-            cellVal = techState;
+        const docValRaw = doc.hasOwnProperty('technisch_verfuegbar') ? doc.technisch_verfuegbar : doc.technisch_vorhanden;
+        const aiValRaw = ai.hasOwnProperty('technisch_verfuegbar') ? ai.technisch_verfuegbar : ai.technisch_vorhanden;
+        let docVal2 = docValRaw && typeof docValRaw === 'object' && 'value' in docValRaw ? docValRaw.value : docValRaw;
+        let aiVal2 = aiValRaw && typeof aiValRaw === 'object' && 'value' in aiValRaw ? aiValRaw.value : aiValRaw;
+        const autoVal = (docVal2 !== undefined && docVal2 !== null && aiVal2 !== undefined && aiVal2 !== null && docVal2 === aiVal2);
+        if (override === null) {
+            cellVal = autoVal;
         }
         row.dataset.negotiable = cellVal ? 'true' : 'false';
         updateNegotiableCell(negCell, cellVal, override);


### PR DESCRIPTION
## Summary
- add helpers for automatic negotiable calculation
- determine `is_negotiable` from doc and AI results unless manually overridden
- adjust HTMX negotiation toggle
- update async worker
- fix frontend logic to show auto negotiation status

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68790bb642e4832ba77888f4c61636dd