### PR TITLE
Fix stale metadata deletion for Anlage 2 parsing

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -335,8 +335,11 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
         project_file.projekt_id,
     )
 
-    # Alte Ergebnisse entfernen, um sie an die aktuelle Datei zu binden
-    AnlagenFunktionsMetadaten.objects.filter(anlage_datei=project_file).delete()
+    # Alte Ergebnisse zum Projekt entfernen, damit nur die aktuelle Datei
+    # berücksichtigt wird
+    AnlagenFunktionsMetadaten.objects.filter(
+        anlage_datei__projekt=project_file.projekt
+    ).delete()
 
     cfg = Anlage2Config.get_instance()
     token_map = build_token_map(cfg)


### PR DESCRIPTION
## Summary
- ensure `run_anlage2_analysis` clears old `AnlagenFunktionsMetadaten` for the whole project

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ResetTests.test_run_anlage2_analysis_resets_results -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687f91c877f0832b8819c3bb81c1dd6b