### PR TITLE
Fix indentation and restore text parser

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -39,6 +39,7 @@ from .text_parser import (
     build_token_map,
     apply_tokens,
     apply_rules,
+    parse_anlage2_text,
 )
 from .llm_utils import query_llm, query_llm_with_images
 from .docx_utils import (

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -1436,16 +1436,16 @@ class LLMTasksTests(NoesisTestCase):
                 "core.parsers.ExactParser.parse", return_value=[{"funktion": "Login"}]
             ) as m_exact,
         ):
-        with patch(
-            "core.parsers.ExactParser.parse", return_value=[]
-        ) as m_exact, patch(
-            "core.text_parser.parse_anlage2_text",
-            return_value=[{"funktion": "Login"}],
-        ) as m_text:
-            result = parser_manager.parse_anlage2(pf)
-        m_exact.assert_called_once()
-        m_text.assert_called_once()
-        self.assertEqual(result, [{"funktion": "Login"}])
+            with patch(
+                "core.parsers.ExactParser.parse", return_value=[]
+            ) as m_exact, patch(
+                "core.text_parser.parse_anlage2_text",
+                return_value=[{"funktion": "Login"}],
+            ) as m_text:
+                result = parser_manager.parse_anlage2(pf)
+            m_exact.assert_called_once()
+            m_text.assert_called_once()
+            self.assertEqual(result, [{"funktion": "Login"}])
 
     def test_run_anlage2_analysis_includes_missing_functions(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -240,3 +240,194 @@ def apply_rules(
         entry[best_field]["note"] = remaining
 
 
+def parse_anlage2_text(
+    text: str, threshold: int = FUZZY_THRESHOLD
+) -> List[dict[str, object]]:
+    """Parst eine Freitext-Liste von Funktionen aus Anlage 2.
+
+    Die neue Logik arbeitet zweistufig: Zuerst werden nur die
+    Hauptfunktionen erkannt und bewertet. Anschließend erfolgt –
+    ausschließlich bei technisch vorhandenen Hauptfunktionen – eine
+    gezielte Suche nach zugehörigen Unterfragen.
+    """
+
+    parser_logger.info("parse_anlage2_text gestartet")
+    cfg = Anlage2Config.get_instance()
+
+    func_aliases, sub_aliases, func_map = _load_alias_lists()
+
+    token_map: Dict[str, List[Tuple[str, bool]]] = {}
+    for attr in dir(cfg):
+        if not attr.startswith("text_"):
+            continue
+        phrases = getattr(cfg, attr, [])
+        if not isinstance(phrases, list):
+            continue
+        if attr.endswith("_true"):
+            field = attr[5:-5]
+            token_map.setdefault(field, []).extend(
+                (p.lower(), True) for p in phrases
+            )
+        elif attr.endswith("_false"):
+            field = attr[5:-6]
+            token_map.setdefault(field, []).extend(
+                (p.lower(), False) for p in phrases
+            )
+
+    rules_main = list(
+        AntwortErkennungsRegel.objects.filter(
+            regel_anwendungsbereich="Hauptfunktion"
+        ).order_by("prioritaet")
+    )
+    rules_sub = list(
+        AntwortErkennungsRegel.objects.filter(
+            regel_anwendungsbereich="Unterfrage"
+        ).order_by("prioritaet")
+    )
+
+    def _format_result(entry: Dict[str, object]) -> str:
+        parts = []
+        for key, val in entry.items():
+            if key == "funktion":
+                continue
+            if isinstance(val, dict):
+                val_str = str(val.get("value"))
+                if val.get("note"):
+                    val_str += f" ({val['note']})"
+            else:
+                val_str = str(val)
+            parts.append(f"{key}={val_str}")
+        return f"{entry['funktion']}: " + ", ".join(parts)
+
+    # Stufe 1: Hauptfunktionen erkennen
+    main_results: Dict[int, Dict[str, object]] = {}
+    sub_lines: Dict[int, List[Tuple[Anlage2SubQuestion, str]]] = {}
+    sub_results: Dict[Tuple[int, int], Dict[str, object]] = {}
+    current_func_id: int | None = None
+    found_main: List[str] = []
+
+    lines = text.splitlines()
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        before, after = (line.split(":", 1) + [""])[0:2]
+        before_norm = _normalize(before)
+
+        matched_func: Anlage2Function | None = None
+        for alias_norm, func in func_aliases:
+            score = fuzz.partial_ratio(alias_norm, before_norm)
+            if score >= threshold:
+                matched_func = func
+                parser_logger.debug("Hauptfunktion '%s' erkannt", func.name)
+                break
+
+        if matched_func:
+            current_func_id = matched_func.id
+            matched_sub: Anlage2SubQuestion | None = None
+            for alias_norm, sub in sub_aliases.get(current_func_id, []):
+                score = fuzz.partial_ratio(alias_norm, before_norm)
+                if score >= threshold:
+                    matched_sub = sub
+                    parser_logger.debug(
+                        "Unterfrage '%s' erkannt", sub.frage_text
+                    )
+                    break
+
+            if matched_sub:
+                entry = main_results.get(current_func_id)
+                if not entry:
+                    entry = {"funktion": matched_func.name, "_skip_output": True}
+                    main_results[current_func_id] = entry
+                    found_main.append(matched_func.name)
+                apply_tokens(entry, after or line, token_map, threshold)
+                apply_rules(entry, after or line, rules_main, threshold)
+
+                key = (current_func_id, matched_sub.id)
+                sub_entry = sub_results.get(key)
+                if not sub_entry:
+                    sub_entry = {
+                        "funktion": f"{matched_func.name} - {matched_sub.frage_text}"
+                    }
+                sub_results[key] = sub_entry
+                apply_tokens(sub_entry, after or line, token_map, threshold)
+                apply_rules(sub_entry, after or line, rules_sub, threshold)
+                sub_entry.pop("technisch_verfuegbar", None)
+                continue
+
+            entry = main_results.get(current_func_id)
+            if not entry:
+                entry = {"funktion": matched_func.name}
+                main_results[current_func_id] = entry
+                found_main.append(matched_func.name)
+            apply_tokens(entry, after or line, token_map, threshold)
+            apply_rules(entry, after or line, rules_main, threshold)
+            continue
+
+        if current_func_id is None:
+            continue
+
+        matched_sub: Anlage2SubQuestion | None = None
+        for alias_norm, sub in sub_aliases.get(current_func_id, []):
+            score = fuzz.partial_ratio(alias_norm, before_norm)
+            if score >= threshold:
+                matched_sub = sub
+                parser_logger.debug(
+                    "Unterfrage '%s' erkannt", sub.frage_text
+                )
+                break
+
+        if matched_sub:
+            sub_lines.setdefault(current_func_id, []).append((matched_sub, line))
+            continue
+
+        entry = main_results[current_func_id]
+        apply_tokens(entry, after or line, token_map, threshold)
+        apply_rules(entry, after or line, rules_main, threshold)
+
+    for func_id, lines_list in sub_lines.items():
+        main_entry = main_results.get(func_id)
+        if not main_entry:
+            continue
+        tech = main_entry.get("technisch_verfuegbar")
+        if not tech or tech.get("value") is not True:
+            parser_logger.debug(
+                "Überspringe Unterfragen zu '%s', da technisch nicht vorhanden",
+                func_map[func_id].name,
+            )
+            continue
+
+        for sub, line in lines_list:
+            before, after = (line.split(":", 1) + [""])[0:2]
+            key = (func_id, sub.id)
+            entry = sub_results.get(key)
+            if not entry:
+                entry = {"funktion": f"{func_map[func_id].name}: {sub.frage_text}"}
+                sub_results[key] = entry
+            apply_tokens(entry, after or line, token_map, threshold)
+            apply_rules(entry, after or line, rules_sub, threshold)
+            entry.pop("technisch_verfuegbar", None)
+
+    all_results = [
+        entry for entry in main_results.values() if not entry.pop("_skip_output", False)
+    ] + list(sub_results.values())
+    if found_main:
+        parser_logger.info("Gefundene Funktionen: %s", ", ".join(found_main))
+    if all_results:
+        summary = "; ".join(_format_result(e) for e in all_results)
+        parser_logger.info("Ergebnisse: %s", summary)
+    parser_logger.info(
+        "parse_anlage2_text beendet: %s Einträge", len(all_results)
+    )
+    return all_results
+
+
+class FuzzyTextParser(AbstractParser):
+    """Parser für Freitext mit Fuzzy-Logik."""
+
+    name = "text"
+
+    def parse(self, project_file: BVProjectFile) -> List[dict[str, object]]:
+        return parse_anlage2_text(project_file.text_content or "")
+
+


### PR DESCRIPTION
## Summary
- fix indentation bug in tests
- restore `parse_anlage2_text` and `FuzzyTextParser`
- expose `parse_anlage2_text` from `llm_tasks`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError and multiple assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_687ff1577400832bbb9cc675e83b67f0