### PR TITLE
Fix project lookup when reading results

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -439,7 +439,10 @@ def _build_row_data(
 
     if result_obj:
         pf = (
-            result_obj.projekt.anlagen.filter(anlage_nr=2).order_by("id").first()
+            result_obj.anlage_datei.projekt.anlagen
+            .filter(anlage_nr=2)
+            .order_by("id")
+            .first()
         )
         parser_entry = (
             FunktionsErgebnis.objects.filter(


### PR DESCRIPTION
## Summary
- use `result_obj.anlage_datei.projekt` instead of the direct `result_obj.projekt` when preparing Anlage 2 display data

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_687f53eb3f90832b833c1f132098de09