### PR TITLE
Fix hx status test permissions

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -507,7 +507,7 @@ class BVProjectFileTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"x"),
             verification_task_id="tid",
         )
-        self.client.login(username=self.user.username, password="pass")
+        self.client.login(username=self.superuser.username, password="pass")
         with patch("core.models.fetch") as mock_fetch:
             mock_fetch.return_value = SimpleNamespace(success=True)
             url = reverse("hx_project_file_status", args=[pf.pk])


### PR DESCRIPTION
## Summary
- use superuser to test hx status view

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687f9e55414c832bad67657b263138ce