### PR TITLE
Fix KI justification storage

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1710,15 +1710,19 @@ def worker_verify_feature(
 
     res.save(update_fields=["is_negotiable"])
 
-    FunktionsErgebnis.objects.create(
-        projekt_id=project_id,
-        anlage_datei=pf,
-        funktion_id=func_id,
-        subquestion=sub_obj,
-        quelle="ki",
-        technisch_verfuegbar=tv,
-        ki_beteiligung=ki_bet,
-    )
+    try:
+        FunktionsErgebnis.objects.create(
+            projekt_id=project_id,
+            anlage_datei=pf,
+            funktion_id=func_id,
+            subquestion=sub_obj,
+            quelle="ki",
+            technisch_verfuegbar=tv,
+            ki_beteiligung=ki_bet,
+            begruendung=justification,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Begr\u00fcndung konnte nicht gespeichert werden: %s", exc)
 
 
     logger.info(

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2969,6 +2969,7 @@ class FeatureVerificationTests(NoesisTestCase):
         self.assertIsNotNone(fe)
         self.assertTrue(fe.technisch_verfuegbar)
         self.assertFalse(fe.ki_beteiligung)
+        self.assertEqual(fe.begruendung, "Begruendung")
 
 
     def test_all_no_returns_false(self):
@@ -3041,6 +3042,12 @@ class FeatureVerificationTests(NoesisTestCase):
         self.assertEqual(result["ki_begruendung"], "Begruendung")
         self.assertIsNone(result["ki_beteiligt"])
         self.assertEqual(result["ki_beteiligt_begruendung"], "")
+        pf = BVProjectFile.objects.get(projekt=self.projekt, anlage_nr=2)
+        fe = FunktionsErgebnis.objects.filter(
+            anlage_datei=pf, funktion=self.func, quelle="ki"
+        ).first()
+        self.assertIsNotNone(fe)
+        self.assertEqual(fe.begruendung, "Begruendung")
 
     def test_negotiable_set_on_match(self):
         pf = BVProjectFile.objects.get(projekt=self.projekt, anlage_nr=2)


### PR DESCRIPTION
## Summary
- ensure `worker_verify_feature` writes AI justification
- log errors when the write fails
- check stored justification in tests

## Testing
- `python manage.py makemigrations --check`
- `pytest -q` *(fails: AppRegistryNotReady)*

------
https://chatgpt.com/codex/tasks/task_e_687fd90b65e8832b8dd73dcbfe75c32a