### PR TITLE
Add processing status to Anlage 2 workflow

### DIFF
--- a/core/migrations/0044_bvprojectfile_processing_status.py
+++ b/core/migrations/0044_bvprojectfile_processing_status.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0043_bvprojectfile_versioning"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="bvprojectfile",
+            name="processing_status",
+            field=models.CharField(
+                default="PENDING",
+                max_length=20,
+                choices=[
+                    ("PENDING", "Ausstehend"),
+                    ("PROCESSING", "In Bearbeitung"),
+                    ("COMPLETE", "Abgeschlossen"),
+                    ("FAILED", "Fehlgeschlagen"),
+                ],
+            ),
+        ),
+    ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -327,6 +327,11 @@ urlpatterns = [
         name="hx_project_file_status",
     ),
     path(
+        "hx_anlage_status/<int:pk>/",
+        views.hx_anlage_status,
+        name="hx_anlage_status",
+    ),
+    path(
         "anlage2/notizen/<int:result_id>/",
         views.edit_gap_notes,
         name="edit_gap_notes",

--- a/templates/partials/anlage_status.html
+++ b/templates/partials/anlage_status.html
@@ -1,0 +1,6 @@
+{% if anlage.processing_status == 'PROCESSING' %}
+<span class="bg-purple-300 text-white px-2 py-1 rounded disabled-btn"><span class="spinner"></span> Initiale Prüfung läuft...</span>
+{% elif anlage.analysis_json %}
+<a href="{% url 'projekt_file_edit_json' anlage.pk %}" class="bg-purple-600 text-white px-2 py-1 rounded">Analyse bearbeiten</a>
+{% endif %}
+

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -59,14 +59,14 @@
             <td class="px-2 py-1 text-center">
                 {% include "partials/check_button.html" with file=a %}
             </td>
-            <td class="px-2 py-1 text-center">
+            <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}"
+                {% if a.anlage_nr == 2 %}
+                    hx-get="{% url 'hx_anlage_status' a.pk %}"
+                    hx-trigger="load, every 5s"
+                    hx-swap="outerHTML"
+                {% endif %}>
             {% if a.anlage_nr == 2 %}
-                {% if a.get_anlage2_state == 'running' %}
-                    <span class="bg-purple-300 text-white px-2 py-1 rounded disabled-btn"><span class="spinner"></span></span>
-                {% elif a.get_anlage2_state == 'parsed' %}
-                    <a href="{% url 'projekt_file_edit_json' a.pk %}"
-                       class="bg-purple-600 text-white px-2 py-1 rounded">Analyse bearbeiten</a>
-                {% endif %}
+                {% include 'partials/anlage_status.html' with anlage=a %}
             {% elif a.anlage_nr == 3 and a.analysis_json %}
                 <a href="{% url 'anlage3_file_review' a.pk %}"
                    class="bg-purple-600 text-white px-2 py-1 rounded">Analyse bearbeiten</a>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -14,6 +14,13 @@
     Zur neuen Supervisions-Ansicht wechseln
   </a>
 </p>
+{% if anlage.processing_status == 'PROCESSING' %}
+<div id="anlage-edit-{{ anlage.pk }}" class="p-4 text-center"
+     hx-get="{% url 'hx_anlage_status' anlage.pk %}"
+     hx-trigger="load, every 5s" hx-swap="outerHTML">
+  <span class="spinner"></span> Initiale Prüfung läuft...
+</div>
+{% else %}
 <div class="bg-white rounded-lg shadow p-4 space-y-4">
 <form method="post" class="space-y-4 mb-4">
     {% csrf_token %}
@@ -157,6 +164,7 @@
     </div>
 </form>
 </div>
+{% endif %}
 {% endblock %}
 {% block extra_js %}
 <script src="{% static 'js/popover.js' %}"></script>

--- a/templates/supervision_review.html
+++ b/templates/supervision_review.html
@@ -3,6 +3,13 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Supervision Anlage 2</h1>
 {% include 'partials/version_switcher.html' %}
+{% if pf.processing_status == 'PROCESSING' %}
+<div id="anlage-edit-{{ pf.pk }}" class="p-4 text-center"
+     hx-get="{% url 'hx_anlage_status' pf.pk %}"
+     hx-trigger="load, every 5s" hx-swap="outerHTML">
+  <span class="spinner"></span> Initiale Prüfung läuft...
+</div>
+{% else %}
 <div class="space-y-4">
   {% for group in rows %}
     {% include 'partials/supervision_group.html' with group=group standard_notes=standard_notes %}
@@ -10,4 +17,5 @@
     <p>Keine Funktionen gefunden.</p>
   {% endfor %}
 </div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `processing_status` field to `BVProjectFile`
- start analysis for Anlage 2 uploads with processing status
- mark status in `run_conditional_anlage2_check`
- provide HTMX endpoint `hx_anlage_status`
- disable editing while initial parsing runs
- update templates for automatic polling

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68825850fee8832b8408db75094f1b1d