### PR TITLE
Fix BuildRowData tests

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -961,6 +961,7 @@ class BuildRowDataTests(NoesisTestCase):
             {},
             {},
             {},
+            {},
             result_map,
         )
 
@@ -1009,6 +1010,7 @@ class BuildRowDataTests(NoesisTestCase):
             self.func.id,
             f"sub{sub.id}_",
             form,
+            {},
             {},
             {},
             {},


### PR DESCRIPTION
## Summary
- update BuildRowData tests to include `result_map` parameter

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_general.py::BuildRowDataTests -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9e533514832b96012428919cf842