### PR TITLE
Improve responsive layouts

### DIFF
--- a/templates/anlage2/function_list.html
+++ b/templates/anlage2/function_list.html
@@ -1,12 +1,13 @@
 {% extends 'admin_base.html' %}
 {% block title %}Anlage 2 Funktionen{% endblock %}
 {% block admin_content %}
-<h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen</h1>
+<h1 class="text-xl sm:text-2xl font-semibold mb-4">Anlage 2 Funktionen</h1>
 <div class="mb-4 space-x-2">
     <a href="{% url 'anlage2_function_new' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Neue Funktion</a>
     <a href="{% url 'anlage2_function_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
     <a href="{% url 'anlage2_function_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
 </div>
+<div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">
@@ -34,4 +35,5 @@
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,7 +2,8 @@
 {% load recording_extras %}
 {% block title %}Dashboard{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">Meine Aufnahmen</h1>
+<h1 class="text-xl sm:text-2xl font-semibold mb-4">Meine Aufnahmen</h1>
+<div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
         <tr class="text-left border-b">
@@ -23,4 +24,5 @@
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/parser_rules/rule_list.html
+++ b/templates/parser_rules/rule_list.html
@@ -1,7 +1,7 @@
 {% extends 'admin_base.html' %}
 {% block title %}Exakter Parser Regeln{% endblock %}
 {% block admin_content %}
-<h1 class="text-2xl font-semibold mb-4">Regeln für Exakten Parser</h1>
+<h1 class="text-xl sm:text-2xl font-semibold mb-4">Regeln für Exakten Parser</h1>
 <div class="mb-4 space-x-2">
     <a href="{% url 'parser_rule_add' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Neue Regel</a>
     <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
@@ -11,6 +11,7 @@
     <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
     <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
 </div>
+<div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">
@@ -40,4 +41,5 @@
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -2,9 +2,10 @@
 {% load recording_extras %}
 {% block title %}Anlage 1 Review{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen prüfen</h1>
+<h1 class="text-xl sm:text-2xl font-semibold mb-4">Anlage 1 Fragen prüfen</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
+    <div class="overflow-x-auto">
     <table class="table-auto w-full border">
         <thead>
             <tr>
@@ -29,6 +30,7 @@
         {% endfor %}
         </tbody>
     </table>
+    </div>
     <div class="space-x-2 mt-2">
         <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
     </div>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -8,7 +8,7 @@
 {% load recording_extras %}
 {% block title %}Anlage 2 Review{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen prüfen</h1>
+<h1 class="text-xl sm:text-2xl font-semibold mb-4">Anlage 2 Funktionen prüfen</h1>
 <p>
   <a href="{% url 'anlage2_supervision' anlage.projekt.pk %}" class="bg-purple-600 text-white px-3 py-1 rounded">
     Zur neuen Supervisions-Ansicht wechseln
@@ -55,7 +55,7 @@
         <button type="button" id="expand-all-subquestions" class="bg-gray-300 text-black px-2 py-1 rounded">Alle aufklappen</button>
         <button type="button" id="collapse-all-subquestions" class="bg-gray-300 text-black px-2 py-1 rounded">Alle einklappen</button>
     </div>
-    <div class="overflow-x-auto">
+    <div class="overflow-x-auto -mx-4 md:mx-0">
     <table class="table-auto w-full border">
         <thead>
             <tr>

--- a/templates/projekt_file_anlage4_review.html
+++ b/templates/projekt_file_anlage4_review.html
@@ -6,10 +6,11 @@
 {% endblock %}
 {% block title %}Anlage 4 Review{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">Anlage 4 Auswertungen prüfen</h1>
+<h1 class="text-xl sm:text-2xl font-semibold mb-4">Anlage 4 Auswertungen prüfen</h1>
 {% include 'partials/version_switcher.html' %}
 <form method="post" class="space-y-4">
     {% csrf_token %}
+    <div class="overflow-x-auto">
     <table class="table-auto w-full border">
         <thead>
             <tr>
@@ -44,6 +45,7 @@
 {% endfor %}
         </tbody>
     </table>
+    </div>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -29,6 +29,7 @@
 </div>
 {% if parent_gaps %}
 <h2 class="text-xl font-semibold mt-6">Offene Gaps aus Version {{ parent.version }}</h2>
+<div class="overflow-x-auto">
 <table class="table-auto w-full border mt-2">
   <thead>
     <tr>
@@ -61,6 +62,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endif %}
 <div class="mt-4">
   <a href="{% url 'projekt_detail' file.projekt.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück zum Projekt</a>


### PR DESCRIPTION
## Summary
- adjust headings and add `overflow-x-auto` for dashboard list
- wrap Anlage 1 review table for scrolling and tweak heading
- improve mobile view on Anlage 2 review
- enable horizontal scrolling in Anlage 4 review
- make parser rule and function lists mobile friendly
- allow scrolling on version comparison table

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6882838370b0832b8ee312733b3a949a