### PR TITLE
Fix ajax review and permission issues

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -25,6 +25,7 @@ from ..models import (
     Anlage2SubQuestion,
 
     AnlagenFunktionsMetadaten,
+    FunktionsErgebnis,
 
     SoftwareKnowledge,
     BVSoftware,
@@ -475,7 +476,7 @@ class BVProjectFileTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"x"),
             verification_task_id="tid",
         )
-        self.client.login(username=self.user.username, password="pass")
+        self.client.login(username=self.superuser.username, password="pass")
         with patch("core.models.fetch") as mock_fetch:
             mock_fetch.return_value = SimpleNamespace(success=None)
             url = reverse("projekt_detail", args=[projekt.pk])
@@ -490,7 +491,7 @@ class BVProjectFileTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"x"),
             verification_task_id="tid",
         )
-        self.client.login(username=self.user.username, password="pass")
+        self.client.login(username=self.superuser.username, password="pass")
         with patch("core.models.fetch") as mock_fetch:
             mock_fetch.return_value = SimpleNamespace(success=None)
             url = reverse("hx_project_file_status", args=[pf.pk])
@@ -3400,7 +3401,9 @@ class Anlage2ConfigViewTests(NoesisTestCase):
 class ParserRuleImportExportTests(NoesisTestCase):
     def setUp(self):
         admin_group = Group.objects.create(name="admin")
-        self.user = User.objects.create_user("ruleadmin", password="pass")
+        self.user = User.objects.create_user(
+            "ruleadmin", password="pass", is_staff=True
+        )
         self.user.groups.add(admin_group)
         self.client.login(username="ruleadmin", password="pass")
 

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -37,9 +37,9 @@
                 {% with open_anl=request.resolver_match.url_name %}
                 <h3 class="accordion-header text-gray-600 uppercase tracking-wider text-sm">
                     <span>Anlagen-Konfiguration</span>
-                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_anl in 'admin_anlage1 anlage2_function_list anlage2_config core_zweckkategoriea_changelist' %}rotate-180{% endif %}"></i>
+                    <i class="fas fa-chevron-down accordion-icon ml-2 {% if open_anl in 'admin_anlage1 anlage2_function_list anlage2_config zweckkategoriea_list' %}rotate-180{% endif %}"></i>
                 </h3>
-                <div class="accordion-content pl-2 space-y-1 {% if open_anl in 'admin_anlage1 anlage2_function_list anlage2_config core_zweckkategoriea_changelist' %}block{% else %}hidden{% endif %}">
+                <div class="accordion-content pl-2 space-y-1 {% if open_anl in 'admin_anlage1 anlage2_function_list anlage2_config zweckkategoriea_list' %}block{% else %}hidden{% endif %}">
                     <a href="{% url 'admin_anlage1' %}" class="nav-link {% if request.resolver_match.url_name == 'admin_anlage1' %}active-nav-link{% endif %}">
                         <i class="fas fa-question-circle fa-fw mr-2"></i>
                         Anlage 1 Fragen
@@ -52,7 +52,7 @@
                         <i class="fas fa-globe fa-fw mr-2"></i>
                         Anlage 2 Globale Phrasen
                     </a>
-                    <a href="{% url 'admin:core_zweckkategoriea_changelist' %}" class="nav-link {% if request.resolver_match.url_name == 'core_zweckkategoriea_changelist' %}active-nav-link{% endif %}">
+                    <a href="{% url 'zweckkategoriea_list' %}" class="nav-link {% if request.resolver_match.url_name == 'zweckkategoriea_list' %}active-nav-link{% endif %}">
                         <i class="fas fa-list fa-fw mr-2"></i>
                         Anlage 5 Konfiguration
                     </a>


### PR DESCRIPTION
## Summary
- ensure Anlage2 review APIs use anlage_datei for queries
- allow editing KI-Begründung and store values
- update dashboard link to custom view
- adjust tests for staff permissions

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.EditKIJustificationTests.test_post_updates_value -v 2`
- `python manage.py test core.tests.test_general.ParserRuleImportExportTests.test_import_creates_rule core.tests.test_general.BVProjectFileTests.test_hx_project_file_status_running -v 2`


------
https://chatgpt.com/codex/tasks/task_e_687f65ab807c832b85edf38510200e10