### PR TITLE
Fix console logging encoding for Python 3.11

### DIFF
--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -189,7 +189,6 @@ LOGGING = {
             "level": "INFO",  # Zeigt nur Informationen und Fehler in der Konsole an
             "class": "logging.StreamHandler",
             "formatter": "simple",
-            "encoding": "utf-8",
         },
         "file": {
             "level": "DEBUG",
@@ -335,6 +334,9 @@ LOGGING = {
         },
     },
 }
+
+if sys.version_info >= (3, 12):
+    LOGGING["handlers"]["console"]["encoding"] = "utf-8"
 
 # Django-Q Konfiguration
 Q_CLUSTER = {


### PR DESCRIPTION
## Summary
- remove `encoding` from `console` handler
- add conditional assignment for Python >= 3.12

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687e683ced3c832b9cad9d68226b6757