### PR TITLE
Display-only view for usage decisions

### DIFF
--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -1,4 +1,19 @@
 {% load recording_extras %}
+{% if field_name == 'einsatz_bei_telefonica' or field_name == 'zur_lv_kontrolle' %}
+<td class="border px-2 text-center">
+    {% if row.result_id %}
+        {% with val=row.doc_result|get_item:field_name %}
+            {% if val %}
+                Vorhanden
+            {% else %}
+                Nicht vorhanden
+            {% endif %}
+        {% endwith %}
+    {% else %}
+        <span>-</span>
+    {% endif %}
+</td>
+{% else %}
 <td class="border px-2 text-center">
     {% if row.result_id %}
     <button class="tri-state-icon{% if field_name == 'technisch_vorhanden' and row.sub %} disabled-field{% endif %}"
@@ -27,3 +42,4 @@
     <span>-</span>
     {% endif %}
 </td>
+{% endif %}


### PR DESCRIPTION
## Summary
- simplify `einsatz_bei_telefonica` and `zur_lv_kontrolle` cells in the review table
- remove interaction and show only whether the document contains these settings

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687e3f2bca14832b9e41c32ac76a627c