### PR TITLE
fix: set anlage_datei for FunktionsErgebnis

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1064,6 +1064,7 @@ def check_anlage2(projekt_id: int, model_name: str | None = None) -> dict:
         )
         FunktionsErgebnis.objects.create(
             projekt=projekt,
+            anlage_datei=anlage,
             funktion=func,
             quelle=source,
             technisch_verfuegbar=_val(vals, "technisch_verfuegbar"),
@@ -1382,6 +1383,7 @@ def check_anlage2_functions(
         )
         FunktionsErgebnis.objects.create(
             projekt=projekt,
+            anlage_datei=anlage,
             funktion=func,
             quelle="llm",
             technisch_verfuegbar=vals.get("technisch_verfuegbar"),


### PR DESCRIPTION
## Summary
- pass `anlage_datei` to `FunktionsErgebnis.objects.create` in `check_anlage2`
- do the same for `check_anlage2_functions`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: errors=16, failures=9)*

------
https://chatgpt.com/codex/tasks/task_e_687f805079b4832b9719ba997a3e400b