### PR TITLE
Fix manual review metadata handling

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1061,11 +1061,6 @@ def check_anlage2(projekt_id: int, model_name: str | None = None) -> dict:
 
             projekt=projekt,
             funktion=func,
-            defaults={
-                "technisch_verfuegbar": _val(vals, "technisch_verfuegbar"),
-                "ki_beteiligung": _val(vals, "ki_beteiligung"),
-                "source": source,
-            },
         )
         FunktionsErgebnis.objects.create(
             projekt=projekt,
@@ -1380,11 +1375,6 @@ def check_anlage2_functions(
 
             projekt=projekt,
             funktion=func,
-            defaults={
-                "technisch_verfuegbar": vals.get("technisch_verfuegbar"),
-                "ki_beteiligung": vals.get("ki_beteiligung"),
-                "source": "llm",
-            },
         )
         FunktionsErgebnis.objects.create(
             projekt=projekt,


### PR DESCRIPTION
## Summary
- stop recording manual review booleans on `AnlagenFunktionsMetadaten`
- keep manual review data only in `FunktionsErgebnis`
- compute negotiable state from latest function results
- clean up verification deletion logic

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f6e4e69a0832b80ff9ce44cf34ff6