### PR TITLE
Fix missing variable in projekt_file_edit_json

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3265,6 +3265,13 @@ def projekt_file_edit_json(request, pk):
         anlage = BVProjectFile.objects.get(pk=pk)
     except BVProjectFile.DoesNotExist:
         raise Http404
+    versions = list(
+        BVProjectFile.objects.filter(
+            projekt=anlage.projekt,
+            anlage_nr=anlage.anlage_nr,
+        ).order_by("version")
+    )
+
     if request.method == "GET" and anlage.anlage_nr == 2:
         results = (
             AnlagenFunktionsMetadaten.objects.filter(anlage_datei=anlage)


### PR DESCRIPTION
## Summary
- define `versions` variable in the JSON edit view so the template can render

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68823a587a98832b8b1b3a0b22aebb5f