### PR TITLE
Implement tab-based attachment view

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -580,6 +580,19 @@ class BVProjectFileTests(NoesisTestCase):
         mock_start.assert_called_with(pf)
         self.assertRedirects(resp, reverse("projekt_detail", args=[projekt.pk]))
 
+    def test_hx_project_anlage_returns_table(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+        )
+        self.client.login(username=self.superuser.username, password="pass")
+        url = reverse("hx_project_anlage", args=[projekt.pk, 1])
+        resp = self.client.get(url)
+        self.assertContains(resp, "a.txt")
+        self.assertContains(resp, "Analyse starten")
+
 
 class ProjektFileUploadTests(NoesisTestCase):
     def setUp(self):

--- a/core/urls.py
+++ b/core/urls.py
@@ -332,6 +332,11 @@ urlpatterns = [
         name="hx_anlage_status",
     ),
     path(
+        "hx/project-anlage/<int:pk>/<int:nr>/",
+        views.hx_project_anlage,
+        name="hx_project_anlage",
+    ),
+    path(
         "anlage2/notizen/<int:result_id>/",
         views.edit_gap_notes,
         name="edit_gap_notes",

--- a/core/views.py
+++ b/core/views.py
@@ -2725,11 +2725,8 @@ def projekt_list(request):
 def projekt_detail(request, pk):
     projekt = get_object_or_404(BVProject, pk=pk)
     all_files = projekt.anlagen.all()
-    anlage3_list = all_files.filter(anlage_nr=3)
-    other_anlagen = all_files.exclude(anlage_nr=3)
     reviewed = all_files.filter(manual_reviewed=True).count()
-    page = request.GET.get("a3page")
-    anlage3_page = Paginator(anlage3_list, 10).get_page(page)
+    anlage_numbers = sorted(all_files.values_list("anlage_nr", flat=True).distinct())
     is_admin = request.user.groups.filter(name="admin").exists()
     software_list = projekt.software_list
     knowledge_map = {k.software_name: k for k in projekt.softwareknowledge.all()}
@@ -2748,8 +2745,7 @@ def projekt_detail(request, pk):
         "num_reviewed": reviewed,
         "is_verhandlungsfaehig": projekt.is_verhandlungsfaehig,
         "is_admin": is_admin,
-        "anlage3_page": anlage3_page,
-        "other_anlagen": other_anlagen,
+        "anlage_numbers": anlage_numbers,
 
         "knowledge_rows": knowledge_rows,
         "knowledge_checked": checked,
@@ -4425,6 +4421,19 @@ def hx_anlage_status(request, pk: int):
 
     context = {"anlage": anlage}
     return render(request, "partials/anlage_status.html", context)
+
+
+@login_required
+def hx_project_anlage(request, pk: int, nr: int):
+    """Liefert die Tabelle f\u00fcr die Anlagen eines Projekts."""
+    projekt = get_object_or_404(BVProject, pk=pk)
+
+    if not _user_can_edit_project(request.user, projekt):
+        return HttpResponseForbidden("Nicht berechtigt")
+
+    files = projekt.anlagen.filter(anlage_nr=nr).order_by("version")
+    context = {"files": files, "anlage_nr": nr}
+    return render(request, "partials/anlagen_tab.html", context)
 
 
 @login_required

--- a/templates/partials/anlagen_tab.html
+++ b/templates/partials/anlagen_tab.html
@@ -1,0 +1,51 @@
+<div class="overflow-x-auto">
+<table class="mb-4 w-full text-left">
+    <thead>
+        <tr>
+            <th class="px-2 py-1">Datei</th>
+            <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
+            <th class="px-2 py-1 text-center">Vergleich</th>
+            <th class="px-2 py-1 text-center">Geprüft</th>
+            <th class="px-2 py-1 text-center">Verhandlungsfähig</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for a in files %}
+        <tr class="border-t">
+            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name|basename }}</a></td>
+            <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}"
+                hx-get="{% url 'hx_anlage_status' a.pk %}"
+                hx-trigger="load, every 5s"
+                hx-swap="outerHTML">
+                {% include 'partials/anlage_status.html' with anlage=a %}
+            </td>
+            <td class="px-2 py-1 text-center">
+                {% if a.parent %}
+                    <a href="{% url 'compare_versions' a.pk %}" class="bg-blue-600 text-white px-2 py-1 rounded">Mit Vorgänger vergleichen</a>
+                {% endif %}
+            </td>
+            <td class="px-2 py-1 text-center">
+                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
+                    {% csrf_token %}
+                    <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
+                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
+                        {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
+                    </button>
+                </form>
+            </td>
+            <td class="px-2 py-1 text-center">
+                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'verhandlungsfaehig' %}">
+                    {% csrf_token %}
+                    <input type="hidden" name="value" value="{{ a.verhandlungsfaehig|yesno:'0,1' }}">
+                    <button class="px-2 py-1 rounded {% if a.verhandlungsfaehig %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
+                        {% if a.verhandlungsfaehig %}✓{% else %}✗{% endif %}
+                    </button>
+                </form>
+            </td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="5">Keine Anlagen vorhanden</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+</div>

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -39,124 +39,20 @@
 
 <div class="bg-white rounded-lg shadow p-4">
 <h2 class="text-xl font-semibold mb-4">Anlagen</h2>
