### PR TITLE
Fix boolean storage for parser rule actions

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1051,7 +1051,14 @@ class AntwortErkennungsRegelForm(forms.ModelForm):
         }
 
     def save(self, commit: bool = True) -> AntwortErkennungsRegel:
-        self.instance.actions_json = self.cleaned_data.get("actions_json", {})
+        actions = self.cleaned_data.get("actions_json", {}) or {}
+        if isinstance(actions, dict):
+            for key, val in list(actions.items()):
+                if val == "on":
+                    actions[key] = True
+                elif val in ("", None):
+                    actions[key] = False
+        self.instance.actions_json = actions
         return super().save(commit=commit)
 
 


### PR DESCRIPTION
## Summary
- ensure checkbox values in parser rule form are stored as booleans

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687e7a4484e8832bb11d5764d76c4206