### PR TITLE
Fix JSON serialisation for actions widget

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -40,7 +40,7 @@ class ActionsJSONWidget(forms.Widget):
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         context["widget"]["value"] = json.dumps(value or {})
-        context["choices"] = self.choices
+        context["choices"] = json.dumps(self.choices)
         return context
 from django.contrib.auth.models import Group
 from .parser_manager import parser_manager


### PR DESCRIPTION
## Summary
- serialise dropdown options for ActionsJSONWidget

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_687e0880e238832b9aacd1db46388d5d