### PR TITLE
Fix JSON actions widget duplication

### DIFF
--- a/core/templates/widgets/actions_json_widget.html
+++ b/core/templates/widgets/actions_json_widget.html
@@ -29,7 +29,13 @@
     container.appendChild(row);
   }
   addBtn.addEventListener('click',()=>{addRow();update();});
-  try{const data=JSON.parse(hidden.value||'{}');Object.entries(data).forEach(([k,v])=>addRow(k,v));}catch(e){addRow();}
+  container.innerHTML='';
+  try{
+    const data=JSON.parse(hidden.value||'{}');
+    Object.entries(data).forEach(([k,v])=>addRow(k,v));
+  }catch(e){
+    addRow();
+  }
   update();
 })();
 </script>


### PR DESCRIPTION
## Summary
- prevent multiple row additions when re-rendering ActionsJSONWidget

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687e1275b6c8832ba01771968ba1bfdb