### PR TITLE
Add Anlage2 result logging

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -142,6 +142,7 @@ logger = logging.getLogger(__name__)
 debug_logger = logging.getLogger("parser_debug")
 admin_a2_logger = logging.getLogger("anlage2_admin_debug")
 anlage2_logger = logging.getLogger("anlage2_debug")
+ergebnis_logger = logging.getLogger("anlage2_ergebnis")
 anlage4_logger = logging.getLogger("anlage4_debug")
 workflow_logger = logging.getLogger("workflow_debug")
 
@@ -2766,6 +2767,17 @@ def projekt_file_edit_json(request, pk):
     ):
         run_anlage2_analysis(anlage)
         anlage.refresh_from_db()
+
+    if request.method == "GET" and anlage.anlage_nr == 2:
+        results = (
+            Anlage2FunctionResult.objects.filter(projekt=anlage.projekt)
+            .select_related("funktion", "subquestion")
+        )
+        for res in results:
+            name = res.get_lookup_key()
+            doc_str = json.dumps(res.doc_result, ensure_ascii=False, indent=2)
+            ai_str = json.dumps(res.ai_result, ensure_ascii=False, indent=2)
+            ergebnis_logger.info("%s\nDOC: %s\nAI: %s", name, doc_str, ai_str)
 
 
 

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -223,6 +223,13 @@ LOGGING = {
             "formatter": "verbose",
             "encoding": "utf-8",
         },
+        "anlage2_ergebnis_file": {
+            "level": "INFO",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "anlage2-ergebnis.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+        },
         "anlage3_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
@@ -293,6 +300,11 @@ LOGGING = {
         "anlage2_debug": {
             "handlers": ["anlage2_file"],
             "level": "DEBUG",
+            "propagate": False,
+        },
+        "anlage2_ergebnis": {
+            "handlers": ["anlage2_ergebnis_file"],
+            "level": "INFO",
             "propagate": False,
         },
         "anlage3_debug": {


### PR DESCRIPTION
## Summary
- configure new logger `anlage2_ergebnis`
- record Anlage2 parser and AI results on GET requests

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687ab9f9b220832b8930f5fa11406a3f