### PR TITLE
Add import/export buttons to parser rules

### DIFF
--- a/templates/parser_rules/rule_list.html
+++ b/templates/parser_rules/rule_list.html
@@ -5,6 +5,10 @@
 <div class="mb-4 space-x-2">
     <a href="{% url 'parser_rule_add' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Neue Regel</a>
 </div>
+<div class="mb-4 space-x-2">
+    <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
+    <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
+</div>
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">


### PR DESCRIPTION
## Summary
- add links for Anlage 2 parser rule import and export

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687f49341eac832b9e90906f4ce8cbc2