### PR TITLE
Fix gutachten cleanup

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1310,8 +1310,7 @@ def admin_project_cleanup(request, pk):
             return redirect("admin_project_cleanup", pk=projekt.pk)
         if action == "delete_gutachten":
             if projekt.gutachten_file:
-                path = Path(settings.MEDIA_ROOT) / projekt.gutachten_file.name
-                path.unlink(missing_ok=True)
+                projekt.gutachten_file.delete(save=False)
                 projekt.gutachten_file = ""
                 projekt.save(update_fields=["gutachten_file"])
             messages.success(request, "Gutachten gelöscht")


### PR DESCRIPTION
## Summary
- ensure deletion of report uses Django's file API

## Testing
- `python manage.py test core.tests.test_admin_views.AdminProjectCleanupTests.test_delete_gutachten -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6879571b05f8832ba9b6270786fcdebd