### PR TITLE
Add export/import for parser rules

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -921,6 +921,15 @@ class ProjectImportForm(forms.Form):
     )
 
 
+class Anlage2ParserRuleImportForm(forms.Form):
+    """Formular für den Import der Parser-Regeln."""
+
+    json_file = forms.FileField(
+        label="JSON-Datei",
+        widget=forms.ClearableFileInput(attrs={"class": "border rounded p-2"}),
+    )
+
+
 class Anlage4ConfigForm(forms.ModelForm):
     """Formular für die Anlage-4-Konfiguration."""
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -169,6 +169,16 @@ urlpatterns = [
         name="parser_rule_delete",
     ),
     path(
+        "projects-admin/parser-rules/export/",
+        views.anlage2_parser_rule_export,
+        name="anlage2_parser_rule_export",
+    ),
+    path(
+        "projects-admin/parser-rules/import/",
+        views.anlage2_parser_rule_import,
+        name="anlage2_parser_rule_import",
+    ),
+    path(
         "projects-admin/anlage2/",
         views.anlage2_function_list,
         name="anlage2_function_list",

--- a/templates/admin_anlage2_parser_rule_import.html
+++ b/templates/admin_anlage2_parser_rule_import.html
@@ -1,0 +1,15 @@
+{% extends 'admin_base.html' %}
+{% block title %}Parser-Regeln importieren{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Parser-Regeln importieren</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.json_file.label_tag }}<br>
+        {{ form.json_file }}
+        {{ form.json_file.errors }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+</form>
+{% endblock %}

--- a/templates/parser_rules/rule_list.html
+++ b/templates/parser_rules/rule_list.html
@@ -4,6 +4,8 @@
 <h1 class="text-2xl font-semibold mb-4">Regeln für Exakten Parser</h1>
 <div class="mb-4 space-x-2">
     <a href="{% url 'parser_rule_add' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Neue Regel</a>
+    <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
+    <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
 </div>
 <table class="min-w-full">
     <thead>


### PR DESCRIPTION
## Summary
- add `Anlage2ParserRuleImportForm`
- implement export/import views for parser rules
- route new views in urls
- provide admin template for importing parser rules
- link export/import in parser rule list
- test exporting and importing parser rules

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687f49332b30832b823d3e654bbe3c1d