### PR TITLE
Fix tests after fuzzy parser removal

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -1509,8 +1509,7 @@ class LLMTasksTests(NoesisTestCase):
 
         result = run_anlage2_analysis(pf)
 
-        self.assertEqual(len(result), 1)
-        self.assertTrue(result[0]["technisch_verfuegbar"]["value"])
+        self.assertEqual(result, [])
 
     def test_check_anlage2_table_error_fallback(self):
         class P1(AbstractParser):

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -543,15 +543,7 @@ class DocxExtractTests(NoesisTestCase):
         cfg.text_technisch_verfuegbar_true = ["ja"]
         cfg.save()
         data = parse_anlage2_text("Logn: ja")
-        self.assertEqual(
-            data,
-            [
-                {
-                    "funktion": "Login",
-                    "technisch_verfuegbar": {"value": True, "note": None},
-                }
-            ],
-        )
+        self.assertEqual(data, [])
 
     def test_parse_anlage2_text_fuzzy_token_phrase(self):
         func = Anlage2Function.objects.create(name="Login")
@@ -559,15 +551,7 @@ class DocxExtractTests(NoesisTestCase):
         cfg.text_technisch_verfuegbar_true = ["ja bitte"]
         cfg.save()
         data = parse_anlage2_text("Lgin: ja bitte")
-        self.assertEqual(
-            data,
-            [
-                {
-                    "funktion": "Login",
-                    "technisch_verfuegbar": {"value": True, "note": None},
-                }
-            ],
-        )
+        self.assertEqual(data, [])
 
     def test_parse_anlage2_text_fuzzy_rule_phrase(self):
         func = Anlage2Function.objects.create(name="Login")
@@ -577,15 +561,7 @@ class DocxExtractTests(NoesisTestCase):
             actions_json=[{"field": "einsatz_telefonica", "value": True}],
         )
         data = parse_anlage2_text("Lgin: aktivv")
-        self.assertEqual(
-            data,
-            [
-                {
-                    "funktion": "Login",
-                    "einsatz_telefonica": {"value": True, "note": None},
-                }
-            ],
-        )
+        self.assertEqual(data, [])
 
     def test_parse_anlage2_text_multiple_rules_priority(self):
         func = Anlage2Function.objects.create(name="Login")


### PR DESCRIPTION
## Summary
- update tests to reflect removal of fuzzy parser

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687fe292ea80832b9825030df84cb33f