### PR TITLE
Adjust A2 review to treat unknowns as absent

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -426,7 +426,11 @@ def _resolve_value(
     if ai_val is not None:
         return ai_val, src
 
-    return doc_val, src
+    if doc_val is not None:
+        return doc_val, src
+
+    # Null-Werte werden als "nicht vorhanden" interpretiert
+    return False, src
 
 
 def _get_display_data(

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -8,10 +8,8 @@
             hx-target="closest td" hx-swap="outerHTML">
         {% if state == True %}
         ✓ Vorhanden
-        {% elif state == False %}
-        ✗ Nicht vorhanden
         {% else %}
-        ? Unbekannt
+        ✗ Nicht vorhanden
         {% endif %}
     </button>
     <span class="source-icon" title="{{ source }}">

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -251,6 +251,12 @@ function updatePopoverContent(icon, input) {
         if ('value' in aiEntry) aiVal = aiEntry.value;
         aiNote = aiEntry.note || aiEntry.text || '';
     }
+    let aiDisplay;
+    if (ai.hasOwnProperty(aiKey)) {
+        aiDisplay = aiVal === true ? 'True' : aiVal === false ? 'False' : 'Unsicher';
+    } else {
+        aiDisplay = 'Nicht geprüft';
+    }
     let manualVal = null;
     let manualEntry = manual[aiKey];
     if (manualEntry && typeof manualEntry === 'object' && 'value' in manualEntry) manualVal = manualEntry.value;
@@ -260,7 +266,7 @@ function updatePopoverContent(icon, input) {
         manualVal = st === 'true' ? true : st === 'false' ? false : null;
     }
     const html = `Dokument: ${docVal}${docNote ? ' ('+docNote+')' : ''}<br>` +
-                 `KI-Check: ${aiVal}${aiNote ? ' ('+aiNote+')' : ''}<br>` +
+                 `KI-Check: ${aiDisplay}${aiNote ? ' ('+aiNote+')' : ''}<br>` +
                  `Manuell: ${manualVal}`;
     icon.dataset.popoverContent = html;
     if (window.attachCustomPopover) {


### PR DESCRIPTION
## Summary
- default unknown statuses to `False` when preparing review data
- drop `? Unbekannt` label from the review table
- improve tooltip to show whether the KI check was skipped or uncertain

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68812744764c832b91c4f537e95b2510