### PR TITLE
Add version comparison workflow

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -392,6 +392,11 @@ urlpatterns = [
         name="projekt_file_edit_json",
     ),
     path(
+        "work/anlage/<int:pk>/compare/",
+        views.compare_versions,
+        name="compare_versions",
+    ),
+    path(
         "work/anlage/<int:pk>/delete-result/",
         views.projekt_file_delete_result,
         name="projekt_file_delete_result",

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -1,0 +1,56 @@
+{% extends 'base.html' %}
+{% load recording_extras %}
+{% block title %}Versionen vergleichen{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Version {{ file.version }} mit Vorgänger vergleichen</h1>
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+  <div>
+    <h2 class="font-semibold">Aktuelle Version (v{{ file.version }})</h2>
+    <pre class="whitespace-pre-wrap border p-2 bg-gray-100">{{ file.manual_analysis_json|default:file.analysis_json|tojson }}</pre>
+  </div>
+  {% if parent %}
+  <div>
+    <h2 class="font-semibold">Vorherige Version (v{{ parent.version }})</h2>
+    <pre class="whitespace-pre-wrap border p-2 bg-gray-100">{{ parent.manual_analysis_json|default:parent.analysis_json|tojson }}</pre>
+  </div>
+  {% endif %}
+</div>
+{% if parent_gaps %}
+<h2 class="text-xl font-semibold mt-6">Offene Gaps aus Version {{ parent.version }}</h2>
+<table class="table-auto w-full border mt-2">
+  <thead>
+    <tr>
+      <th class="border px-2">Funktion</th>
+      <th class="border px-2">Gap-Notizen</th>
+      <th class="border px-2">Aktion</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for gap in parent_gaps %}
+    <tr id="gap-row-{{ gap.id }}">
+      <td class="border px-2">{{ gap.get_lookup_key }}</td>
+      <td class="border px-2">
+        {% if gap.gap_notiz %}<p>{{ gap.gap_notiz|linebreaksbr }}</p>{% endif %}
+        {% if gap.gap_summary %}<p class="mt-1">{{ gap.gap_summary|linebreaksbr }}</p>{% endif %}
+      </td>
+      <td class="border px-2 space-x-2 whitespace-nowrap">
+        <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline">
+          <input type="hidden" name="result_id" value="{{ gap.id }}">
+          <input type="hidden" name="action" value="carry">
+          <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Übernehmen</button>
+        </form>
+        <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline ms-2">
+          <input type="hidden" name="result_id" value="{{ gap.id }}">
+          <input type="hidden" name="action" value="fix">
+          <button type="submit" class="bg-green-600 text-white px-2 py-1 rounded">Behoben</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+<div class="mt-4">
+  <a href="{% url 'projekt_detail' file.projekt.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück zum Projekt</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `compare_versions` view and URL
- show parent/new analysis side by side with gap actions
- redirect to comparison when uploading a new version

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6882352853b8832b80845be8f2af63d9