### PR TITLE
Verbesserte Statusanzeige in Anlage 2 Reviews

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -429,6 +429,16 @@ def _resolve_value(
     return doc_val, src
 
 
+def _status_text(value: bool | None, exists: bool) -> str:
+    """Wandelt einen booleschen Wert in einen Status-Text um."""
+
+    if value is True:
+        return "ja"
+    if value is False:
+        return "nein"
+    return "unsicher" if exists else "nicht_geprueft"
+
+
 def _get_display_data(
     lookup_key: str,
     analysis_data: dict[str, dict],
@@ -536,15 +546,33 @@ def _build_row_data(
             "ki_beteiligung": ai_entry.ki_beteiligung if ai_entry else None,
             "begruendung": ai_entry.begruendung if ai_entry else None,
         }
+        doc_status = {}
+        ai_status = {}
+        manual_status = {}
+        initial_status = {}
+        for field, _ in get_anlage2_fields():
+            doc_status[field] = _status_text(doc_data.get(field), parser_entry is not None)
+            ai_status[field] = _status_text(ai_data.get(field), ai_entry is not None)
+            manual_status[field] = _status_text(manual_data.get(field), field in manual_data)
+            exists = (parser_entry is not None) or (ai_entry is not None) or (field in manual_data)
+            initial_status[field] = _status_text(disp["values"].get(field), exists)
     else:
         doc_data = {}
         ai_data = {}
+        doc_status = {}
+        ai_status = {}
+        manual_status = {}
+        initial_status = {}
 
     override_val = result_obj.is_negotiable_manual_override if result_obj else None
     manual_data = manual_lookup.get(lookup_key, {})
     doc_json = json.dumps(doc_data, ensure_ascii=False)
     ai_json = json.dumps(ai_data, ensure_ascii=False)
     manual_json = json.dumps(manual_data, ensure_ascii=False)
+    doc_status_json = json.dumps(doc_status, ensure_ascii=False)
+    ai_status_json = json.dumps(ai_status, ensure_ascii=False)
+    manual_status_json = json.dumps(manual_status, ensure_ascii=False)
+    initial_status_json = json.dumps(initial_status, ensure_ascii=False)
 
     disp = _get_display_data(
         lookup_key, {lookup_key: doc_data}, {lookup_key: ai_data}, manual_lookup
@@ -616,11 +644,19 @@ def _build_row_data(
         "name": display_name,
         "doc_result": doc_data,
         "doc_json": doc_json,
+        "doc_status": doc_status,
+        "doc_status_json": doc_status_json,
         "ai_result": ai_data,
         "ai_json": ai_json,
+        "ai_status": ai_status,
+        "ai_status_json": ai_status_json,
         "manual_result": manual_data,
         "manual_json": manual_json,
+        "manual_status": manual_status,
+        "manual_status_json": manual_status_json,
         "initial": disp["values"],
+        "initial_status": initial_status,
+        "initial_status_json": initial_status_json,
         "manual_flags": disp["manual_flags"],
         "form_fields": form_fields_map,
         "is_negotiable": is_negotiable,
@@ -3987,6 +4023,7 @@ def hx_update_review_cell(request, result_id: int, field_name: str):
 
     context = {
         "state": new_state,
+        "state_text": _status_text(new_state, True),
         "source": "Manuell",
         "field_name": field_name,
         "row": {

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -6,12 +6,14 @@
             data-is-manual="{{ is_manual|yesno:'true,false' }}"
             hx-post="{% url 'hx_update_review_cell' result_id=row.result_id field_name=field_name %}{% if row.sub_id %}?sub_id={{ row.sub_id }}{% endif %}"
             hx-target="closest td" hx-swap="outerHTML">
-        {% if state == True %}
-        ✓ Vorhanden
-        {% elif state == False %}
-        ✗ Nicht vorhanden
+        {% if state_text == 'ja' %}
+        ✓ Ja
+        {% elif state_text == 'nein' %}
+        ✗ Nein
+        {% elif state_text == 'unsicher' %}
+        ? Unsicher
         {% else %}
-        ? Unbekannt
+        – Nicht geprüft
         {% endif %}
     </button>
     <span class="source-icon" title="{{ source }}">

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -71,6 +71,9 @@
                 data-ai='{{ row.ai_result|tojson }}'
                 data-doc='{{ row.doc_result|tojson }}'
                 data-manual='{{ row.manual_result|tojson }}'
+                data-ai-labels='{{ row.ai_status|tojson }}'
+                data-doc-labels='{{ row.doc_status|tojson }}'
+                data-manual-labels='{{ row.manual_status|tojson }}'
                 data-negotiable="{{ row.is_negotiable|yesno:'true,false' }}"
                 data-manual-override="{{ row.negotiable_manual_override|yesno:'true,false,' }}"
                 data-requires-review="{{ row.requires_manual_review|yesno:'true,false' }}"
@@ -116,7 +119,7 @@
                 </td>
                 {% for field in fields %}
                 {% with f=row.form_fields|get_item:field %}
-                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
+                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field state_text=row.initial_status|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
                 {% endwith %}
                 {% endfor %}
                 {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}
@@ -226,27 +229,36 @@ function updatePopoverContent(icon, input) {
     const doc = safeJsonParse(row.dataset.doc);
     const ai = safeJsonParse(row.dataset.ai);
     const manual = safeJsonParse(row.dataset.manual);
+    const docLabels = safeJsonParse(row.dataset.docLabels);
+    const aiLabels = safeJsonParse(row.dataset.aiLabels);
+    const manualLabels = safeJsonParse(row.dataset.manualLabels);
     const field = icon.dataset.fieldName;
     const docKey = field === 'technisch_vorhanden' && doc.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : field;
     const aiKey = field === 'technisch_vorhanden' && ai.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : field;
     let docEntry = doc[docKey];
-    let docVal = docEntry;
+    let docVal = docLabels && docLabels[docKey];
     let docNote = '';
     if (docEntry && typeof docEntry === 'object') {
-        if ('value' in docEntry) docVal = docEntry.value;
+        if (docVal === undefined && 'value' in docEntry) docVal = docEntry.value;
         docNote = docEntry.note || docEntry.text || '';
+    } else if (docVal === undefined) {
+        docVal = docEntry;
     }
     let aiEntry = ai[aiKey];
-    let aiVal = aiEntry;
+    let aiVal = aiLabels && aiLabels[aiKey];
     let aiNote = '';
     if (aiEntry && typeof aiEntry === 'object') {
-        if ('value' in aiEntry) aiVal = aiEntry.value;
+        if (aiVal === undefined && 'value' in aiEntry) aiVal = aiEntry.value;
         aiNote = aiEntry.note || aiEntry.text || '';
+    } else if (aiVal === undefined) {
+        aiVal = aiEntry;
     }
-    let manualVal = null;
+    let manualVal = manualLabels && manualLabels[aiKey];
     let manualEntry = manual[aiKey];
-    if (manualEntry && typeof manualEntry === 'object' && 'value' in manualEntry) manualVal = manualEntry.value;
-    else if (manualEntry !== undefined) manualVal = manualEntry;
+    if (manualVal === undefined) {
+        if (manualEntry && typeof manualEntry === 'object' && 'value' in manualEntry) manualVal = manualEntry.value;
+        else if (manualEntry !== undefined) manualVal = manualEntry;
+    }
     if (manualVal === null && icon.dataset.isManual === 'true' && input && input.dataset && 'state' in input.dataset) {
         const st = input.dataset.state;
         manualVal = st === 'true' ? true : st === 'false' ? false : null;
@@ -272,6 +284,7 @@ function updateRowAppearance(row) {
         if (!icon) return;
         const manual = textToState(icon.textContent);
         icon.dataset.isManual = manual !== null ? 'true' : 'false';
+        const labels = safeJsonParse(row.dataset.manualLabels || '{}');
         const docKey = f === 'technisch_vorhanden' && doc.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : f;
         const aiKey = f === 'technisch_vorhanden' && ai.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : f;
         let docVal = doc[docKey];
@@ -289,6 +302,8 @@ function updateRowAppearance(row) {
             cls = docVal === aiVal ? 'status-ok' : 'status-konflikt';
         }
         icon.classList.add(cls);
+        labels[aiKey] = manual === true ? 'ja' : manual === false ? 'nein' : 'unsicher';
+        row.dataset.manualLabels = JSON.stringify(labels);
         updatePopoverContent(icon, {dataset: {state: manual === true ? 'true' : manual === false ? 'false' : 'unknown'}});
         if (docVal !== undefined && aiVal !== undefined && docVal !== aiVal && manual === null) {
             needsReview = true;


### PR DESCRIPTION
## Summary
- Backend gibt jetzt Klartext-Status wie *ja*, *nein* oder *unsicher* aus
- Review-Buttons zeigen diese Texte an
- Popover nutzt die neuen Texte und zeigt sie verständlich an

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6880d4353aec832bbe993208ad7f4e00