### PR TITLE
Fix missing template filter

### DIFF
--- a/templates/partials/_response_rules_table_simple.html
+++ b/templates/partials/_response_rules_table_simple.html
@@ -1,3 +1,4 @@
+{% load recording_extras %}
 {{ formset.management_form }}
 {{ formset.non_form_errors }}
 <table class="min-w-full mb-4">


### PR DESCRIPTION
## Summary
- load `recording_extras` in response rules partial

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError or long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_687f24932c70832b9dc7bc8f0fe0bb6a