### PR TITLE
Fix missing prompt and unicode logging error

### DIFF
--- a/core/migrations/0034_add_subquestion_possibility_prompt.py
+++ b/core/migrations/0034_add_subquestion_possibility_prompt.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+
+def add_prompt(apps, schema_editor):
+    Prompt = apps.get_model("core", "Prompt")
+    Prompt.objects.update_or_create(
+        name="anlage2_subquestion_possibility_check",
+        defaults={
+            "text": (
+                "Im Kontext der Funktion '{function_name}' der Software '{software_name}': "
+                "Ist die spezifische Anforderung '{subquestion_text}' technisch möglich? "
+                "Antworte nur mit 'Ja', 'Nein' oder 'Unsicher'."
+            ),
+        },
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0033_migrate_actions_json"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_prompt, reverse_code=migrations.RunPython.noop),
+    ]

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -189,6 +189,7 @@ LOGGING = {
             "level": "INFO",  # Zeigt nur Informationen und Fehler in der Konsole an
             "class": "logging.StreamHandler",
             "formatter": "simple",
+            "encoding": "utf-8",
         },
         "file": {
             "level": "DEBUG",


### PR DESCRIPTION
## Summary
- create migration to seed `anlage2_subquestion_possibility_check` prompt
- log console output using UTF-8 to avoid unicode errors

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687e4e30d17c832bb9ce5c60eb0ad87c