### PR TITLE
Fix missing template filter

### DIFF
--- a/templates/partials/_response_rule_row_simple.html
+++ b/templates/partials/_response_rule_row_simple.html
@@ -1,3 +1,4 @@
+{% load recording_extras %}
 <tr class="border-b text-sm">
     {{ form.id }}
     {{ form.ORDER }}


### PR DESCRIPTION
## Summary
- load `recording_extras` in partial template

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687f5dd498e8832b8cc9c29b72d4eaaf