### PR TITLE
Überarbeitung Anlage1 Review

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -28,14 +28,6 @@ from .parser_manager import parser_manager
 from .llm_tasks import ANLAGE1_QUESTIONS
 
 
-# Auswahloptionen für die Bewertung einer Frage in Anlage 1
-REVIEW_STATUS_CHOICES = [
-    ("ok", "ok"),
-    ("unklar", "unklar"),
-    ("unvollständig", "unvollständig"),
-]
-
-
 def get_anlage1_numbers() -> list[int]:
     """Gibt die vorhandenen Fragen-Nummern zurück."""
     qs = list(Anlage1Question.objects.order_by("num"))
@@ -270,33 +262,20 @@ class Anlage1ReviewForm(forms.Form):
         for i in get_anlage1_numbers():
             self.fields[f"q{i}_ok"] = forms.BooleanField(
                 required=False,
-                label=f"Frage {i} geprüft und in Ordnung",
+                label=f"Frage {i} verhandlungsfähig",
                 widget=forms.CheckboxInput(attrs={"class": "mr-2"}),
-            )
-            self.fields[f"q{i}_note"] = forms.CharField(
-                required=False,
-                label=f"Frage {i} Kommentar intern",
-                widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
-            )
-            self.fields[f"q{i}_status"] = forms.ChoiceField(
-                required=False,
-                choices=REVIEW_STATUS_CHOICES,
-                label=f"Frage {i} Status",
-                widget=forms.Select(attrs={"class": "border rounded p-2"}),
             )
             self.fields[f"q{i}_hinweis"] = forms.CharField(
                 required=False,
-                label=f"Frage {i} Hinweise PMO",
+                label=f"Frage {i} Interne Arbeitsanmerkung (Gap-Analyse)",
                 widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
             )
             self.fields[f"q{i}_vorschlag"] = forms.CharField(
                 required=False,
-                label=f"Frage {i} Vorschlag an Fachbereich",
+                label=f"Frage {i} (Extern) Anmerkungen für den Fachbereich",
                 widget=forms.Textarea(attrs={"class": "border rounded p-2", "rows": 2}),
             )
             self.initial[f"q{i}_ok"] = data.get(str(i), {}).get("ok", False)
-            self.initial[f"q{i}_note"] = data.get(str(i), {}).get("note", "")
-            self.initial[f"q{i}_status"] = data.get(str(i), {}).get("status", "")
             self.initial[f"q{i}_hinweis"] = data.get(str(i), {}).get("hinweis", "")
             self.initial[f"q{i}_vorschlag"] = data.get(str(i), {}).get("vorschlag", "")
 
@@ -307,14 +286,11 @@ class Anlage1ReviewForm(forms.Form):
         for i in get_anlage1_numbers():
             key = str(i)
             q_data: dict[str, object] = {
-                "status": self.cleaned_data.get(f"q{i}_status", ""),
                 "hinweis": self.cleaned_data.get(f"q{i}_hinweis", ""),
                 "vorschlag": self.cleaned_data.get(f"q{i}_vorschlag", ""),
             }
             if f"q{i}_ok" in self.cleaned_data:
                 q_data["ok"] = self.cleaned_data.get(f"q{i}_ok", False)
-            if f"q{i}_note" in self.cleaned_data:
-                q_data["note"] = self.cleaned_data.get(f"q{i}_note", "")
             out[key] = q_data
         return out
 

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -102,19 +102,18 @@ class ProjektFileJSONEditTests(NoesisTestCase):
         url = reverse("projekt_file_edit_json", args=[self.anlage1.pk])
         resp = self.client.post(
             url,
-            {"q1_ok": "on", "q1_note": "Hinweis"},
+            {"q1_ok": "on"},
         )
         self.assertRedirects(resp, reverse("projekt_detail", args=[self.projekt.pk]))
         self.anlage1.refresh_from_db()
         self.assertTrue(self.anlage1.question_review["1"]["ok"])
