### PR TITLE
Manual gap summary workflow

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -263,6 +263,11 @@ urlpatterns = [
         name="edit_gap_notes",
     ),
     path(
+        "ajax/generate-gap-summary/<int:result_id>/",
+        views.ajax_generate_gap_summary,
+        name="ajax_generate_gap_summary",
+    ),
+    path(
         "ajax/start-gutachten/<int:project_id>/",
         views.ajax_start_gutachten_generation,
         name="ajax_start_gutachten_generation",

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -101,6 +101,7 @@
                     {% if row.result_id %}
                     <a href="{% url 'edit_gap_notes' row.result_id %}"
                        class="gap-note-icon {% if row.has_notes %}text-blue-600{% endif %}">🗒️</a>
+                    <button type="button" class="gap-summary-btn" data-result-id="{{ row.result_id }}" title="Gap-Zusammenfassung generieren">↻</button>
                     {% else %}
                     <span class="gap-note-icon">🗒️</span>
                     {% endif %}
@@ -360,6 +361,20 @@ function updateRowAppearance(row) {
         }).catch(() => { btn.textContent = '⚠️'; });
     }
 
+    function generateGapSummary(btn) {
+        showSpinner(btn, '');
+        const resultId = btn.dataset.resultId;
+        fetch(`/ajax/generate-gap-summary/${resultId}/`, {
+            method: 'POST',
+            headers: { 'X-CSRFToken': getCookie('csrftoken') }
+        }).then(() => {
+            hideSpinner(btn);
+        }).catch(() => {
+            btn.textContent = '⚠️';
+            btn.disabled = false;
+        });
+    }
+
     document.querySelectorAll('.review-cycle-btn').forEach(button => {
         button.addEventListener('click', function() {
             const state = this.dataset.state;
@@ -372,6 +387,12 @@ function updateRowAppearance(row) {
                     window.location.href = this.dataset.justificationUrl;
                 }
             }
+        });
+    });
+
+    document.querySelectorAll('.gap-summary-btn').forEach(btn => {
+        btn.addEventListener('click', function() {
+            generateGapSummary(this);
         });
     });
 


### PR DESCRIPTION
## Summary
- make gap summary generation manual
- add endpoint and button for manual generation
- update tests for manual workflow

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6879507eebdc832ba59865bcb94175a0