### PR TITLE
Add KI involvement detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ erscheinen anschließend direkt in der Tabelle, wobei die jeweilige Begründung
 Die Antwort auf die KI-Frage wird unter `ki_beteiligt` gespeichert. Gibt das
 Modell "Ja" zurück, folgt zudem eine kurze Erläuterung, die im Feld
 `ki_beteiligt_begruendung` landet.
+Über das ℹ️-Symbol in der Tabelle gelangt man zur Detailansicht, in der sich
+die Begründung bearbeiten lässt.
 
 ### Edit-Ansicht für Analysedaten
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -257,6 +257,11 @@ urlpatterns = [
         name="justification_detail_edit",
     ),
     path(
+        "work/anlage/file/<int:file_id>/involvement/<path:function_key>/",
+        views.ki_involvement_detail_edit,
+        name="ki_involvement_detail_edit",
+    ),
+    path(
         "work/anlage/file/<int:file_id>/justification/<path:function_key>/delete/",
         views.justification_delete,
         name="justification_delete",

--- a/core/views.py
+++ b/core/views.py
@@ -4459,6 +4459,54 @@ def justification_detail_edit(request, file_id, function_key):
 
 
 @login_required
+def ki_involvement_detail_edit(request, file_id, function_key):
+    """Zeigt und bearbeitet die Begründung zur KI-Beteiligung."""
+
+    anlage = get_object_or_404(BVProjectFile, pk=file_id)
+    if anlage.anlage_nr != 2:
+        raise Http404
+
+    func_name = function_key
+    sub_text = None
+    if ":" in function_key:
+        func_name, sub_text = [p.strip() for p in function_key.split(":", 1)]
+
+    get_object_or_404(Anlage2Function, name=func_name)
+    if sub_text:
+        get_object_or_404(
+            Anlage2SubQuestion,
+            funktion__name=func_name,
+            frage_text=sub_text,
+        )
+
+    data = (anlage.verification_json or {}).get(function_key, {})
+    initial_text = data.get("ki_beteiligt_begruendung", "")
+
+    if request.method == "POST":
+        form = JustificationForm(request.POST)
+        if form.is_valid():
+            text = form.cleaned_data["justification"]
+            vdata = anlage.verification_json or {}
+            entry = vdata.setdefault(function_key, {})
+            entry["ki_beteiligt_begruendung"] = text
+            anlage.verification_json = vdata
+            anlage.save(update_fields=["verification_json"])
+            messages.success(request, "Begründung gespeichert")
+            return redirect("projekt_file_edit_json", pk=anlage.pk)
+    else:
+        form = JustificationForm(initial={"justification": initial_text})
+
+    involvement_html = markdownify(initial_text)
+    context = {
+        "project_file": anlage,
+        "function_name": function_key,
+        "form": form,
+        "involvement_html": involvement_html,
+    }
+    return render(request, "involvement_detail.html", context)
+
+
+@login_required
 def justification_delete(request, file_id, function_key):
     """Löscht die KI-Begründung für einen Funktionsschlüssel."""
 

--- a/templates/involvement_detail.html
+++ b/templates/involvement_detail.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}KI-Beteiligung{% endblock %}
+{% block content %}
+<h3 class="text-xl font-semibold mb-4">Begründung zur KI-Beteiligung: {{ function_name }}</h3>
+<div class="mb-4 p-2 border rounded bg-gray-50">
+    {{ involvement_html|safe }}
+</div>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.justification.label_tag }}
+    {{ form.justification }}
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+</form>
+{% endblock %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -85,6 +85,10 @@
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
+                    {% if row.ki_beteiligt_begruendung %}
+                    <a href="{% url 'ki_involvement_detail_edit' anlage.pk row.verif_key %}"
+                       class="ms-2 text-blue-600" title="KI-Beteiligung">ℹ️</a>
+                    {% endif %}
                     {% else %}
                     {{ row.name }}
                     {% if row.has_justification %}
@@ -92,6 +96,10 @@
                        class="btn btn-sm btn-outline-secondary ms-2">
                         Begründung ansehen/bearbeiten
                     </a>
+                    {% endif %}
+                    {% if row.ki_beteiligt_begruendung %}
+                    <a href="{% url 'ki_involvement_detail_edit' anlage.pk row.verif_key %}"
+                       class="ms-2 text-blue-600" title="KI-Beteiligung">ℹ️</a>
                     {% endif %}
                     {% endif %}
                     {% if row.source_text and row.source_text != 'N/A' %}


### PR DESCRIPTION
## Summary
- add `ki_involvement_detail_edit` view and URL
- mirror UI template for KI involvement editing
- show info link in Anlage 2 review when involvement reason exists
- document KI involvement info link

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py test` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6881235d3164832b9444a4475bc5608a