### PR TITLE
Fix indentation in tests

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -1434,17 +1434,17 @@ class LLMTasksTests(NoesisTestCase):
             patch("core.parsers.parse_anlage2_table", return_value=[]),
             patch(
                 "core.parsers.ExactParser.parse", return_value=[{"funktion": "Login"}]
-            ) as m_exact,
+            ) as m_exact_table,
         ):
-        with patch(
-            "core.parsers.ExactParser.parse", return_value=[]
-        ) as m_exact, patch(
-            "core.text_parser.parse_anlage2_text",
-            return_value=[{"funktion": "Login"}],
-        ) as m_text:
-            result = parser_manager.parse_anlage2(pf)
-        m_exact.assert_called_once()
-        m_text.assert_called_once()
+            with patch(
+                "core.parsers.ExactParser.parse", return_value=[]
+            ) as m_exact, patch(
+                "core.text_parser.parse_anlage2_text",
+                return_value=[{"funktion": "Login"}],
+            ) as m_text:
+                result = parser_manager.parse_anlage2(pf)
+            m_exact.assert_called_once()
+            m_text.assert_called_once()
         self.assertEqual(result, [{"funktion": "Login"}])
 
     def test_run_anlage2_analysis_includes_missing_functions(self):

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -240,3 +240,10 @@ def apply_rules(
         entry[best_field]["note"] = remaining
 
 
+def parse_anlage2_text(text: str) -> List[dict[str, object]]:
+    """Platzhalter für die Textparser-Logik."""
+
+    parser_logger.info("parse_anlage2_text gestartet")
+    return []
+
+


### PR DESCRIPTION
## Summary
- fix indentation in `Anlage2` test
- add placeholder `parse_anlage2_text` function for import stability

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError & AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_687ff1577400832bbb9cc675e83b67f0