### PR TITLE
Fix race condition by removing auto parser call

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2183,7 +2183,7 @@ class Anlage2ReviewTests(NoesisTestCase):
         )
         self.assertContains(resp, link)
 
-    def test_auto_analysis_runs_once_for_new_file(self):
+    def test_no_auto_analysis_on_get(self):
         pf = BVProjectFile.objects.create(
             projekt=self.projekt,
             anlage_nr=2,
@@ -2200,7 +2200,7 @@ class Anlage2ReviewTests(NoesisTestCase):
         with patch("core.views.run_anlage2_analysis", side_effect=_fake) as mock_func:
             self.client.get(url)
             self.client.get(url)
-        self.assertEqual(mock_func.call_count, 1)
+        self.assertEqual(mock_func.call_count, 0)
 
 
 class WorkerGenerateGutachtenTests(NoesisTestCase):

--- a/core/views.py
+++ b/core/views.py
@@ -2844,12 +2844,6 @@ def projekt_file_edit_json(request, pk):
         anlage = BVProjectFile.objects.get(pk=pk)
     except BVProjectFile.DoesNotExist:
         raise Http404
-    if (
-        request.method == "GET" and anlage.anlage_nr == 2 and not anlage.analysis_json
-    ):
-        run_anlage2_analysis(anlage)
-        anlage.refresh_from_db()
-
     if request.method == "GET" and anlage.anlage_nr == 2:
         results = (
             Anlage2FunctionResult.objects.filter(projekt=anlage.projekt)


### PR DESCRIPTION
## Summary
- remove `run_anlage2_analysis` call from `projekt_file_edit_json`
- update related test to expect no automatic analysis

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ReviewTests.test_no_auto_analysis_on_get -v 2`


------
https://chatgpt.com/codex/tasks/task_e_687e1d79cef4832b936b8f22eaca0582