### PR TITLE
Implement progressive disclosure in supervision view

### DIFF
--- a/templates/partials/supervision_group.html
+++ b/templates/partials/supervision_group.html
@@ -1,0 +1,14 @@
+<details class="border rounded" {% if group.function.has_discrepancy %}open{% endif %}>
+  <summary class="p-2 cursor-pointer {% if group.function.has_discrepancy %}bg-red-100{% else %}bg-gray-100{% endif %}">
+    {{ group.function.name }}
+    {% if group.subrows %}<span class="ms-2">+</span>{% endif %}
+  </summary>
+  {% include 'partials/supervision_row_content.html' with row=group.function %}
+  {% if group.show_subs and group.subrows %}
+  <div class="ms-4 space-y-4 mt-2">
+    {% for sub in group.subrows %}
+      {% include 'partials/supervision_row.html' with row=sub %}
+    {% endfor %}
+  </div>
+  {% endif %}
+</details>

--- a/templates/partials/supervision_row.html
+++ b/templates/partials/supervision_row.html
@@ -3,24 +3,5 @@
     {{ row.name }}
     {% if row.has_discrepancy %}<span class="ms-2 text-red-600">⚠️</span>{% endif %}
   </summary>
-  <div class="p-2 space-y-2">
-    <div>
-      <strong>Parser:</strong> {{ row.doc_val|yesno:"Vorhanden,Nicht vorhanden,?" }}
-      {% if row.doc_snippet %}<pre class="bg-gray-100 p-2 rounded">{{ row.doc_snippet }}</pre>{% endif %}
-    </div>
-    <div>
-      <strong>KI:</strong> {{ row.ai_val|yesno:"Vorhanden,Nicht vorhanden,?" }}
-      {% if row.ai_reason %}<pre class="bg-gray-100 p-2 rounded">{{ row.ai_reason }}</pre>{% endif %}
-    </div>
-    <div>
-      <strong>Final:</strong> {{ row.final_val|yesno:"Vorhanden,Nicht vorhanden,?" }}
-      <form hx-post="{% url 'hx_supervision_confirm' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="inline">
-        <button class="bg-green-600 text-white px-2 py-1 rounded ms-2" type="submit">Bestätigen</button>
-      </form>
-    </div>
-    <form hx-post="{% url 'hx_supervision_save_notes' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="space-y-2">
-      <textarea name="notes" rows="2" class="border rounded w-full p-2">{{ row.notes }}</textarea>
-      <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Speichern</button>
-    </form>
-  </div>
+  {% include 'partials/supervision_row_content.html' with row=row %}
 </details>

--- a/templates/partials/supervision_row_content.html
+++ b/templates/partials/supervision_row_content.html
@@ -1,0 +1,20 @@
+<div class="p-2 space-y-2">
+  <div>
+    <strong>Parser:</strong> {{ row.doc_val|yesno:"Vorhanden,Nicht vorhanden,?" }}
+    {% if row.doc_snippet %}<pre class="bg-gray-100 p-2 rounded">{{ row.doc_snippet }}</pre>{% endif %}
+  </div>
+  <div>
+    <strong>KI:</strong> {{ row.ai_val|yesno:"Vorhanden,Nicht vorhanden,?" }}
+    {% if row.ai_reason %}<pre class="bg-gray-100 p-2 rounded">{{ row.ai_reason }}</pre>{% endif %}
+  </div>
+  <div>
+    <strong>Final:</strong> {{ row.final_val|yesno:"Vorhanden,Nicht vorhanden,?" }}
+    <form hx-post="{% url 'hx_supervision_confirm' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="inline">
+      <button class="bg-green-600 text-white px-2 py-1 rounded ms-2" type="submit">Bestätigen</button>
+    </form>
+  </div>
+  <form hx-post="{% url 'hx_supervision_save_notes' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="space-y-2">
+    <textarea name="notes" rows="2" class="border rounded w-full p-2">{{ row.notes }}</textarea>
+    <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Speichern</button>
+  </form>
+</div>

--- a/templates/supervision_review.html
+++ b/templates/supervision_review.html
@@ -3,8 +3,8 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Supervision Anlage 2</h1>
 <div class="space-y-4">
-  {% for row in rows %}
-    {% include 'partials/supervision_row.html' with row=row %}
+  {% for group in rows %}
+    {% include 'partials/supervision_group.html' with group=group %}
   {% empty %}
     <p>Keine Funktionen gefunden.</p>
   {% endfor %}


### PR DESCRIPTION
## Summary
- group main functions and subquestions in Supervision
- add templates for grouped display and row contents
- show subquestions only when the main function is present

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate --noinput`
- `python manage.py test` *(fails: AttributeError in core.llm_tasks)*

------
https://chatgpt.com/codex/tasks/task_e_6881f2243a54832b8bed4a0412227fe3