### PR TITLE
Add subquestion prompts and AI verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,20 +289,23 @@ Tabellenparser Vorrang.
 ### KI-Begründung per Tooltip
 
 Bei der LLM-Prüfung einzelner Funktionen ruft der Hintergrundtask zusätzlich den
-Prompt `anlage2_feature_justification` auf. Dieser fragt nach einer kurzen
-Begründung, warum die Funktion bei der angegebenen Software üblicherweise
-vorhanden ist. Das Ergebnis wird als `ki_begruendung` gespeichert und im
-Review-Formular neben dem Funktionsnamen als Info-Symbol angezeigt. Ein
-Mouseover blendet den Text als Tooltip ein.
+Prompt `anlage2_feature_justification` auf. Dieser ermittelt, warum die Software
+die Funktion üblicherweise besitzt und ob sich damit eine Leistungs- oder
+Verhaltenskontrolle nach §87 Abs. 1 Nr. 6 BetrVG durchführen lässt. Für
+Unterfragen nutzt das System den gesonderten Prompt
+`anlage2_subquestion_justification_check`. Das Ergebnis wird als
+`ki_begruendung` gespeichert und im Review-Formular neben dem Funktionsnamen als
+Info-Symbol angezeigt. Ein Mouseover blendet den Text als Tooltip ein.
 
 ### Zweistufige KI‑Beteiligungsprüfung
 
 In der Review-Ansicht von Anlage 2 lässt sich für jede Funktion eine
-"KI‑Prüfung starten". Der Prozess arbeitet nun in zwei Stufen. Zunächst wird
-geklärt, ob die Funktion technisch verfügbar ist. Nur wenn diese Prüfung
-bejaht wird, folgt Stufe 2 mit der Einschätzung, ob üblicherweise eine
-KI‑Beteiligung vorliegt. Beide Ergebnisse erscheinen anschließend direkt in der
-Tabelle, wobei die Begründung weiterhin über den Info‑Link abrufbar ist.
+"KI‑Prüfung starten". Der Prozess arbeitet in zwei Stufen. Zunächst wird mit
+einem spezifischen Prompt geklärt, ob die Funktion beziehungsweise Unterfrage
+technisch möglich ist. Nur bei einem positiven Ergebnis folgt Stufe 2 mit der
+Einschätzung, ob üblicherweise eine KI‑Beteiligung vorliegt. Beide Ergebnisse
+erscheinen anschließend direkt in der Tabelle, wobei die jeweilige Begründung
+über einen Info‑Link abrufbar ist.
 
 Die Antwort auf die KI-Frage wird unter `ki_beteiligt` gespeichert. Gibt das
 Modell "Ja" zurück, folgt zudem eine kurze Erläuterung, die im Feld

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -266,6 +266,34 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
                 "Wenn ja, wie?"
             )
         },
+        "anlage2_subquestion_possibility_check": {
+            "text": (
+                "Im Kontext der Funktion '{function_name}' der Software "
+                "'{software_name}': Ist die spezifische Anforderung "
+                "'{subquestion_text}' technisch möglich? Antworte nur mit 'Ja', "
+                "'Nein' oder 'Unsicher'."
+            )
+        },
+        "anlage2_subquestion_justification_check": {
+            "text": (
+                " [SYSTEM]\nDu bist Fachautor*in für IT-Mitbestimmung (§87 Abs. 1 Nr. 6 BetrVG).\n"
+                "Antworte Unterfrage prägnant in **maximal zwei Sätzen** (insgesamt ≤ 65 Wörter) und erfülle folgende Regeln :\n\n"
+                "1. Starte Teil A mit „Typischer Zweck: …“  \n2. Starte Teil B mit „Kontrolle: Ja, …“ oder „Kontrolle: Nein, …“.  \n"
+                "3. Nenne exakt die übergebene Funktion/Eigenschaft, erfinde nichts dazu.  \n"
+                "4. Erkläre knapp *warum* mit der Funktion die Unterfrage (oder warum nicht) eine Leistungs- oder Verhaltenskontrolle möglich ist.  \n"
+                "5. Verwende Alltagssprache, keine Marketing-Floskeln.\n\n"
+                " [USER]\nSoftware: {{software_name}}  \nFunktion/Eigenschaft: {{function_name}}  \nUnterfrage: \"{{subquestion_text}}\""
+            )
+        },
+        "anlage2_ai_verification_prompt": {
+            "text": (
+                "Gib eine kurze Begründung, warum die Funktion '{function_name}' "
+                "(oder die Unterfrage '{subquestion_text}') der Software "
+                "'{software_name}' eine KI-Komponente beinhaltet oder beinhalten kann, "
+                "insbesondere im Hinblick auf die Verarbeitung unstrukturierter Daten "
+                "oder nicht-deterministischer Ergebnisse."
+            )
+        },
         "anlage2_feature_verification": {
             "text": (
                 "Deine einzige Aufgabe ist es, die folgende Frage mit einem einzigen "


### PR DESCRIPTION
## Summary
- expand documentation about technical check prompts
- add new prompts for subquestion checks and AI verification in tests
- adapt `worker_verify_feature` to use different prompts for subquestions
- extend AI justification with new prompt `anlage2_ai_verification_prompt`

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687932e40c58832b8d02475762bbc27d