-        self.assertEqual(self.anlage1.question_review["1"]["note"], "Hinweis")
+        self.assertNotIn("note", self.anlage1.question_review["1"])
 
     def test_question_review_extended_fields_saved(self):
         url = reverse("projekt_file_edit_json", args=[self.anlage1.pk])
         resp = self.client.post(
             url,
             {
-                "q1_status": "unvollst\u00e4ndig",
                 "q1_hinweis": "Fehlt",
                 "q1_vorschlag": "Mehr Infos",
             },
@@ -122,9 +121,9 @@ class ProjektFileJSONEditTests(NoesisTestCase):
         self.assertRedirects(resp, reverse("projekt_detail", args=[self.projekt.pk]))
         self.anlage1.refresh_from_db()
         data = self.anlage1.question_review["1"]
-        self.assertEqual(data["status"], "unvollst\u00e4ndig")
         self.assertEqual(data["hinweis"], "Fehlt")
         self.assertEqual(data["vorschlag"], "Mehr Infos")
+        self.assertNotIn("status", data)
 
     def test_question_review_prefill_from_analysis(self):
         """Initialwerte stammen aus der automatischen Analyse."""
@@ -144,7 +143,6 @@ class ProjektFileJSONEditTests(NoesisTestCase):
         url = reverse("projekt_file_edit_json", args=[self.anlage1.pk])
         resp = self.client.get(url)
         form = resp.context["form"]
-        self.assertEqual(form.initial["q1_status"], "ok")
         self.assertEqual(form.initial["q1_hinweis"], "H")
         self.assertEqual(form.initial["q1_vorschlag"], "V")
 

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2422,25 +2422,6 @@ class Anlage2ConfigSingletonTests(NoesisTestCase):
         self.assertEqual(Anlage2Config.objects.count(), 1)
 
 
-class Anlage1EmailTests(NoesisTestCase):
-    def setUp(self):
-        self.user = User.objects.create_user("emailer", password="pass")
-        self.client.login(username="emailer", password="pass")
-        self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        self.file = BVProjectFile.objects.create(
-            projekt=self.projekt,
-            anlage_nr=1,
-            upload=SimpleUploadedFile("a.txt", b"data"),
-            question_review={"1": {"vorschlag": "Text"}},
-        )
-
-    def test_generate_email(self):
-        url = reverse("anlage1_generate_email", args=[self.file.pk])
-        with patch("core.views.query_llm", return_value="Mail"):
-            resp = self.client.post(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json()["text"], "Mail")
-
 
 class TileVisibilityTests(NoesisTestCase):
     def setUp(self):

--- a/core/urls.py
+++ b/core/urls.py
@@ -342,11 +342,6 @@ urlpatterns = [
         name="project_file_toggle_flag",
     ),
     path(
-        "work/anlage/<int:pk>/email/",
-        views.anlage1_generate_email,
-        name="anlage1_generate_email",
-    ),
-    path(
         "work/projekte/<int:pk>/gap-analysis/",
         views.projekt_gap_analysis,
         name="projekt_gap_analysis",

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -11,50 +11,26 @@
                 <th class="border px-2">Nr.</th>
                 <th class="border px-2">Frage</th>
                 <th class="border px-2">Antwort</th>
-                <th class="border px-2">Status</th>
-                <th class="border px-2">Hinweise PMO</th>
-                <th class="border px-2">Vorschlag an Fachbereich</th>
-                <th class="border px-2">geprüft und in Ordnung</th>
-                <th class="border px-2">Kommentar intern</th>
+                <th class="border px-2">Interne Arbeitsanmerkung (Gap-Analyse)</th>
+                <th class="border px-2">(Extern) Anmerkungen für den Fachbereich</th>
+                <th class="border px-2">Verhandlungsfähig</th>
             </tr>
         </thead>
         <tbody>
-        {% for num, question, ans, status_field, hinweis_field, vorschlag_field, ok_field, note_field in qa %}
+        {% for num, question, ans, hinweis_field, vorschlag_field, ok_field in qa %}
             <tr>
                 <td class="border px-2">{{ num }}</td>
                 <td class="border px-2">{{ question }}</td>
                 <td class="border px-2">{{ ans|markdownify }}</td>
-                <td class="border px-2">{{ status_field }}</td>
                 <td class="border px-2">{{ hinweis_field }}</td>
                 <td class="border px-2">{{ vorschlag_field }}</td>
                 <td class="border px-2">{{ ok_field }}</td>
-                <td class="border px-2">{{ note_field }}</td>
             </tr>
         {% endfor %}
         </tbody>
     </table>
     <div class="space-x-2 mt-2">
         <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
-        <button type="button" id="generate-email" class="bg-green-600 text-white px-4 py-2 rounded">E-Mail generieren</button>
     </div>
-    <textarea id="email-text" rows="8" class="border rounded w-full p-2 mt-4 hidden"></textarea>
 </form>
-<script>
-const emailField=document.getElementById('email-text');
-document.getElementById('generate-email').addEventListener('click',function(){
-    const btn=this;
-    showSpinner(btn, 'Generiere...');
-    fetch('{% url "anlage1_generate_email" anlage.pk %}',{
-        method:'POST',
-        headers:{'X-CSRFToken':getCookie('csrftoken')}
-    }).then(r=>r.json()).then(data=>{
-        hideSpinner(btn);
-        if(data.text){
-            emailField.classList.remove('hidden');
-            emailField.value=data.text;
-            navigator.clipboard.writeText(data.text).then(()=>alert('E-Mail Text kopiert'));
-        }else if(data.error){alert('Fehler: '+data.error);}
-    }).catch(()=>{hideSpinner(btn);alert('Fehler bei der Generierung');});
-});
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- UI der Anlage1-Prüfmaske vereinfacht
- Spalten und Felder für Status und internen Kommentar entfernt
- Bezeichnungen der verbleibenden Felder angepasst
- E-Mail-Funktion inklusive Route und View gelöscht
- Tests entsprechend aktualisiert

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fehlschlagend)*

------
https://chatgpt.com/codex/tasks/task_e_687a874dbb44832bbc3710ae32200aa7