### PR TITLE
Refactor response rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,7 @@ bearbeitbaren Bereiche:
   "answer_rules": [{
     "regel_name": "Standard",
     "erkennungs_phrase": "ja",
-    "ziel_feld": "technisch_verfuegbar",
-    "wert": true
+    "actions": {"technisch_verfuegbar": true}
   }],
   "a4_parser": {"delimiter_phrase": "Name der"}
 }

--- a/core/admin.py
+++ b/core/admin.py
@@ -224,12 +224,11 @@ class Anlage3ParserRuleAdmin(admin.ModelAdmin):
 class AntwortErkennungsRegelAdmin(admin.ModelAdmin):
     list_display = (
         "regel_name",
-        "ziel_feld",
         "regel_anwendungsbereich",
-        "wert",
         "prioritaet",
+        "actions_json",
     )
-    list_editable = ("ziel_feld", "regel_anwendungsbereich", "wert", "prioritaet")
+    list_editable = ("regel_anwendungsbereich", "prioritaet")
 
 
 @admin.register(Anlage4ParserConfig)

--- a/core/migrations/0033_migrate_actions_json.py
+++ b/core/migrations/0033_migrate_actions_json.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    Rule = apps.get_model('core', 'AntwortErkennungsRegel')
+    for rule in Rule.objects.all():
+        if not rule.actions_json and getattr(rule, 'ziel_feld', None):
+            rule.actions_json = {rule.ziel_feld: rule.wert}
+            rule.save(update_fields=['actions_json'])
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0032_antworterkennungsregel_actions_json_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, noop),
+        migrations.RemoveField(
+            model_name='antworterkennungsregel',
+            name='ziel_feld',
+        ),
+        migrations.RemoveField(
+            model_name='antworterkennungsregel',
+            name='wert',
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -711,11 +711,6 @@ class AntwortErkennungsRegel(models.Model):
 
     regel_name = models.CharField(max_length=100)
     erkennungs_phrase = models.CharField(max_length=200)
-    ziel_feld = models.CharField(
-        max_length=50,
-        choices=FormatBParserRule.FIELD_CHOICES,
-    )
-    wert = models.BooleanField()
     actions_json = models.JSONField(
         default=dict,
         blank=True,

--- a/core/parsers.py
+++ b/core/parsers.py
@@ -47,7 +47,7 @@ class ExactParser(AbstractParser):
         text = (project_file.text_content or "").lower()
         for rule in AntwortErkennungsRegel.objects.all().order_by("prioritaet"):
             if rule.erkennungs_phrase.lower() in text:
-                actions = rule.actions_json or {rule.ziel_feld: rule.wert}
+                actions = rule.actions_json or {}
                 for entry in results:
                     for field, val in actions.items():
                         entry[field] = {"value": bool(val), "note": None}

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -3154,8 +3154,7 @@ class Anlage2ConfigImportExportTests(NoesisTestCase):
         AntwortErkennungsRegel.objects.create(
             regel_name="R1",
             erkennungs_phrase="ja",
-            ziel_feld="technisch_verfuegbar",
-            wert=True,
+            actions_json={"technisch_verfuegbar": True},
             prioritaet=0,
         )
         a4 = Anlage4ParserConfig.objects.create(delimiter_phrase="X")
@@ -3189,8 +3188,7 @@ class Anlage2ConfigImportExportTests(NoesisTestCase):
                     {
                         "regel_name": "R2",
                         "erkennungs_phrase": "nein",
-                        "ziel_feld": "technisch_verfuegbar",
-                        "wert": False,
+                        "actions": {"technisch_verfuegbar": False},
                         "prioritaet": 1
                     }
                 ],

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -574,8 +574,7 @@ class DocxExtractTests(NoesisTestCase):
         AntwortErkennungsRegel.objects.create(
             regel_name="aktiv",
             erkennungs_phrase="aktivv",
-            ziel_feld="einsatz_telefonica",
-            wert=True,
+            actions_json={"einsatz_telefonica": True},
         )
         data = parse_anlage2_text("Lgin: aktivv")
         self.assertEqual(
@@ -593,15 +592,13 @@ class DocxExtractTests(NoesisTestCase):
         AntwortErkennungsRegel.objects.create(
             regel_name="a",
             erkennungs_phrase="foo",
-            ziel_feld="technisch_verfuegbar",
-            wert=True,
+            actions_json={"technisch_verfuegbar": True},
             prioritaet=2,
         )
         AntwortErkennungsRegel.objects.create(
             regel_name="b",
             erkennungs_phrase="bar",
-            ziel_feld="einsatz_telefonica",
-            wert=False,
+            actions_json={"einsatz_telefonica": False},
             prioritaet=1,
         )
         data = parse_anlage2_text("Login: foo bar rest")

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -199,20 +199,22 @@ def apply_rules(
     found_rules: Dict[str, tuple[bool, int, str]] = {}
     for rule in rules:
         if fuzzy_match(rule.erkennungs_phrase, text_part, threshold):
-            current = found_rules.get(rule.ziel_feld)
-            if current is None or rule.prioritaet < current[1]:
-                found_rules[rule.ziel_feld] = (
-                    rule.wert,
-                    rule.prioritaet,
-                    rule.erkennungs_phrase,
-                )
-                parser_logger.debug(
-                    "Regel '%s' (%s) setzt %s=%s",
-                    rule.regel_name,
-                    rule.erkennungs_phrase,
-                    rule.ziel_feld,
-                    rule.wert,
-                )
+            actions = rule.actions_json or {}
+            for field, val in actions.items():
+                current = found_rules.get(field)
+                if current is None or rule.prioritaet < current[1]:
+                    found_rules[field] = (
+                        bool(val),
+                        rule.prioritaet,
+                        rule.erkennungs_phrase,
+                    )
+                    parser_logger.debug(
+                        "Regel '%s' (%s) setzt %s=%s",
+                        rule.regel_name,
+                        rule.erkennungs_phrase,
+                        field,
+                        val,
+                    )
 
     if not found_rules:
         return

--- a/core/views.py
+++ b/core/views.py
@@ -1837,9 +1837,8 @@ def admin_anlage2_config_export(request):
         {
             "regel_name": r.regel_name,
             "erkennungs_phrase": r.erkennungs_phrase,
-            "ziel_feld": r.ziel_feld,
             "regel_anwendungsbereich": r.regel_anwendungsbereich,
-            "wert": r.wert,
+            "actions": r.actions_json,
             "prioritaet": r.prioritaet,
         }
         for r in rules
@@ -1914,12 +1913,11 @@ def admin_anlage2_config_import(request):
                 regel_name=r.get("regel_name"),
                 defaults={
                     "erkennungs_phrase": r.get("erkennungs_phrase", ""),
-                    "ziel_feld": r.get("ziel_feld", ""),
                     "regel_anwendungsbereich": r.get(
                         "regel_anwendungsbereich",
                         "Hauptfunktion",
                     ),
-                    "wert": r.get("wert", False),
+                    "actions_json": r.get("actions", {}),
                     "prioritaet": r.get("prioritaet", 0),
                 },
             )
@@ -2019,7 +2017,7 @@ def anlage2_config(request):
 
             if request.headers.get("HX-Request"):
                 formset = RuleFormSet(queryset=rules_qs, prefix="rules")
-                context = {"rule_formset": formset, "rule_choices": FormatBParserRule.FIELD_CHOICES}
+                context = {"rule_formset": formset}
                 return render(request, "partials/_response_rules_table.html", context)
             return redirect(f"{reverse('anlage2_config')}?tab=rules")
 
@@ -2090,7 +2088,6 @@ def anlage2_config(request):
         "rule_formset": rule_formset,
         "rule_formset_fb": rule_formset_fb,
         "choices": Anlage2ColumnHeading.FIELD_CHOICES,
-        "rule_choices": FormatBParserRule.FIELD_CHOICES,
         "parser_choices": get_parser_choices(),
         "active_tab": active_tab,
         "a4_parser_form": a4_parser_form,
@@ -2116,7 +2113,7 @@ def anlage2_rule_add(request):
     formset = RuleFormSet(queryset=AntwortErkennungsRegel.objects.none(), prefix="rules")
     form = formset.empty_form
     form.prefix = f"rules-{index}"
-    context = {"form": form, "rule_choices": FormatBParserRule.FIELD_CHOICES}
+    context = {"form": form}
     return render(request, "partials/_response_rule_row.html", context)
 
 
@@ -2353,9 +2350,7 @@ class AntwortErkennungsRegelCreateView(LoginRequiredMixin, StaffRequiredMixin, C
     success_url = reverse_lazy("parser_rule_list")
 
     def get_context_data(self, **kwargs):
-        ctx = super().get_context_data(**kwargs)
-        ctx["rule_choices"] = FormatBParserRule.FIELD_CHOICES
-        return ctx
+        return super().get_context_data(**kwargs)
 
 
 class AntwortErkennungsRegelUpdateView(LoginRequiredMixin, StaffRequiredMixin, UpdateView):
@@ -2367,9 +2362,7 @@ class AntwortErkennungsRegelUpdateView(LoginRequiredMixin, StaffRequiredMixin, U
     success_url = reverse_lazy("parser_rule_list")
 
     def get_context_data(self, **kwargs):
-        ctx = super().get_context_data(**kwargs)
-        ctx["rule_choices"] = FormatBParserRule.FIELD_CHOICES
-        return ctx
+        return super().get_context_data(**kwargs)
 
 
 class AntwortErkennungsRegelDeleteView(LoginRequiredMixin, StaffRequiredMixin, DeleteView):

--- a/templates/parser_rules/rule_form.html
+++ b/templates/parser_rules/rule_form.html
@@ -18,18 +18,8 @@
         {{ form.regel_anwendungsbereich }}{{ form.regel_anwendungsbereich.errors }}
     </div>
     <div>
-        {{ form.ziel_feld.label_tag }}<br>
-        {{ form.ziel_feld }}{{ form.ziel_feld.errors }}
-    </div>
-    <div>
-        {{ form.wert.label_tag }}<br>
-        {{ form.wert }}{{ form.wert.errors }}
-    </div>
-    <div>
-        <label>Aktionen</label>
-        <div id="actions-container"></div>
+        {{ form.actions_json.label_tag }}<br>
         {{ form.actions_json }}{{ form.actions_json.errors }}
-        <button type="button" id="add-action" class="btn btn-sm btn-secondary mt-1">+ Aktion</button>
     </div>
     <div>
         {{ form.prioritaet.label_tag }}<br>
@@ -37,29 +27,5 @@
     </div>
     <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
 </form>
-<script>
-const ruleChoices = {{ rule_choices|safe }};
-function createRow(field='', val=false){
-  const row=document.createElement('div');
-  row.className='flex items-center mb-2 action-row';
-  const sel=document.createElement('select');
-  sel.className='border rounded p-1 mr-2 flex-grow';
-  ruleChoices.forEach(([v,l])=>{const o=document.createElement('option');o.value=v;o.textContent=l;if(v===field) o.selected=true;sel.appendChild(o);});
-  const cb=document.createElement('input');cb.type='checkbox';cb.className='mr-2';cb.checked=val;
-  const del=document.createElement('button');del.type='button';del.textContent='x';del.className='ml-2';del.addEventListener('click',()=>{row.remove();update();});
-  sel.addEventListener('change',update);cb.addEventListener('change',update);
-  row.appendChild(sel);row.appendChild(cb);row.appendChild(del);document.getElementById('actions-container').appendChild(row);
-}
-function update(){
-  const data={};document.querySelectorAll('.action-row').forEach(r=>{const f=r.querySelector('select').value;const v=r.querySelector('input').checked;if(f) data[f]=v;});
-  document.getElementById('id_actions_json').value=JSON.stringify(data);
-}
-function init(){
-  const hidden=document.getElementById('id_actions_json');hidden.type='hidden';
-  try{const data=JSON.parse(hidden.value||'{}');Object.entries(data).forEach(([k,v])=>createRow(k,v));}catch(e){createRow();}
-  update();
-}
-document.getElementById('add-action').addEventListener('click',()=>{createRow();update();});
-document.addEventListener('DOMContentLoaded',init);
-</script>
+
 {% endblock %}

--- a/templates/partials/_response_rule_row.html
+++ b/templates/partials/_response_rule_row.html
@@ -4,9 +4,7 @@
     <td class="py-1 drag-handle cursor-move"><i class="fa fa-bars"></i></td>
     <td class="py-1">{{ form.regel_name }}</td>
     <td class="py-1">{{ form.erkennungs_phrase }}</td>
-    <td class="py-1">{{ form.ziel_feld }}</td>
     <td class="py-1">{{ form.regel_anwendungsbereich }}</td>
-    <td class="py-1 text-center">{{ form.wert }}</td>
     <td class="py-1">{{ form.actions_json }}</td>
     <td class="py-1 text-center">
         {% if form.instance.pk %}

--- a/templates/partials/_response_rule_row_simple.html
+++ b/templates/partials/_response_rule_row_simple.html
@@ -11,16 +11,8 @@
         {{ form.erkennungs_phrase.errors }}
     </td>
     <td class="py-1">
-        {{ form.ziel_feld }}
-        {{ form.ziel_feld.errors }}
-    </td>
-    <td class="py-1">
         {{ form.regel_anwendungsbereich }}
         {{ form.regel_anwendungsbereich.errors }}
-    </td>
-    <td class="py-1 text-center">
-        {{ form.wert }}
-        {{ form.wert.errors }}
     </td>
     <td class="py-1">
         {{ form.actions_json }}

--- a/templates/partials/_response_rules_table.html
+++ b/templates/partials/_response_rules_table.html
@@ -5,9 +5,7 @@
             <th></th>
             <th class="py-2">Name</th>
             <th class="py-2">Phrase</th>
-            <th class="py-2">Ziel-Feld</th>
             <th class="py-2">Anwendungsbereich</th>
-            <th class="py-2">Wert</th>
             <th class="py-2">Aktionen</th>
             <th class="py-2 text-center">Entfernen</th>
         </tr>
@@ -16,7 +14,7 @@
         {% for form in formset %}
             {% include 'partials/_response_rule_row.html' with form=form %}
         {% empty %}
-        <tr><td colspan="8">Keine Regeln</td></tr>
+        <tr><td colspan="6">Keine Regeln</td></tr>
         {% endfor %}
     </tbody>
 </table>

--- a/templates/partials/_response_rules_table_simple.html
+++ b/templates/partials/_response_rules_table_simple.html
@@ -5,9 +5,7 @@
         <tr class="border-b text-left">
             <th class="py-2">Name</th>
             <th class="py-2">Phrase</th>
-            <th class="py-2">Ziel-Feld</th>
             <th class="py-2">Anwendungsbereich</th>
-            <th class="py-2">Wert</th>
             <th class="py-2">Aktionen</th>
             <th class="py-2 text-center">Entfernen</th>
         </tr>
@@ -16,7 +14,7 @@
         {% for form in formset %}
             {% include 'partials/_response_rule_row_simple.html' with form=form %}
         {% empty %}
-        <tr><td colspan="7">Keine Regeln</td></tr>
+        <tr><td colspan="6">Keine Regeln</td></tr>
         {% endfor %}
     </tbody>
 </table>

--- a/templates/widgets/actions_json_widget.html
+++ b/templates/widgets/actions_json_widget.html
@@ -1,0 +1,35 @@
+<div id="{{ widget.attrs.id }}_container"></div>
+<input type="hidden" name="{{ widget.name }}" id="{{ widget.attrs.id }}" value="{{ widget.value }}">
+<button type="button" class="btn btn-sm btn-secondary mt-1" id="{{ widget.attrs.id }}_add">+ Aktion</button>
+<script>
+(function(){
+  const container=document.getElementById('{{ widget.attrs.id }}_container');
+  const hidden=document.getElementById('{{ widget.attrs.id }}');
+  const addBtn=document.getElementById('{{ widget.attrs.id }}_add');
+  const choices={{ choices|safe }};
+  function update(){
+    const data={};
+    container.querySelectorAll('.action-row').forEach(r=>{
+      const f=r.querySelector('select').value;
+      const v=r.querySelector('input[type="checkbox"]').checked;
+      if(f){data[f]=v;}
+    });
+    hidden.value=JSON.stringify(data);
+  }
+  function addRow(field='', val=false){
+    const row=document.createElement('div');
+    row.className='flex items-center mb-2 action-row';
+    const sel=document.createElement('select');
+    sel.className='border rounded p-1 mr-2 flex-grow';
+    choices.forEach(([v,l])=>{const o=document.createElement('option');o.value=v;o.textContent=l;if(v===field)o.selected=true;sel.appendChild(o);});
+    const cb=document.createElement('input');cb.type='checkbox';cb.className='mr-2';cb.checked=val;
+    const del=document.createElement('button');del.type='button';del.textContent='x';del.className='ml-2';del.addEventListener('click',()=>{row.remove();update();});
+    sel.addEventListener('change',update);cb.addEventListener('change',update);
+    row.appendChild(sel);row.appendChild(cb);row.appendChild(del);
+    container.appendChild(row);
+  }
+  addBtn.addEventListener('click',()=>{addRow();update();});
+  try{const data=JSON.parse(hidden.value||'{}');Object.entries(data).forEach(([k,v])=>addRow(k,v));}catch(e){addRow();}
+  update();
+})();
+</script>


### PR DESCRIPTION
## Summary
- remove redundant fields from `AntwortErkennungsRegel`
- migrate existing rules to JSON actions
- add custom widget for editing actions
- adjust admin forms and templates
- update parsers and tests

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687de227e774832ba3252fbd807f2f99