### PR TITLE
Fix review handling for unknown states

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -452,6 +452,8 @@ def _get_display_data(
         doc_val = a_data.get(field)
         manual_exists = field in m_data
         val, src = _resolve_value(man_val, ai_val, doc_val, field, manual_exists)
+        if val is None:
+            val = False
         values[field] = val
         sources[field] = src
         manual_flags[field] = manual_exists
@@ -555,11 +557,7 @@ def _build_row_data(
     for field, _ in fields_def:
         bf = form[f"{form_prefix}{field}"]
         initial_value = disp["values"].get(field)
-        state = (
-            "true"
-            if initial_value is True
-            else "false" if initial_value is False else "unknown"
-        )
+        state = "true" if initial_value is True else "false"
         origin_val = "none"
         if field == "technisch_vorhanden":
             man_val = manual_lookup.get(lookup_key, {}).get(field)
@@ -576,12 +574,13 @@ def _build_row_data(
             "data-origin": origin_val,
         }
         if field == "technisch_vorhanden" and sub_id is not None:
-            attrs.update({"disabled": True, "class": "disabled-field", "data-initial-state": "unknown"})
+            attrs.update({"disabled": True, "class": "disabled-field", "data-initial-state": "false"})
         bf.field.widget.attrs.update(attrs)
         form_fields_map[field] = {
             "widget": bf,
             "source": disp["sources"][field],
             "origin": rev_origin.get(field),
+            "ai_unsicher": field in ai_data and ai_data.get(field) is None,
         }
 
 

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -4,14 +4,13 @@
     <button class="tri-state-icon{% if field_name == 'technisch_vorhanden' and row.sub %} disabled-field{% endif %}"
             data-field-name="{{ field_name }}"
             data-is-manual="{{ is_manual|yesno:'true,false' }}"
+            data-ai-unsicher="{{ ai_unsicher|yesno:'true,false' }}"
             hx-post="{% url 'hx_update_review_cell' result_id=row.result_id field_name=field_name %}{% if row.sub_id %}?sub_id={{ row.sub_id }}{% endif %}"
             hx-target="closest td" hx-swap="outerHTML">
         {% if state == True %}
         ✓ Vorhanden
-        {% elif state == False %}
-        ✗ Nicht vorhanden
         {% else %}
-        ? Unbekannt
+        ✗ Nicht vorhanden
         {% endif %}
     </button>
     <span class="source-icon" title="{{ source }}">

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -116,7 +116,7 @@
                 </td>
                 {% for field in fields %}
                 {% with f=row.form_fields|get_item:field %}
-                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
+                {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget ai_unsicher=f.ai_unsicher %}
                 {% endwith %}
                 {% endfor %}
                 {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}
@@ -249,7 +249,7 @@ function updatePopoverContent(icon, input) {
     else if (manualEntry !== undefined) manualVal = manualEntry;
     if (manualVal === null && icon.dataset.isManual === 'true' && input && input.dataset && 'state' in input.dataset) {
         const st = input.dataset.state;
-        manualVal = st === 'true' ? true : st === 'false' ? false : null;
+        manualVal = st === 'true' ? true : false;
     }
     const html = `Dokument: ${docVal}${docNote ? ' ('+docNote+')' : ''}<br>` +
                  `KI-Check: ${aiVal}${aiNote ? ' ('+aiNote+')' : ''}<br>` +
@@ -266,12 +266,12 @@ function updateRowAppearance(row) {
     const doc = safeJsonParse(row.dataset.doc);
     const fieldOrder = ['technisch_vorhanden','einsatz_bei_telefonica','zur_lv_kontrolle','ki_beteiligung'];
     let needsReview = false;
-    const textToState = txt => txt.trim().startsWith('✓') ? true : (txt.trim().startsWith('✗') ? false : null);
+    const textToState = txt => txt.trim().startsWith('✓');
     fieldOrder.forEach(f => {
         const icon = row.querySelector(`.tri-state-icon[data-field-name="${f}"]`);
         if (!icon) return;
         const manual = textToState(icon.textContent);
-        icon.dataset.isManual = manual !== null ? 'true' : 'false';
+        icon.dataset.isManual = manual ? 'true' : 'false';
         const docKey = f === 'technisch_vorhanden' && doc.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : f;
         const aiKey = f === 'technisch_vorhanden' && ai.hasOwnProperty('technisch_verfuegbar') ? 'technisch_verfuegbar' : f;
         let docVal = doc[docKey];
@@ -280,16 +280,20 @@ function updateRowAppearance(row) {
         if (aiVal && typeof aiVal === 'object' && 'value' in aiVal) aiVal = aiVal.value;
         icon.classList.remove('status-badge','status-ja','status-nein','status-unbekannt','status-ok','status-konflikt','status-manuell-abweichung');
         if (manual === true) icon.classList.add('status-badge','status-ja');
-        else if (manual === false) icon.classList.add('status-badge','status-nein');
-        else icon.classList.add('status-badge','status-unbekannt');
-        let cls = 'status-unbekannt';
-        if (manual !== null) {
+        else icon.classList.add('status-badge','status-nein');
+        let cls = 'status-nein';
+        if (manual !== undefined) {
             cls = manual === docVal ? 'status-ok' : 'status-manuell-abweichung';
         } else if (docVal !== undefined && aiVal !== undefined) {
             cls = docVal === aiVal ? 'status-ok' : 'status-konflikt';
         }
         icon.classList.add(cls);
-        updatePopoverContent(icon, {dataset: {state: manual === true ? 'true' : manual === false ? 'false' : 'unknown'}});
+        updatePopoverContent(icon, {dataset: {state: manual === true ? 'true' : 'false'}});
+        if (icon.dataset.aiUnsicher === 'true') {
+            icon.title = 'KI unsicher';
+        } else {
+            icon.removeAttribute('title');
+        }
         if (docVal !== undefined && aiVal !== undefined && docVal !== aiVal && manual === null) {
             needsReview = true;
         }


### PR DESCRIPTION
## Summary
- treat `None` values as `False` during review
- keep AI uncertainty flag and show tooltip
- simplify tri-state UI to remove 'unknown'

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6881269a9250832b86c9a77e9441151e