### PR TITLE
Fix Parser rules saving and add debug logging

### DIFF
--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -258,6 +258,13 @@ LOGGING = {
             "formatter": "verbose",
             "encoding": "utf-8",
         },
+        "parse_exact_anlage2_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "parse_exact_anlage2.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+        },
         "workflow_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
@@ -324,6 +331,11 @@ LOGGING = {
         },
         "anlage2_admin_debug": {
             "handlers": ["anlage2_admin_file"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
+        "parse_exact_anlage2_log": {
+            "handlers": ["parse_exact_anlage2_file"],
             "level": "DEBUG",
             "propagate": False,
         },

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -94,7 +94,7 @@
     <div id="tab-rules2" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Parser-Antwortregeln (Fallback)</h2>
         <div class="overflow-x-auto">
-            {% include 'partials/_response_rules_table_simple.html' with formset=rule_formset_fb %}
+            {% include 'partials/_response_rules_table_simple.html' with formset=rule_formset_fb raw_actions=raw_actions %}
         </div>
         <button type="submit" name="action" value="save_rules_fb" class="mt-2 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
     </div>

--- a/templates/partials/_response_rule_row_simple.html
+++ b/templates/partials/_response_rule_row_simple.html
@@ -18,5 +18,8 @@
         {{ form.actions_json }}
         {{ form.actions_json.errors }}
     </td>
+    <td class="py-1 font-mono text-xs whitespace-pre">
+        {{ raw_actions|raw_item:form.instance.pk|tojson }}
+    </td>
     <td class="py-1 text-center">{{ form.DELETE }}</td>
 </tr>

--- a/templates/partials/_response_rules_table_simple.html
+++ b/templates/partials/_response_rules_table_simple.html
@@ -7,14 +7,15 @@
             <th class="py-2">Phrase</th>
             <th class="py-2">Anwendungsbereich</th>
             <th class="py-2">Aktionen</th>
+            <th class="py-2">DB JSON</th>
             <th class="py-2 text-center">Entfernen</th>
         </tr>
     </thead>
     <tbody>
         {% for form in formset %}
-            {% include 'partials/_response_rule_row_simple.html' with form=form %}
+            {% include 'partials/_response_rule_row_simple.html' with form=form raw_actions=raw_actions %}
         {% empty %}
-        <tr><td colspan="6">Keine Regeln</td></tr>
+        <tr><td colspan="7">Keine Regeln</td></tr>
         {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- simplify saving of `AntwortErkennungsRegelForm`
- add logger `parse_exact_anlage2_log`
- log actions_json during form init and save
- log raw rule data when loading formsets
- expose raw JSON value in Anlage2 admin table

## Testing
- `python manage.py makemigrations --check`
- `pytest -q` *(fails: ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_687e9f3dabdc832b82f037b42be9df5d