### PR TITLE
Revert review status changes

### DIFF
--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -6,14 +6,12 @@
             data-is-manual="{{ is_manual|yesno:'true,false' }}"
             hx-post="{% url 'hx_update_review_cell' result_id=row.result_id field_name=field_name %}{% if row.sub_id %}?sub_id={{ row.sub_id }}{% endif %}"
             hx-target="closest td" hx-swap="outerHTML">
-        {% if state_text == 'ja' %}
-        ✓ Ja
-        {% elif state_text == 'nein' %}
-        ✗ Nein
-        {% elif state_text == 'unsicher' %}
-        ? Unsicher
+        {% if state == True %}
+        ✓ Vorhanden
+        {% elif state == False %}
+        ✗ Nicht vorhanden
         {% else %}
-        – Nicht geprüft
+        ? Unbekannt
         {% endif %}
     </button>
     <span class="source-icon" title="{{ source }}">

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -71,9 +71,6 @@
                 data-ai='{{ row.ai_result|tojson }}'
                 data-doc='{{ row.doc_result|tojson }}'
                 data-manual='{{ row.manual_result|tojson }}'
-                data-ai-labels='{{ row.ai_status|tojson }}'
-                data-doc-labels='{{ row.doc_status|tojson }}'
-                data-manual-labels='{{ row.manual_status|tojson }}'
                 data-negotiable="{{ row.is_negotiable|yesno:'true,false' }}"
                 data-manual-override="{{ row.negotiable_manual_override|yesno:'true,false,' }}"
                 data-requires-review="{{ row.requires_manual_review|yesno:'true,false' }}"
@@ -119,7 +116,7 @@
                 </td>
                 {% for field in fields %}
                 {% with f=row.form_fields|get_item:field %}
-                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field state_text=row.initial_status|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
+                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
                 {% endwith %}
                 {% endfor %}
                 {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}
@@ -229,36 +226,27 @@ function updatePopoverContent(icon, input) {
     const doc = safeJsonParse(row.dataset.doc);
     const ai = safeJsonParse(row.dataset.ai);
     const manual = safeJsonParse(row.dataset.manual);
-    const docLabels = safeJsonParse(row.dataset.docLabels);
-    const aiLabels = safeJsonParse(row.dataset.aiLabels);
-    const manualLabels = safeJsonParse(row.dataset.manualLabels);
     const field = icon.dataset.fieldName;
     const docKey = field === 'technisch_vorhanden' && doc.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : field;
     const aiKey = field === 'technisch_vorhanden' && ai.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : field;
     let docEntry = doc[docKey];
-    let docVal = docLabels && docLabels[docKey];
+    let docVal = docEntry;
     let docNote = '';
     if (docEntry && typeof docEntry === 'object') {
-        if (docVal === undefined && 'value' in docEntry) docVal = docEntry.value;
+        if ('value' in docEntry) docVal = docEntry.value;
         docNote = docEntry.note || docEntry.text || '';
-    } else if (docVal === undefined) {
-        docVal = docEntry;
     }
     let aiEntry = ai[aiKey];
-    let aiVal = aiLabels && aiLabels[aiKey];
+    let aiVal = aiEntry;
     let aiNote = '';
     if (aiEntry && typeof aiEntry === 'object') {
-        if (aiVal === undefined && 'value' in aiEntry) aiVal = aiEntry.value;
+        if ('value' in aiEntry) aiVal = aiEntry.value;
         aiNote = aiEntry.note || aiEntry.text || '';
-    } else if (aiVal === undefined) {
-        aiVal = aiEntry;
     }
-    let manualVal = manualLabels && manualLabels[aiKey];
+    let manualVal = null;
     let manualEntry = manual[aiKey];
-    if (manualVal === undefined) {
-        if (manualEntry && typeof manualEntry === 'object' && 'value' in manualEntry) manualVal = manualEntry.value;
-        else if (manualEntry !== undefined) manualVal = manualEntry;
-    }
+    if (manualEntry && typeof manualEntry === 'object' && 'value' in manualEntry) manualVal = manualEntry.value;
+    else if (manualEntry !== undefined) manualVal = manualEntry;
     if (manualVal === null && icon.dataset.isManual === 'true' && input && input.dataset && 'state' in input.dataset) {
         const st = input.dataset.state;
         manualVal = st === 'true' ? true : st === 'false' ? false : null;
@@ -284,7 +272,6 @@ function updateRowAppearance(row) {
         if (!icon) return;
         const manual = textToState(icon.textContent);
         icon.dataset.isManual = manual !== null ? 'true' : 'false';
-        const labels = safeJsonParse(row.dataset.manualLabels || '{}');
         const docKey = f === 'technisch_vorhanden' && doc.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : f;
         const aiKey = f === 'technisch_vorhanden' && ai.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : f;
         let docVal = doc[docKey];
@@ -302,8 +289,6 @@ function updateRowAppearance(row) {
             cls = docVal === aiVal ? 'status-ok' : 'status-konflikt';
         }
         icon.classList.add(cls);
-        labels[aiKey] = manual === true ? 'ja' : manual === false ? 'nein' : 'unsicher';
-        row.dataset.manualLabels = JSON.stringify(labels);
         updatePopoverContent(icon, {dataset: {state: manual === true ? 'true' : manual === false ? 'false' : 'unknown'}});
         if (docVal !== undefined && aiVal !== undefined && docVal !== aiVal && manual === null) {
             needsReview = true;


### PR DESCRIPTION
## Summary
- revert manual status label functionality in Anlage 2 review
- revert initialization changes depending on that functionality

## Testing
- `python manage.py makemigrations --check` *(fails: DJANGO_SECRET_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_6880f9fd8a84832b846dffd056ae9272