### PR TITLE
Fix admin UI forms and analysis initialization

### DIFF
--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load recording_extras %}
 {% block title %}Anlage 2 Konfiguration{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Konfiguration</h1>

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -26,4 +26,5 @@
     {% else %}
     <span>-</span>
     {% endif %}
+    {{ widget }}
 </td>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -116,7 +116,7 @@
                 </td>
                 {% for field in fields %}
                 {% with f=row.form_fields|get_item:field %}
-                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field %}
+                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
                 {% endwith %}
                 {% endfor %}
                 {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}


### PR DESCRIPTION
## Summary
- register template filters in admin config
- render hidden form inputs in Anlage2 review table
- initialize Anlage2 forms from analysis JSON when no DB results exist

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ReviewTests.test_get_shows_table -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687f65a1d550832bb9a8d671e912bd97