### PR TITLE
Implement tabbed view for project attachments

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -565,6 +565,19 @@ class BVProjectFileTests(NoesisTestCase):
         resp = self.client.get(url)
         self.assertContains(resp, "Analyse starten")
 
+    def test_hx_project_anlage_tab(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+        )
+        self.client.login(username=self.superuser.username, password="pass")
+        url = reverse("hx_project_anlage_tab", args=[projekt.pk, 1])
+        resp = self.client.get(url)
+        self.assertContains(resp, "a.txt")
+        self.assertContains(resp, "hx-trigger")
+
     def test_trigger_file_analysis_starts_tasks(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         pf = BVProjectFile.objects.create(

--- a/core/urls.py
+++ b/core/urls.py
@@ -332,6 +332,11 @@ urlpatterns = [
         name="hx_anlage_status",
     ),
     path(
+        "hx/project/<int:pk>/anlage/<int:nr>/",
+        views.hx_project_anlage_tab,
+        name="hx_project_anlage_tab",
+    ),
+    path(
         "anlage2/notizen/<int:result_id>/",
         views.edit_gap_notes,
         name="edit_gap_notes",

--- a/templates/partials/anlagen_tab.html
+++ b/templates/partials/anlagen_tab.html
@@ -1,0 +1,66 @@
+{% load recording_extras %}
+{% url 'hx_project_anlage_tab' projekt.pk anlage_nr as base_url %}
+<div class="overflow-x-auto">
+<table class="mb-4 w-full text-left">
+    <thead>
+        <tr>
+            {% if show_nr %}<th class="px-2 py-1">Nr.</th>{% endif %}
+            <th class="px-2 py-1">Datei</th>
+            <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
+            <th class="px-2 py-1 text-center">Vergleich</th>
+            <th class="px-2 py-1 text-center">Geprüft</th>
+            <th class="px-2 py-1 text-center">Verhandlungsfähig</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for a in anlagen %}
+        <tr class="border-t">
+            {% if show_nr %}<td class="px-2 py-1">{{ a.anlage_nr }}</td>{% endif %}
+            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name|basename }}</a></td>
+            <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}"
+                hx-get="{% url 'hx_anlage_status' a.pk %}"
+                hx-trigger="load, every 5s"
+                hx-swap="outerHTML">
+                {% include 'partials/anlage_status.html' with anlage=a %}
+            </td>
+            <td class="px-2 py-1 text-center">
+                {% if a.parent %}
+                    <a href="{% url 'compare_versions' a.pk %}" class="bg-blue-600 text-white px-2 py-1 rounded">Mit Vorgänger vergleichen</a>
+                {% endif %}
+            </td>
+            <td class="px-2 py-1 text-center">
+                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
+                    {% csrf_token %}
+                    <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
+                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
+                        {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
+                    </button>
+                </form>
+            </td>
+            <td class="px-2 py-1 text-center">
+                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'verhandlungsfaehig' %}">
+                    {% csrf_token %}
+                    <input type="hidden" name="value" value="{{ a.verhandlungsfaehig|yesno:'0,1' }}">
+                    <button class="px-2 py-1 rounded {% if a.verhandlungsfaehig %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
+                        {% if a.verhandlungsfaehig %}✓{% else %}✗{% endif %}
+                    </button>
+                </form>
+            </td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="{% if show_nr %}6{% else %}5{% endif %}">Keine Anlagen vorhanden</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% if page_obj %}
+<div class="flex justify-between items-center">
+    {% if page_obj.has_previous %}
+        <a hx-get="{{ base_url }}?page={{ page_obj.previous_page_number }}" hx-target="#anlage-tab-content" class="px-2 py-1 bg-gray-300 rounded">«</a>
+    {% endif %}
+    <span>Seite {{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
+    {% if page_obj.has_next %}
+        <a hx-get="{{ base_url }}?page={{ page_obj.next_page_number }}" hx-target="#anlage-tab-content" class="px-2 py-1 bg-gray-300 rounded">»</a>
+    {% endif %}
+</div>
+{% endif %}
+</div>

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -39,125 +39,17 @@
 
 <div class="bg-white rounded-lg shadow p-4">
 <h2 class="text-xl font-semibold mb-4">Anlagen</h2>
-<div class="overflow-x-auto">
-<table class="mb-4 w-full text-left">
-    <thead>
-        <tr>
-            <th class="px-2 py-1">Nr.</th>
-            <th class="px-2 py-1">Datei</th>
-            <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
-            <th class="px-2 py-1 text-center">Vergleich</th>
-            <th class="px-2 py-1 text-center">Geprüft</th>
-            <th class="px-2 py-1 text-center">Verhandlungsfähig</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for a in other_anlagen %}
-        <tr class="border-t">
-            <td class="px-2 py-1">{{ a.anlage_nr }}</td>
-            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">Anlage {{ a.anlage_nr }}</a></td>
-            <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}"
-                hx-get="{% url 'hx_anlage_status' a.pk %}"
-                hx-trigger="load, every 5s"
-                hx-swap="outerHTML">
-            {% include 'partials/anlage_status.html' with anlage=a %}
-            </td>
-            <td class="px-2 py-1 text-center">
-                {% if a.parent %}
-                    <a href="{% url 'compare_versions' a.pk %}"
-                       class="bg-blue-600 text-white px-2 py-1 rounded">Mit Vorgänger vergleichen</a>
-                {% endif %}
-            </td>
-            <td class="px-2 py-1 text-center">
-                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
-                    </button>
-                </form>
-            </td>
-            <td class="px-2 py-1 text-center">
-                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'verhandlungsfaehig' %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="value" value="{{ a.verhandlungsfaehig|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.verhandlungsfaehig %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.verhandlungsfaehig %}✓{% else %}✗{% endif %}
-                    </button>
-                </form>
-            </td>
-        </tr>
-    {% empty %}
-        <tr><td colspan="5">Keine Anlagen vorhanden</td></tr>
-    {% endfor %}
-    </tbody>
-</table>
-</div>
-<details class="mt-4">
-<summary class="cursor-pointer font-semibold">Anlage 3 Dateien ({{ anlage3_page.paginator.count }})</summary>
-<div class="overflow-x-auto mt-2">
-<table class="mb-2 w-full text-left">
-    <thead>
-        <tr>
-            <th class="px-2 py-1">Datei</th>
-            <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
-            <th class="px-2 py-1 text-center">Vergleich</th>
-            <th class="px-2 py-1 text-center">Geprüft</th>
-            <th class="px-2 py-1 text-center">Verhandlungsfähig</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for a in anlage3_page %}
-        <tr class="border-t">
-            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name|basename }}</a></td>
-            <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}"
-                hx-get="{% url 'hx_anlage_status' a.pk %}"
-                hx-trigger="load, every 5s"
-                hx-swap="outerHTML">
-                {% include 'partials/anlage_status.html' with anlage=a %}
-            </td>
-            <td class="px-2 py-1 text-center">
-                {% if a.parent %}
-                    <a href="{% url 'compare_versions' a.pk %}"
-                       class="bg-blue-600 text-white px-2 py-1 rounded">Mit Vorgänger vergleichen</a>
-                {% endif %}
-            </td>
-            <td class="px-2 py-1 text-center">
-                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
-                    </button>
-                </form>
-            </td>
-            <td class="px-2 py-1 text-center">
-                <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'verhandlungsfaehig' %}">
-                    {% csrf_token %}
-                    <input type="hidden" name="value" value="{{ a.verhandlungsfaehig|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.verhandlungsfaehig %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.verhandlungsfaehig %}✓{% else %}✗{% endif %}
-                    </button>
-                </form>
-            </td>
-        </tr>
-    {% empty %}
-        <tr><td colspan="5">Keine Anlagen vorhanden</td></tr>
-    {% endfor %}
-    </tbody>
-</table>
-<div class="flex justify-between items-center">
-    {% if anlage3_page.has_previous %}
-        <a href="?a3page={{ anlage3_page.previous_page_number }}" class="px-2 py-1 bg-gray-300 rounded">«</a>
-    {% endif %}
-    <span>Seite {{ anlage3_page.number }} / {{ anlage3_page.paginator.num_pages }}</span>
-    {% if anlage3_page.has_next %}
-        <a href="?a3page={{ anlage3_page.next_page_number }}" class="px-2 py-1 bg-gray-300 rounded">»</a>
-    {% endif %}
-</div>
-</div>
-</details>
-<a href="{% url 'projekt_file_upload' projekt.pk %}" class="bg-blue-600 text-white px-4 py-2 rounded">Anlage hochladen</a>
+<nav class="flex space-x-2 mb-4" id="anlage-tabs-nav">
+  {% for nr in anlage_numbers %}
+  <button class="anlage-tab-btn px-3 py-1 border-b-2 {% if forloop.first %}border-blue-600 text-blue-600{% else %}border-transparent text-gray-600{% endif %}"
+          hx-get="{% url 'hx_project_anlage_tab' projekt.pk nr %}"
+          hx-target="#anlage-tab-content" hx-swap="innerHTML" hx-push-url="false">
+    Anlage {{ nr }}
+  </button>
+  {% endfor %}
+</nav>
+<div id="anlage-tab-content" hx-get="{% url 'hx_project_anlage_tab' projekt.pk 1 %}" hx-trigger="load"></div>
+<a href="{% url 'projekt_file_upload' projekt.pk %}" class="bg-blue-600 text-white px-4 py-2 rounded mt-4 inline-block">Anlage hochladen</a>
 </div>
 
 
@@ -431,6 +323,18 @@ document.addEventListener('DOMContentLoaded',function(){
       const modalEl=document.getElementById('contextModal');
       bootstrap.Modal.getInstance(modalEl).hide();
     });
+  }
+});
+
+document.addEventListener('htmx:beforeRequest',function(e){
+  const t=e.target;
+  if(t.classList.contains('anlage-tab-btn')){
+    document.querySelectorAll('.anlage-tab-btn').forEach(b=>{
+      b.classList.remove('border-blue-600','text-blue-600');
+      b.classList.add('border-transparent','text-gray-600');
+    });
+    t.classList.remove('border-transparent','text-gray-600');
+    t.classList.add('border-blue-600','text-blue-600');
   }
 });
 });


### PR DESCRIPTION
## Summary
- add partial template for project file tabs
- provide `hx_project_anlage_tab` view and URL
- adjust project detail page to use tab navigation
- highlight active attachment tab with JS
- test new HTMX endpoint

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: <module 'core.llm_tasks' ...>)*

------
https://chatgpt.com/codex/tasks/task_e_6882a90d98f0832bb3bc07118013f8bf