### PR TITLE
feat: erweitere Regelprotokollierung

### DIFF
--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -19,6 +19,7 @@ from .parsers import AbstractParser
 
 logger = logging.getLogger(__name__)
 parser_logger = logging.getLogger("parser_debug")
+result_logger = logging.getLogger("anlage2_sergebnis")
 
 # Standard-Schwelle für Fuzzy-Vergleiche
 FUZZY_THRESHOLD = 80
@@ -193,7 +194,15 @@ def apply_rules(
     parser_logger.debug("Prüfe Regeln in '%s'", text_part)
     found_rules: Dict[str, tuple[bool, int, str]] = {}
     for rule in rules:
-        if fuzzy_match(rule.erkennungs_phrase, text_part, threshold):
+        match = fuzzy_match(rule.erkennungs_phrase, text_part, threshold)
+        result_logger.debug(
+            "Regelvergleich '%s' (Prio %s) -> %s in '%s'",
+            rule.erkennungs_phrase,
+            rule.prioritaet,
+            "GEFUNDEN" if match else "NICHT gefunden",
+            text_part,
+        )
+        if match:
             actions = rule.actions_json or []
             if isinstance(actions, dict):
                 actions = [

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -231,6 +231,13 @@ LOGGING = {
             "formatter": "verbose",
             "encoding": "utf-8",
         },
+        "anlage2_sergebnis_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "anlage2-sergebnis.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+        },
         "anlage3_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
@@ -313,6 +320,11 @@ LOGGING = {
         "anlage2_ergebnis": {
             "handlers": ["anlage2_ergebnis_file"],
             "level": "INFO",
+            "propagate": False,
+        },
+        "anlage2_sergebnis": {
+            "handlers": ["anlage2_sergebnis_file"],
+            "level": "DEBUG",
             "propagate": False,
         },
         "anlage3_debug": {


### PR DESCRIPTION
## Summary
- logge Regelvergleiche mit neuer Datei `anlage2-sergebnis.log`
- erweitere `apply_rules` um detaillierte Debug-Ausgaben
- ergänze Logging-Handler und Logger in den Einstellungen

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_687ff705c894832ba19a5356f3b92eb5