### PR TITLE
Add project negotiation flag property

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -161,6 +161,11 @@ class BVProject(models.Model):
         """Gibt alle Dateien der Anlage 3 zurück."""
         return self.anlagen.filter(anlage_nr=3)
 
+    @property
+    def is_verhandlungsfaehig(self) -> bool:
+        """Gibt zurück, ob alle Anlagen verhandlungsfähig sind."""
+        return all(f.verhandlungsfaehig for f in self.anlagen.all())
+
 
 class BVSoftware(models.Model):
     """Software-Eintrag innerhalb eines Projekts."""

--- a/core/views.py
+++ b/core/views.py
@@ -2541,6 +2541,7 @@ def projekt_detail(request, pk):
         "history": projekt.status_history.all(),
         "num_attachments": all_files.count(),
         "num_reviewed": reviewed,
+        "is_verhandlungsfaehig": projekt.is_verhandlungsfaehig,
         "is_admin": is_admin,
         "anlage3_page": anlage3_page,
         "other_anlagen": other_anlagen,

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -252,6 +252,7 @@
     <p class="mt-1"><strong>Anlagen:</strong> {{ num_attachments }}</p>
     <p class="mt-1"><strong>Gutachten vorhanden:</strong> {% if projekt.gutachten_file %}Ja{% else %}Nein{% endif %}</p>
     <p class="mt-1"><strong>Geprüft:</strong> {{ num_reviewed }} / {{ num_attachments }}</p>
+    <p class="mt-1"><strong>Verhandlungsfähig:</strong> {% if is_verhandlungsfaehig %}Ja{% else %}Nein{% endif %}</p>
     <p class="mt-1"><strong>Initial-Prüfung:</strong> <span id="knowledge-progress">{{ knowledge_checked }} / {{ total_software }}</span> Komponenten analysiert</p>
     <h4 class="font-semibold mt-2">Status-Historie</h4>
     <ul class="list-disc pl-5">


### PR DESCRIPTION
## Summary
- add `is_verhandlungsfaehig` property on `BVProject`
- expose project negotiation status in `projekt_detail` view and template

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687f32328bf8832ba5d0f8c18b71d5fa