### PR TITLE
Fix mapping of Telefonica field in parser results

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -473,7 +473,9 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
         tv = _extract_bool(
             row.get("technisch_vorhanden") or row.get("technisch_verfuegbar")
         )
-        eins = _extract_bool(row.get("einsatz_bei_telefonica"))
+        eins = _extract_bool(
+            row.get("einsatz_bei_telefonica") or row.get("einsatz_telefonica")
+        )
         lv = _extract_bool(row.get("zur_lv_kontrolle"))
         ki = _extract_bool(row.get("ki_beteiligung"))
         AnlagenFunktionsMetadaten.objects.update_or_create(


### PR DESCRIPTION
## Summary
- ensure parser data for 'Einsatz bei Telefónica' is persisted

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test -v 0` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6881106b6d68832b9ed28b87ce1d9eee