### PR TITLE
Fix manual_analysis_json usage in tests

### DIFF
--- a/core/tests/test_admin_views.py
+++ b/core/tests/test_admin_views.py
@@ -43,9 +43,9 @@ class AdminProjectCleanupTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
 
     def test_delete_file(self):

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -45,16 +45,16 @@ class ProjektFileJSONEditTests(NoesisTestCase):
             anlage_nr=4,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={"old": {"value": True, "editable": True}},
-            verification_json={},
+            verification_json={"functions": {}},
         )
         self.anlage1 = BVProjectFile.objects.create(
             projekt=self.projekt,
             anlage_nr=1,
             upload=SimpleUploadedFile("b.txt", b"data"),
             text_content="Text",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={
                 "questions": {
                     "1": {
@@ -65,7 +65,7 @@ class ProjektFileJSONEditTests(NoesisTestCase):
                     }
                 }
             },
-            verification_json={},
+            verification_json={"functions": {}},
         )
 
     def test_edit_json_updates_and_reports(self):

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2137,9 +2137,9 @@ class ProjektFileCheckViewTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
 
     def test_file_check_endpoint_saves_json(self):
@@ -2220,7 +2220,7 @@ class Anlage2ReviewTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("c.txt", b"d"),
             text_content="Text",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={
                 "functions": [
                     {
@@ -2232,7 +2232,7 @@ class Anlage2ReviewTests(NoesisTestCase):
                     }
                 ]
             },
-            verification_json={},
+            verification_json={"functions": {}},
         )
         self.func = Anlage2Function.objects.create(name="Login")
         self.sub = Anlage2SubQuestion.objects.create(funktion=self.func, frage_text="Warum?")
@@ -2332,9 +2332,9 @@ class WorkerGenerateGutachtenTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
         self.knowledge = SoftwareKnowledge.objects.create(
             projekt=self.projekt,
@@ -2378,9 +2378,9 @@ class WorkerAnlage3VisionTests(NoesisTestCase):
             anlage_nr=3,
             upload=upload,
             text_content="ignored",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
 
     def test_worker_runs_vision_check(self):
@@ -2411,8 +2411,8 @@ class ProjektFileDeleteResultTests(NoesisTestCase):
             upload=SimpleUploadedFile("d.txt", b"data"),
             text_content="Text",
             analysis_json={"auto_ok": True},
-            manual_analysis_json={},
-            verification_json={},
+            manual_analysis_json={"functions": {}},
+            verification_json={"functions": {}},
             manual_reviewed=True,
             verhandlungsfaehig=True,
         )
@@ -2437,18 +2437,18 @@ class ProjektFileCheckResultTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
         self.file2 = BVProjectFile.objects.create(
             projekt=self.projekt,
             anlage_nr=2,
             upload=SimpleUploadedFile("b.txt", b"data"),
             text_content="Text2",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
 
     def test_get_runs_check_and_redirects_to_edit(self):
@@ -2802,9 +2802,9 @@ class ModelSelectionTests(NoesisTestCase):
             anlage_nr=1,
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Text",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
         LLMConfig.objects.create(
             default_model="d",
@@ -2953,9 +2953,9 @@ class FeatureVerificationTests(NoesisTestCase):
             projekt=self.projekt,
             anlage_nr=2,
             upload=SimpleUploadedFile("a.txt", b"data"),
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
         self.func = Anlage2Function.objects.create(name="Export")
         self.sub = Anlage2SubQuestion.objects.create(
@@ -3168,7 +3168,7 @@ class EditKIJustificationTests(NoesisTestCase):
             projekt=self.projekt,
             anlage_nr=2,
             upload=SimpleUploadedFile("a.txt", b"data"),
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
 
             verification_json={
@@ -3207,9 +3207,9 @@ class VerificationToInitialTests(NoesisTestCase):
             projekt=self.project,
             anlage_nr=2,
             upload=SimpleUploadedFile("v.txt", b"data"),
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
         self.func = Anlage2Function.objects.create(name="Export")
         self.sub = Anlage2SubQuestion.objects.create(
@@ -3510,9 +3510,9 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
             projekt=self.projekt,
             anlage_nr=2,
             upload=SimpleUploadedFile("a.txt", b"x"),
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
         self.func = Anlage2Function.objects.create(name="Login")
 

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1207,8 +1207,8 @@ class Anlage4ReviewViewTests(NoesisTestCase):
             anlage_nr=4,
             upload=SimpleUploadedFile("a.txt", b""),
             analysis_json={"items": [{"text": "A"}, {"text": "B"}]},
-            manual_analysis_json={},
-            verification_json={},
+            manual_analysis_json={"functions": {}},
+            verification_json={"functions": {}},
         )
 
     def test_post_saves_manual_review(self):
@@ -1238,9 +1238,9 @@ class ProjektFileAnalyseAnlage4ViewTests(NoesisTestCase):
             anlage_nr=4,
             upload=SimpleUploadedFile("a.txt", b""),
             text_content="Zwecke",
-            manual_analysis_json={},
+            manual_analysis_json={"functions": {}},
             analysis_json={},
-            verification_json={},
+            verification_json={"functions": {}},
         )
 
     def test_get_runs_analysis_and_redirects(self):


### PR DESCRIPTION
## Summary
- initialize `manual_analysis_json` and `verification_json` with `{"functions": {}}` in tests
- avoid `KeyError` when tests access nested function data

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py test` *(partial run)*

------
https://chatgpt.com/codex/tasks/task_e_687f9e54aea0832ba5bc9d26e241c36b