### PR TITLE
Add helper to get latest project file

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -13,6 +13,8 @@ from django.db import DatabaseError
 from django.utils import timezone
 from django_q.tasks import async_task
 
+from .utils import get_project_file
+
 from .models import (
     BVProject,
     BVProjectFile,
@@ -1429,7 +1431,7 @@ def run_conditional_anlage2_check(
                     projekt_id, "subquestion", sub.id, model_name
                 )
 
-    pf = BVProjectFile.objects.filter(projekt_id=projekt_id, anlage_nr=2).first()
+    pf = get_project_file(projekt, 2)
     if pf:
         pf.verification_task_id = ""
         pf.save(update_fields=["verification_task_id"])
@@ -1457,13 +1459,7 @@ def worker_verify_feature(
     )
 
     projekt = BVProject.objects.get(pk=project_id)
-    pf = BVProjectFile.objects.filter(projekt_id=project_id, anlage_nr=2).first()
-
-    pf = (
-        BVProjectFile.objects.filter(projekt_id=project_id, anlage_nr=2)
-        .order_by("id")
-        .first()
-    )
+    pf = get_project_file(projekt, 2)
 
 
     gutachten_text = ""

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .models import BVProject, BVProjectFile
+
+
+def get_project_file(projekt: BVProject, nr: int, version: int | None = None) -> BVProjectFile | None:
+    """Hilfsfunktion zum Abrufen einer Projektdatei.
+
+    Gibt bei Angabe einer ``version`` die entsprechende Datei zurueck. Fehlt die
+    Angabe, wird die aktive Datei mit der hoechsten Versionsnummer geliefert.
+    """
+
+    qs = projekt.anlagen.filter(anlage_nr=nr)
+    if version is not None:
+        return qs.filter(version=version).first()
+    return qs.filter(is_active=True).order_by("-version").first()
+


### PR DESCRIPTION
## Summary
- add `get_project_file` utility
- use helper in supervision and task views
- refactor LLMT tasks to reuse helper

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68822c77e014832ba62327618805ac10