### PR TITLE
Fix tests for parser config and parser manager

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -1430,15 +1430,17 @@ class LLMTasksTests(NoesisTestCase):
         )
         cfg = Anlage2Config.get_instance()
         cfg.parser_mode = "auto"
-        cfg.parser_order = ["table", "exact"]
+        cfg.parser_order = ["exact", "text"]
         cfg.save()
         with patch(
-            "core.parsers.parse_anlage2_table", return_value=[]
-        ), patch(
-            "core.parsers.ExactParser.parse", return_value=[{"funktion": "Login"}]
-        ) as m_exact:
+            "core.parsers.ExactParser.parse", return_value=[]
+        ) as m_exact, patch(
+            "core.text_parser.parse_anlage2_text",
+            return_value=[{"funktion": "Login"}],
+        ) as m_text:
             result = parser_manager.parse_anlage2(pf)
         m_exact.assert_called_once()
+        m_text.assert_called_once()
         self.assertEqual(result, [{"funktion": "Login"}])
 
     def test_run_anlage2_analysis_includes_missing_functions(self):
@@ -3419,17 +3421,23 @@ class Anlage2ConfigViewTests(NoesisTestCase):
         self.client.login(username="cfguser", password="pass")
         self.cfg = Anlage2Config.get_instance()
 
+    def _build_general_data(self, **extra) -> dict:
+        """Erstellt Grunddaten für das Anlage2Config-Formular."""
+        data = {name: "" for name in Anlage2ConfigForm.OPTIONAL_JSON_FIELDS}
+        data.update(extra)
+        return data
+
 
     def test_update_parser_mode(self):
         url = reverse("anlage2_config")
         resp = self.client.post(
             url,
-            {
-                "parser_mode": "text_only",
-                "parser_order": ["text"],
-                "action": "save_general",
-                "active_tab": "general",
-            },
+            self._build_general_data(
+                parser_mode="text_only",
+                parser_order=["text"],
+                action="save_general",
+                active_tab="general",
+            ),
         )
         self.assertRedirects(resp, url + "?tab=general")
         self.cfg.refresh_from_db()
@@ -3439,12 +3447,12 @@ class Anlage2ConfigViewTests(NoesisTestCase):
         url = reverse("anlage2_config")
         resp = self.client.post(
             url,
-            {
-                "parser_mode": self.cfg.parser_mode,
-                "parser_order": ["text"],
-                "action": "save_general",
-                "active_tab": "general",
-            },
+            self._build_general_data(
+                parser_mode=self.cfg.parser_mode,
+                parser_order=["text"],
+                action="save_general",
+                active_tab="general",
+            ),
         )
         self.assertRedirects(resp, url + "?tab=general")
         self.cfg.refresh_from_db()
@@ -3470,13 +3478,13 @@ class Anlage2ConfigViewTests(NoesisTestCase):
         url = reverse("anlage2_config")
         resp = self.client.post(
             url,
-            {
-                "text_technisch_verfuegbar_true": "ja\nokay\n",
-                "parser_mode": self.cfg.parser_mode,
-                "parser_order": self.cfg.parser_order,
-                "action": "save_general",
-                "active_tab": "general",
-            },
+            self._build_general_data(
+                text_technisch_verfuegbar_true="ja\nokay\n",
+                parser_mode=self.cfg.parser_mode,
+                parser_order=self.cfg.parser_order,
+                action="save_general",
+                active_tab="general",
+            ),
         )
         self.assertRedirects(resp, url + "?tab=general")
         self.cfg.refresh_from_db()


### PR DESCRIPTION
## Summary
- fix missing fields in Anlage2 config form tests
- correct parser fallback test in auto mode

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_687fdae76d90832b8e42914d74d5e579