-<div class="overflow-x-auto">
-<table class="mb-4 w-full text-left">
-    <thead>
-        <tr>
-            <th class="px-2 py-1">Nr.</th>
-            <th class="px-2 py-1">Datei</th>
-            <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
-            <th class="px-2 py-1 text-center">Vergleich</th>
-            <th class="px-2 py-1 text-center">Geprüft</th>
-            <th class="px-2 py-1 text-center">Verhandlungsfähig</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for a in other_anlagen %}
-        <tr class="border-t">
-            <td class="px-2 py-1">{{ a.anlage_nr }}</td>
-            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">Anlage {{ a.anlage_nr }}</a></td>
-            <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}"
-                hx-get="{% url 'hx_anlage_status' a.pk %}"
-                hx-trigger="load, every 5s"
-                hx-swap="outerHTML">
-            {% include 'partials/anlage_status.html' with anlage=a %}
-            </td>
-            <td class="px-2 py-1 text-center">
-                {% if a.parent %}
-                    <a href="{% url 'compare_versions' a.pk %}"
-                       class="bg-blue-600 text-white px-2 py-1 rounded">Mit Vorgänger vergleichen</a>
-                {% endif %}
-            </td>
-            <td class="px-2 py-1 text-center">
-                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
-                    </button>
-                </form>
-            </td>
-            <td class="px-2 py-1 text-center">
-                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'verhandlungsfaehig' %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="value" value="{{ a.verhandlungsfaehig|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.verhandlungsfaehig %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.verhandlungsfaehig %}✓{% else %}✗{% endif %}
-                    </button>
-                </form>
-            </td>
-        </tr>
-    {% empty %}
-        <tr><td colspan="5">Keine Anlagen vorhanden</td></tr>
+<ul class="flex border-b mb-4" id="anlage-tabs" role="tablist">
+    {% for nr in anlage_numbers %}
+    <li class="mr-2" role="presentation">
+        <button class="px-4 py-2 {% if forloop.first %}bg-gray-200{% else %}bg-gray-100{% endif %}"
+                hx-get="{% url 'hx_project_anlage' projekt.pk nr %}"
+                hx-target="#anlage-tab-content"
+                hx-swap="innerHTML"
+                {% if forloop.first %}hx-trigger="load"{% endif %}>
+            Anlage {{ nr }}
+        </button>
+    </li>
     {% endfor %}
-    </tbody>
-</table>
-</div>
-<details class="mt-4">
-<summary class="cursor-pointer font-semibold">Anlage 3 Dateien ({{ anlage3_page.paginator.count }})</summary>
-<div class="overflow-x-auto mt-2">
-<table class="mb-2 w-full text-left">
-    <thead>
-        <tr>
-            <th class="px-2 py-1">Datei</th>
-            <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
-            <th class="px-2 py-1 text-center">Vergleich</th>
-            <th class="px-2 py-1 text-center">Geprüft</th>
-            <th class="px-2 py-1 text-center">Verhandlungsfähig</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for a in anlage3_page %}
-        <tr class="border-t">
-            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name|basename }}</a></td>
-            <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}"
-                hx-get="{% url 'hx_anlage_status' a.pk %}"
-                hx-trigger="load, every 5s"
-                hx-swap="outerHTML">
-                {% include 'partials/anlage_status.html' with anlage=a %}
-            </td>
-            <td class="px-2 py-1 text-center">
-                {% if a.parent %}
-                    <a href="{% url 'compare_versions' a.pk %}"
-                       class="bg-blue-600 text-white px-2 py-1 rounded">Mit Vorgänger vergleichen</a>
-                {% endif %}
-            </td>
-            <td class="px-2 py-1 text-center">
-                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
-                    </button>
-                </form>
-            </td>
-            <td class="px-2 py-1 text-center">
-                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'verhandlungsfaehig' %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="value" value="{{ a.verhandlungsfaehig|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.verhandlungsfaehig %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.verhandlungsfaehig %}✓{% else %}✗{% endif %}
-                    </button>
-                </form>
-            </td>
-        </tr>
-    {% empty %}
-        <tr><td colspan="5">Keine Anlagen vorhanden</td></tr>
-    {% endfor %}
-    </tbody>
-</table>
-<div class="flex justify-between items-center">
-    {% if anlage3_page.has_previous %}
-        <a href="?a3page={{ anlage3_page.previous_page_number }}" class="px-2 py-1 bg-gray-300 rounded">«</a>
-    {% endif %}
-    <span>Seite {{ anlage3_page.number }} / {{ anlage3_page.paginator.num_pages }}</span>
-    {% if anlage3_page.has_next %}
-        <a href="?a3page={{ anlage3_page.next_page_number }}" class="px-2 py-1 bg-gray-300 rounded">»</a>
-    {% endif %}
-</div>
-</div>
-</details>
+</ul>
+<div id="anlage-tab-content"></div>
 <a href="{% url 'projekt_file_upload' projekt.pk %}" class="bg-blue-600 text-white px-4 py-2 rounded">Anlage hochladen</a>
 </div>
 


### PR DESCRIPTION
## Summary
- render project attachments via new tabbed navigation
- load per-anlage table through `hx_project_anlage`
- provide endpoint and template for tab content
- update tests for new endpoint

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6882a90d98f0832bb3bc07118013f8bf