### PR TITLE
feat: erweitere Regel-Protokollierung

### DIFF
--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -19,6 +19,7 @@ from .parsers import AbstractParser
 
 logger = logging.getLogger(__name__)
 parser_logger = logging.getLogger("parser_debug")
+result_logger = logging.getLogger("anlage2_ergebnis")
 
 # Standard-Schwelle für Fuzzy-Vergleiche
 FUZZY_THRESHOLD = 80
@@ -193,7 +194,15 @@ def apply_rules(
     parser_logger.debug("Prüfe Regeln in '%s'", text_part)
     found_rules: Dict[str, tuple[bool, int, str]] = {}
     for rule in rules:
-        if fuzzy_match(rule.erkennungs_phrase, text_part, threshold):
+        match_found = fuzzy_match(rule.erkennungs_phrase, text_part, threshold)
+        result_logger.debug(
+            "Regel '%s' mit Priorität %s -> %s in '%s'",
+            rule.erkennungs_phrase,
+            rule.prioritaet,
+            "GEFUNDEN" if match_found else "NICHT gefunden",
+            text_part,
+        )
+        if match_found:
             actions = rule.actions_json or []
             if isinstance(actions, dict):
                 actions = [

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -225,9 +225,9 @@ LOGGING = {
             "encoding": "utf-8",
         },
         "anlage2_ergebnis_file": {
-            "level": "INFO",
+            "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": BASE_DIR / "anlage2-ergebnis.log",
+            "filename": BASE_DIR / "anlage2-sergebnis.log",
             "formatter": "verbose",
             "encoding": "utf-8",
         },
@@ -312,7 +312,7 @@ LOGGING = {
         },
         "anlage2_ergebnis": {
             "handlers": ["anlage2_ergebnis_file"],
-            "level": "INFO",
+            "level": "DEBUG",
             "propagate": False,
         },
         "anlage3_debug": {


### PR DESCRIPTION
## Summary
- erweitere apply_rules um detailliertes Debug-Logging
- leite Logger "anlage2_ergebnis" auf neues Logfile `anlage2-sergebnis.log`

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687ff705c894832ba19a5356f3b92eb5