### PR TITLE
Fix multiple actions in parser rules

### DIFF
--- a/core/migrations/0035_actions_json_list.py
+++ b/core/migrations/0035_actions_json_list.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    Rule = apps.get_model('core', 'AntwortErkennungsRegel')
+    for rule in Rule.objects.all():
+        data = rule.actions_json
+        if isinstance(data, dict):
+            rule.actions_json = [{"field": k, "value": v} for k, v in data.items()]
+            rule.save(update_fields=['actions_json'])
+
+
+def backwards(apps, schema_editor):
+    Rule = apps.get_model('core', 'AntwortErkennungsRegel')
+    for rule in Rule.objects.all():
+        data = rule.actions_json
+        if isinstance(data, list):
+            out = {}
+            for obj in data:
+                field = obj.get('field')
+                if not field:
+                    continue
+                out[field] = obj.get('value')
+            rule.actions_json = out
+            rule.save(update_fields=['actions_json'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0034_add_subquestion_possibility_prompt'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='antworterkennungsregel',
+            name='actions_json',
+            field=models.JSONField(default=list, blank=True, help_text='Aktionen als Liste von Objekten.'),
+        ),
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -714,9 +714,9 @@ class AntwortErkennungsRegel(models.Model):
     regel_name = models.CharField(max_length=100)
     erkennungs_phrase = models.CharField(max_length=200)
     actions_json = models.JSONField(
-        default=dict,
+        default=list,
         blank=True,
-        help_text="Feld-Wert-Paare für den exakten Parser.",
+        help_text="Aktionen als Liste von Objekten.",
     )
     REGEL_ANWENDUNGSBEREICH_CHOICES = [
         ("Hauptfunktion", "Hauptfunktion"),

--- a/core/parsers.py
+++ b/core/parsers.py
@@ -47,9 +47,16 @@ class ExactParser(AbstractParser):
         text = (project_file.text_content or "").lower()
         for rule in AntwortErkennungsRegel.objects.all().order_by("prioritaet"):
             if rule.erkennungs_phrase.lower() in text:
-                actions = rule.actions_json or {}
+                actions = rule.actions_json or []
+                if isinstance(actions, dict):
+                    actions = [
+                        {"field": k, "value": v} for k, v in actions.items()
+                    ]
                 for entry in results:
-                    for field, val in actions.items():
-                        entry[field] = {"value": bool(val), "note": None}
+                    for act in actions:
+                        field = act.get("field")
+                        if not field:
+                            continue
+                        entry[field] = {"value": bool(act.get("value")), "note": None}
         return results
 

--- a/core/templates/widgets/actions_json_widget.html
+++ b/core/templates/widgets/actions_json_widget.html
@@ -8,11 +8,11 @@
   const addBtn=document.getElementById('{{ widget.attrs.id }}_add');
   const choices={{ choices|safe }};
   function update(){
-    const data={};
+    const data=[];
     container.querySelectorAll('.action-row').forEach(r=>{
       const f=r.querySelector('select').value;
       const v=r.querySelector('input[type="checkbox"]').checked;
-      if(f){data[f]=v;}
+      if(f){data.push({field:f,value:v});}
     });
     hidden.value=JSON.stringify(data);
   }
@@ -31,8 +31,12 @@
   addBtn.addEventListener('click',()=>{addRow();update();});
   container.innerHTML='';
   try{
-    const data=JSON.parse(hidden.value||'{}');
-    Object.entries(data).forEach(([k,v])=>addRow(k,v));
+    const data=JSON.parse(hidden.value||'[]');
+    if(Array.isArray(data)){
+      data.forEach(obj=>addRow(obj.field||'',obj.value||false));
+    }else{
+      Object.entries(data).forEach(([k,v])=>addRow(k,v));
+    }
   }catch(e){
     addRow();
   }

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -3154,7 +3154,7 @@ class Anlage2ConfigImportExportTests(NoesisTestCase):
         AntwortErkennungsRegel.objects.create(
             regel_name="R1",
             erkennungs_phrase="ja",
-            actions_json={"technisch_verfuegbar": True},
+            actions_json=[{"field": "technisch_verfuegbar", "value": True}],
             prioritaet=0,
         )
         a4 = Anlage4ParserConfig.objects.create(delimiter_phrase="X")
@@ -3188,7 +3188,7 @@ class Anlage2ConfigImportExportTests(NoesisTestCase):
                     {
                         "regel_name": "R2",
                         "erkennungs_phrase": "nein",
-                        "actions": {"technisch_verfuegbar": False},
+                        "actions": [{"field": "technisch_verfuegbar", "value": False}],
                         "prioritaet": 1
                     }
                 ],

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -574,7 +574,7 @@ class DocxExtractTests(NoesisTestCase):
         AntwortErkennungsRegel.objects.create(
             regel_name="aktiv",
             erkennungs_phrase="aktivv",
-            actions_json={"einsatz_telefonica": True},
+            actions_json=[{"field": "einsatz_telefonica", "value": True}],
         )
         data = parse_anlage2_text("Lgin: aktivv")
         self.assertEqual(
@@ -592,13 +592,13 @@ class DocxExtractTests(NoesisTestCase):
         AntwortErkennungsRegel.objects.create(
             regel_name="a",
             erkennungs_phrase="foo",
-            actions_json={"technisch_verfuegbar": True},
+            actions_json=[{"field": "technisch_verfuegbar", "value": True}],
             prioritaet=2,
         )
         AntwortErkennungsRegel.objects.create(
             regel_name="b",
             erkennungs_phrase="bar",
-            actions_json={"einsatz_telefonica": False},
+            actions_json=[{"field": "einsatz_telefonica", "value": False}],
             prioritaet=1,
         )
         data = parse_anlage2_text("Login: foo bar rest")

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -199,8 +199,16 @@ def apply_rules(
     found_rules: Dict[str, tuple[bool, int, str]] = {}
     for rule in rules:
         if fuzzy_match(rule.erkennungs_phrase, text_part, threshold):
-            actions = rule.actions_json or {}
-            for field, val in actions.items():
+            actions = rule.actions_json or []
+            if isinstance(actions, dict):
+                actions = [
+                    {"field": k, "value": v} for k, v in actions.items()
+                ]
+            for act in actions:
+                field = act.get("field")
+                if not field:
+                    continue
+                val = act.get("value")
                 current = found_rules.get(field)
                 if current is None or rule.prioritaet < current[1]:
                     found_rules[field] = (

--- a/core/views.py
+++ b/core/views.py
@@ -1917,7 +1917,7 @@ def admin_anlage2_config_import(request):
                         "regel_anwendungsbereich",
                         "Hauptfunktion",
                     ),
-                    "actions_json": r.get("actions", {}),
+                    "actions_json": r.get("actions", []),
                     "prioritaet": r.get("prioritaet", 0),
                 },
             )


### PR DESCRIPTION
## Summary
- store parser rule actions as list of field/value objects
- handle both dict and list formats in widget and form
- adjust parsers and text parser for new data structure
- migrate existing rules to list format
- update tests for new structure

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_parsing --keepdb -v 2` *(fails: ModuleNotFoundError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_687e86c9fb04832b8debe463f1eb0495