### PR TITLE
Implement admin-configurable standard notes for supervision

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -24,6 +24,7 @@ from .models import (
     Anlage3ParserRule,
     Anlage3Metadata,
     Anlage5Review,
+    SupervisionStandardNote,
 )
 
 
@@ -272,6 +273,12 @@ class Anlage5ReviewAdmin(admin.ModelAdmin):
 @admin.register(Anlage3Metadata)
 class Anlage3MetadataAdmin(admin.ModelAdmin):
     list_display = ("project_file", "name", "zeitraum")
+
+
+@admin.register(SupervisionStandardNote)
+class SupervisionStandardNoteAdmin(admin.ModelAdmin):
+    list_display = ("note_text", "is_active", "display_order")
+    list_editable = ("is_active", "display_order")
 
 
 # Registrierung der Modelle

--- a/core/migrations/0042_supervision_standard_note.py
+++ b/core/migrations/0042_supervision_standard_note.py
@@ -1,0 +1,46 @@
+from django.db import migrations, models
+
+
+def add_default_notes(apps, schema_editor):
+    Note = apps.get_model('core', 'SupervisionStandardNote')
+    defaults = [
+        'Kein mitbest. relevanter Einsatz',
+        'Lizenz-/kostenpflichtig',
+        'Geplant, aber nicht aktiv',
+    ]
+    for order, text in enumerate(defaults, start=1):
+        Note.objects.get_or_create(note_text=text, defaults={'display_order': order})
+
+
+def remove_default_notes(apps, schema_editor):
+    Note = apps.get_model('core', 'SupervisionStandardNote')
+    Note.objects.filter(note_text__in=[
+        'Kein mitbest. relevanter Einsatz',
+        'Lizenz-/kostenpflichtig',
+        'Geplant, aber nicht aktiv',
+    ]).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0041_add_supervisor_notes'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SupervisionStandardNote',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('note_text', models.CharField(max_length=100, unique=True)),
+                ('is_active', models.BooleanField(default=True)),
+                ('display_order', models.PositiveIntegerField(default=0)),
+            ],
+            options={
+                'ordering': ['display_order', 'note_text'],
+                'verbose_name': 'Standardnotiz Supervision',
+                'verbose_name_plural': 'Standardnotizen Supervision',
+            },
+        ),
+        migrations.RunPython(add_default_notes, reverse_code=remove_default_notes),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -1073,3 +1073,19 @@ class Anlage3ParserRule(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return self.field_name
+
+
+class SupervisionStandardNote(models.Model):
+    """Vordefinierte Notiz für die Supervision."""
+
+    note_text = models.CharField(max_length=100, unique=True)
+    is_active = models.BooleanField(default=True)
+    display_order = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        ordering = ["display_order", "note_text"]
+        verbose_name = "Standardnotiz Supervision"
+        verbose_name_plural = "Standardnotizen Supervision"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.note_text

--- a/core/urls.py
+++ b/core/urls.py
@@ -312,6 +312,11 @@ urlpatterns = [
         name="hx_supervision_save_notes",
     ),
     path(
+        "hx/supervision/add-note/<int:result_id>/",
+        views.hx_supervision_add_standard_note,
+        name="hx_supervision_add_standard_note",
+    ),
+    path(
         "projects/anlagen/<int:pf_id>/status/",
         views.hx_project_file_status,
         name="hx_project_file_status",

--- a/templates/partials/supervision_group.html
+++ b/templates/partials/supervision_group.html
@@ -3,11 +3,11 @@
     {{ group.function.name }}
     {% if group.subrows %}<span class="ms-2">+</span>{% endif %}
   </summary>
-  {% include 'partials/supervision_row_content.html' with row=group.function %}
+  {% include 'partials/supervision_row_content.html' with row=group.function standard_notes=standard_notes %}
   {% if group.show_subs and group.subrows %}
   <div class="ms-4 space-y-4 mt-2">
     {% for sub in group.subrows %}
-      {% include 'partials/supervision_row.html' with row=sub %}
+      {% include 'partials/supervision_row.html' with row=sub standard_notes=standard_notes %}
     {% endfor %}
   </div>
   {% endif %}

--- a/templates/partials/supervision_row.html
+++ b/templates/partials/supervision_row.html
@@ -3,5 +3,5 @@
     {{ row.name }}
     {% if row.has_discrepancy %}<span class="ms-2 text-red-600">⚠️</span>{% endif %}
   </summary>
-  {% include 'partials/supervision_row_content.html' with row=row %}
+  {% include 'partials/supervision_row_content.html' with row=row standard_notes=standard_notes %}
 </details>

--- a/templates/partials/supervision_row_content.html
+++ b/templates/partials/supervision_row_content.html
@@ -13,6 +13,17 @@
       <button class="bg-green-600 text-white px-2 py-1 rounded ms-2" type="submit">Bestätigen</button>
     </form>
   </div>
+  <div class="space-x-2">
+    {% for note in standard_notes %}
+    <button type="button"
+            hx-post="{% url 'hx_supervision_add_standard_note' row.result_id %}"
+            hx-vals='{"note_text": "{{ note.note_text }}"}'
+            hx-target="closest details" hx-swap="outerHTML"
+            class="bg-gray-200 px-2 py-1 rounded">
+      {{ note.note_text }}
+    </button>
+    {% endfor %}
+  </div>
   <form hx-post="{% url 'hx_supervision_save_notes' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="space-y-2">
     <textarea name="notes" rows="2" class="border rounded w-full p-2">{{ row.notes }}</textarea>
     <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Speichern</button>

--- a/templates/supervision_review.html
+++ b/templates/supervision_review.html
@@ -4,7 +4,7 @@
 <h1 class="text-2xl font-semibold mb-4">Supervision Anlage 2</h1>
 <div class="space-y-4">
   {% for group in rows %}
-    {% include 'partials/supervision_group.html' with group=group %}
+    {% include 'partials/supervision_group.html' with group=group standard_notes=standard_notes %}
   {% empty %}
     <p>Keine Funktionen gefunden.</p>
   {% endfor %}


### PR DESCRIPTION
## Summary
- add model `SupervisionStandardNote`
- preload default notes via data migration
- expose model in admin with editable list view
- load notes in supervision view and add hx endpoint to append them
- render quick note buttons dynamically in supervision templates

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6881fc1a470c832b81883138dbd92f9a