### PR TITLE
Fix BVProjectFile defaults in tests

### DIFF
--- a/core/tests/test_admin_views.py
+++ b/core/tests/test_admin_views.py
@@ -43,6 +43,9 @@ class AdminProjectCleanupTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
 
     def test_delete_file(self):

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -45,13 +45,16 @@ class ProjektFileJSONEditTests(NoesisTestCase):
             anlage_nr=4,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
+            manual_analysis_json={},
             analysis_json={"old": {"value": True, "editable": True}},
+            verification_json={},
         )
         self.anlage1 = BVProjectFile.objects.create(
             projekt=self.projekt,
             anlage_nr=1,
             upload=SimpleUploadedFile("b.txt", b"data"),
             text_content="Text",
+            manual_analysis_json={},
             analysis_json={
                 "questions": {
                     "1": {
@@ -62,6 +65,7 @@ class ProjektFileJSONEditTests(NoesisTestCase):
                     }
                 }
             },
+            verification_json={},
         )
 
     def test_edit_json_updates_and_reports(self):

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2110,6 +2110,9 @@ class ProjektFileCheckViewTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
 
     def test_file_check_endpoint_saves_json(self):
@@ -2190,6 +2193,7 @@ class Anlage2ReviewTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("c.txt", b"d"),
             text_content="Text",
+            manual_analysis_json={},
             analysis_json={
                 "functions": [
                     {
@@ -2201,6 +2205,7 @@ class Anlage2ReviewTests(NoesisTestCase):
                     }
                 ]
             },
+            verification_json={},
         )
         self.func = Anlage2Function.objects.create(name="Login")
         self.sub = Anlage2SubQuestion.objects.create(funktion=self.func, frage_text="Warum?")
@@ -2300,6 +2305,9 @@ class WorkerGenerateGutachtenTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
         self.knowledge = SoftwareKnowledge.objects.create(
             projekt=self.projekt,
@@ -2343,6 +2351,9 @@ class WorkerAnlage3VisionTests(NoesisTestCase):
             anlage_nr=3,
             upload=upload,
             text_content="ignored",
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
 
     def test_worker_runs_vision_check(self):
@@ -2373,6 +2384,8 @@ class ProjektFileDeleteResultTests(NoesisTestCase):
             upload=SimpleUploadedFile("d.txt", b"data"),
             text_content="Text",
             analysis_json={"auto_ok": True},
+            manual_analysis_json={},
+            verification_json={},
             manual_reviewed=True,
             verhandlungsfaehig=True,
         )
@@ -2397,12 +2410,18 @@ class ProjektFileCheckResultTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
         self.file2 = BVProjectFile.objects.create(
             projekt=self.projekt,
             anlage_nr=2,
             upload=SimpleUploadedFile("b.txt", b"data"),
             text_content="Text2",
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
 
     def test_get_runs_check_and_redirects_to_edit(self):
@@ -2756,6 +2775,9 @@ class ModelSelectionTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
         LLMConfig.objects.create(
             default_model="d",
@@ -2904,6 +2926,9 @@ class FeatureVerificationTests(NoesisTestCase):
             projekt=self.projekt,
             anlage_nr=2,
             upload=SimpleUploadedFile("a.txt", b"data"),
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
         self.func = Anlage2Function.objects.create(name="Export")
         self.sub = Anlage2SubQuestion.objects.create(
@@ -3126,6 +3151,8 @@ class EditKIJustificationTests(NoesisTestCase):
             projekt=self.projekt,
             anlage_nr=2,
             upload=SimpleUploadedFile("a.txt", b"data"),
+            manual_analysis_json={},
+            analysis_json={},
 
             verification_json={
                 "Export": {"technisch_verfuegbar": True, "ki_begruendung": "Alt"}
@@ -3163,6 +3190,9 @@ class VerificationToInitialTests(NoesisTestCase):
             projekt=self.project,
             anlage_nr=2,
             upload=SimpleUploadedFile("v.txt", b"data"),
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
         self.func = Anlage2Function.objects.create(name="Export")
         self.sub = Anlage2SubQuestion.objects.create(
@@ -3463,6 +3493,9 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
             projekt=self.projekt,
             anlage_nr=2,
             upload=SimpleUploadedFile("a.txt", b"x"),
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
         self.func = Anlage2Function.objects.create(name="Login")
 

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1207,6 +1207,8 @@ class Anlage4ReviewViewTests(NoesisTestCase):
             anlage_nr=4,
             upload=SimpleUploadedFile("a.txt", b""),
             analysis_json={"items": [{"text": "A"}, {"text": "B"}]},
+            manual_analysis_json={},
+            verification_json={},
         )
 
     def test_post_saves_manual_review(self):
@@ -1236,6 +1238,9 @@ class ProjektFileAnalyseAnlage4ViewTests(NoesisTestCase):
             anlage_nr=4,
             upload=SimpleUploadedFile("a.txt", b""),
             text_content="Zwecke",
+            manual_analysis_json={},
+            analysis_json={},
+            verification_json={},
         )
 
     def test_get_runs_analysis_and_redirects(self):


### PR DESCRIPTION
## Summary
- set default JSON fields when creating BVProjectFile objects in tests
- ensure migrations check and test suite run

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: failures=10, errors=14)*

------
https://chatgpt.com/codex/tasks/task_e_687f92f1b9d8832b9d1cf0e75db7cc9c