### PR TITLE
Verbesserte Prüfstatus-Darstellung

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -429,6 +429,15 @@ def _resolve_value(
     return doc_val, src
 
 
+def _bool_to_status(value: bool | None) -> str:
+    """Wandelt einen Bool-Wert in einen Status-String um."""
+    if value is True:
+        return "ja"
+    if value is False:
+        return "nein"
+    return "unsicher"
+
+
 def _get_display_data(
     lookup_key: str,
     analysis_data: dict[str, dict],
@@ -549,6 +558,7 @@ def _build_row_data(
     disp = _get_display_data(
         lookup_key, {lookup_key: doc_data}, {lookup_key: ai_data}, manual_lookup
     )
+    status_map = {field: _bool_to_status(disp["values"].get(field)) for field, _ in get_anlage2_fields()}
     fields_def = get_anlage2_fields()
     form_fields_map: dict[str, dict] = {}
     rev_origin = {}
@@ -621,6 +631,7 @@ def _build_row_data(
         "manual_result": manual_data,
         "manual_json": manual_json,
         "initial": disp["values"],
+        "status_values": status_map,
         "manual_flags": disp["manual_flags"],
         "form_fields": form_fields_map,
         "is_negotiable": is_negotiable,
@@ -3987,6 +3998,7 @@ def hx_update_review_cell(request, result_id: int, field_name: str):
 
     context = {
         "state": new_state,
+        "status": _bool_to_status(new_state),
         "source": "Manuell",
         "field_name": field_name,
         "row": {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -26,6 +26,14 @@
 .status-nein {
     background-color: #6c757d;
 }
+.status-unsicher {
+    background-color: #ffc107;
+    color: black;
+}
+.status-ungeprueft {
+    background-color: #6c757d;
+    color: white;
+}
 /* Farblogik für technische Verfügbarkeit */
 .status-ok {
     background-color: #28a745;

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -6,12 +6,14 @@
             data-is-manual="{{ is_manual|yesno:'true,false' }}"
             hx-post="{% url 'hx_update_review_cell' result_id=row.result_id field_name=field_name %}{% if row.sub_id %}?sub_id={{ row.sub_id }}{% endif %}"
             hx-target="closest td" hx-swap="outerHTML">
-        {% if state == True %}
-        ✓ Vorhanden
-        {% elif state == False %}
-        ✗ Nicht vorhanden
+        {% if status == 'ja' %}
+        ✓ Ja
+        {% elif status == 'nein' %}
+        ✗ Nein
+        {% elif status == 'unsicher' %}
+        ? Unsicher
         {% else %}
-        ? Unbekannt
+        ? Nicht geprüft
         {% endif %}
     </button>
     <span class="source-icon" title="{{ source }}">
@@ -24,7 +26,7 @@
         {% endif %}
     </span>
     {% else %}
-    <span>-</span>
+    <span class="status-badge status-ungeprueft">Nicht geprüft</span>
     {% endif %}
     {{ widget }}
 </td>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -116,7 +116,7 @@
                 </td>
                 {% for field in fields %}
                 {% with f=row.form_fields|get_item:field %}
-                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
+                {% include 'partials/review_cell.html' with row=row field_name=field status=row.status_values|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
                 {% endwith %}
                 {% endfor %}
                 {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}
@@ -278,11 +278,11 @@ function updateRowAppearance(row) {
         if (docVal && typeof docVal === 'object' && 'value' in docVal) docVal = docVal.value;
         let aiVal = ai[aiKey];
         if (aiVal && typeof aiVal === 'object' && 'value' in aiVal) aiVal = aiVal.value;
-        icon.classList.remove('status-badge','status-ja','status-nein','status-unbekannt','status-ok','status-konflikt','status-manuell-abweichung');
+        icon.classList.remove('status-badge','status-ja','status-nein','status-unsicher','status-ok','status-konflikt','status-manuell-abweichung');
         if (manual === true) icon.classList.add('status-badge','status-ja');
         else if (manual === false) icon.classList.add('status-badge','status-nein');
-        else icon.classList.add('status-badge','status-unbekannt');
-        let cls = 'status-unbekannt';
+        else icon.classList.add('status-badge','status-unsicher');
+        let cls = 'status-unsicher';
         if (manual !== null) {
             cls = manual === docVal ? 'status-ok' : 'status-manuell-abweichung';
         } else if (docVal !== undefined && aiVal !== undefined) {


### PR DESCRIPTION
## Summary
- liefere Statustexte aus dem Backend
- stelle Status in der Review-Tabelle klarer dar
- unterstütze neue Badge-Farben

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6880bf86763c832b9bd041676bfff5f4