### PR TITLE
Implement delete for project file versions

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -412,6 +412,11 @@ urlpatterns = [
         name="projekt_file_delete_result",
     ),
     path(
+        "work/anlage/<int:pk>/delete-version/",
+        views.delete_project_file_version,
+        name="delete_project_file_version",
+    ),
+    path(
         "work/anlage/<int:pk>/reset-all-reviews/",
         views.ajax_reset_all_reviews,
         name="ajax_reset_all_reviews",

--- a/templates/partials/version_switcher.html
+++ b/templates/partials/version_switcher.html
@@ -7,6 +7,14 @@
     {% endfor %}
   </select>
 </div>
+<div class="space-x-2 mb-4">
+  {% for v in versions %}
+  <form method="post" action="{% url 'delete_project_file_version' v.pk %}" class="inline">
+    {% csrf_token %}
+    <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded" onclick="return confirm('Sind Sie sicher?')">v{{ v.version }} löschen</button>
+  </form>
+  {% endfor %}
+</div>
 <script>
   document.getElementById('version-select').addEventListener('change', function(){
     const params = new URLSearchParams(window.location.search);

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -5,12 +5,24 @@
 <h1 class="text-2xl font-semibold mb-4">Version {{ file.version }} mit Vorgänger vergleichen</h1>
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
   <div>
-    <h2 class="font-semibold">Aktuelle Version (v{{ file.version }})</h2>
+    <h2 class="font-semibold">
+      Aktuelle Version (v{{ file.version }})
+      <form method="post" action="{% url 'delete_project_file_version' file.pk %}" class="inline">
+        {% csrf_token %}
+        <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
+      </form>
+    </h2>
     <pre class="whitespace-pre-wrap border p-2 bg-gray-100">{{ file.manual_analysis_json|default:file.analysis_json|tojson }}</pre>
   </div>
   {% if parent %}
   <div>
-    <h2 class="font-semibold">Vorherige Version (v{{ parent.version }})</h2>
+    <h2 class="font-semibold">
+      Vorherige Version (v{{ parent.version }})
+      <form method="post" action="{% url 'delete_project_file_version' parent.pk %}" class="inline">
+        {% csrf_token %}
+        <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
+      </form>
+    </h2>
     <pre class="whitespace-pre-wrap border p-2 bg-gray-100">{{ parent.manual_analysis_json|default:parent.analysis_json|tojson }}</pre>
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary
- add `delete_project_file_version` view with transactional logic
- wire up URL for version deletion
- show delete buttons on version comparison and switcher
- test version deletion behaviour
- extend tests to verify permission and success messages

## Testing
- `python manage.py test core.tests.test_general.ProjektFileVersionDeletionTests --verbosity 2 --keepdb`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_688266706c48832bb1ed7749d937981e