### PR TITLE
Add htmx polling for verification state

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -480,6 +480,38 @@ class BVProjectFileTests(NoesisTestCase):
             resp = self.client.get(url)
         self.assertContains(resp, "disabled-btn")
 
+    def test_hx_project_file_status_running(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+            verification_task_id="tid",
+        )
+        self.client.login(username=self.user.username, password="pass")
+        with patch("core.models.fetch") as mock_fetch:
+            mock_fetch.return_value = SimpleNamespace(success=None)
+            url = reverse("hx_project_file_status", args=[pf.pk])
+            resp = self.client.get(url)
+        self.assertContains(resp, "hx-trigger")
+        self.assertContains(resp, "spinner")
+
+    def test_hx_project_file_status_ready(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+            verification_task_id="tid",
+        )
+        self.client.login(username=self.user.username, password="pass")
+        with patch("core.models.fetch") as mock_fetch:
+            mock_fetch.return_value = SimpleNamespace(success=True)
+            url = reverse("hx_project_file_status", args=[pf.pk])
+            resp = self.client.get(url)
+        self.assertNotContains(resp, "hx-trigger")
+        self.assertContains(resp, "Prüfen")
+
 
 class ProjektFileUploadTests(NoesisTestCase):
     def setUp(self):

--- a/core/urls.py
+++ b/core/urls.py
@@ -262,6 +262,11 @@ urlpatterns = [
         name="hx_toggle_negotiable",
     ),
     path(
+        "projects/anlagen/<int:pf_id>/status/",
+        views.hx_project_file_status,
+        name="hx_project_file_status",
+    ),
+    path(
         "anlage2/notizen/<int:result_id>/",
         views.edit_gap_notes,
         name="edit_gap_notes",

--- a/core/views.py
+++ b/core/views.py
@@ -3605,6 +3605,18 @@ def hx_toggle_negotiable(request, result_id: int):
 
 
 @login_required
+def hx_project_file_status(request, pf_id: int):
+    """Liefert den HTML-Status des Prüfbuttons für eine Anlage."""
+    pf = get_object_or_404(BVProjectFile, pk=pf_id)
+
+    if not _user_can_edit_project(request.user, pf.projekt):
+        return HttpResponseForbidden("Nicht berechtigt")
+
+    context = {"file": pf}
+    return render(request, "partials/check_button.html", context)
+
+
+@login_required
 def edit_gap_notes(request, result_id: int):
     """Bearbeitet die Gap-Notizen für ein Ergebnis."""
 

--- a/templates/partials/check_button.html
+++ b/templates/partials/check_button.html
@@ -1,0 +1,22 @@
+{% comment %}Button für Anlagenprüfung mit optionalem Polling per htmx{% endcomment %}
+<div id="check-btn-{{ file.pk }}"
+     {% if file.anlage_nr == 2 and file.is_verification_running %}
+        hx-get="{% url 'hx_project_file_status' file.pk %}"
+        hx-trigger="every 3s"
+        hx-swap="outerHTML"
+     {% endif %}>
+    {% if file.anlage_nr == 5 %}
+        <a href="{% url 'projekt_file_check_view' file.pk %}"
+           class="{% if file.anlage5review %}bg-green-600{% else %}bg-red-600{% endif %} text-white px-2 py-1 rounded">Prüfen</a>
+    {% elif file.anlage_nr == 6 %}
+        <a href="{% url 'anlage6_review' file.pk %}"
+           class="{% if file.anlage6_note or file.manual_reviewed %}bg-green-600{% else %}bg-red-600{% endif %} text-white px-2 py-1 rounded">Prüfen</a>
+    {% else %}
+        {% if file.anlage_nr == 2 and file.is_verification_running %}
+            <span class="bg-gray-400 text-white px-2 py-1 rounded disabled-btn"><span class="spinner"></span> Läuft...</span>
+        {% else %}
+            <a href="{% url 'projekt_file_check_view' file.pk %}"
+               class="{% if file.analysis_json %}bg-green-600{% else %}bg-red-600{% endif %} text-white px-2 py-1 rounded">Prüfen</a>
+        {% endif %}
+    {% endif %}
+</div>

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -56,20 +56,7 @@
             <td class="px-2 py-1">{{ a.anlage_nr }}</td>
             <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">Anlage {{ a.anlage_nr }}</a></td>
             <td class="px-2 py-1 text-center">
-                {% if a.anlage_nr == 5 %}
-                    <a href="{% url 'projekt_file_check_view' a.pk %}"
-                       class="{% if a.anlage5review %}bg-green-600{% else %}bg-red-600{% endif %} text-white px-2 py-1 rounded">Prüfen</a>
-                {% elif a.anlage_nr == 6 %}
-                    <a href="{% url 'anlage6_review' a.pk %}"
-                       class="{% if a.anlage6_note or a.manual_reviewed %}bg-green-600{% else %}bg-red-600{% endif %} text-white px-2 py-1 rounded">Prüfen</a>
-                {% else %}
-                    {% if a.anlage_nr == 2 and a.is_verification_running %}
-                        <span class="bg-gray-400 text-white px-2 py-1 rounded disabled-btn"><span class="spinner"></span> Läuft...</span>
-                    {% else %}
-                        <a href="{% url 'projekt_file_check_view' a.pk %}"
-                           class="{% if a.analysis_json %}bg-green-600{% else %}bg-red-600{% endif %} text-white px-2 py-1 rounded">Prüfen</a>
-                    {% endif %}
-                {% endif %}
+                {% include "partials/check_button.html" with file=a %}
             </td>
             <td class="px-2 py-1 text-center">
             {% if a.analysis_json or a.anlage_nr == 5 and a.anlage5review %}


### PR DESCRIPTION
## Summary
- render Prüfen-Button via new `partials/check_button.html`
- add `hx_project_file_status` view and route
- integrate button partial in project detail page
- cover new htmx endpoint with tests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py test` *(fails: Reverse for 'core_zweckkategoriea_changelist' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a91c240d4832b9c2035dafa6a2c37