### PR TITLE
Fix prompt duplication in tests

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -253,14 +253,6 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
                 "probabilistische Ergebnisse liefert."
             )
         },
-        "anlage2_ai_involvement_justification": {
-            "text": (
-                "Gib eine kurze Begründung, warum die Funktion '{function_name}' "
-                "der Software '{software_name}' eine KI-Komponente beinhaltet oder "
-                "beinhalten kann, insbesondere im Hinblick auf die Verarbeitung "
-                "unstrukturierter Daten oder nicht-deterministischer Ergebnisse."
-            )
-        },
         "anlage2_feature_justification": {
             "text": (
                 "Warum besitzt die Software '{software_name}' typischerweise die "


### PR DESCRIPTION
## Summary
- remove outdated `anlage2_ai_involvement_justification` prompt from tests

## Testing
- `python manage.py makemigrations --check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6881235e5838832ba2693b9f94f6abd9