### PR TITLE
Implement manual analysis trigger for project files

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -526,26 +526,29 @@ class BVProjectFileTests(NoesisTestCase):
 
     def test_hx_anlage_status_ready(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        pf = BVProjectFile.objects.create(
-            projekt=projekt,
-            anlage_nr=2,
-            upload=SimpleUploadedFile("a.txt", b"x"),
-            processing_status=BVProjectFile.COMPLETE,
-            analysis_json={},
-        )
+        with patch("core.signals.start_analysis_for_file"):
+            pf = BVProjectFile.objects.create(
+                projekt=projekt,
+                anlage_nr=2,
+                upload=SimpleUploadedFile("a.txt", b"x"),
+                processing_status=BVProjectFile.COMPLETE,
+                analysis_json={},
+            )
         self.client.login(username=self.superuser.username, password="pass")
         url = reverse("hx_anlage_status", args=[pf.pk])
         resp = self.client.get(url)
         self.assertContains(resp, "Analyse bearbeiten")
+        self.assertContains(resp, "Analyse erneut starten")
 
     def test_hx_anlage_status_failed(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        pf = BVProjectFile.objects.create(
-            projekt=projekt,
-            anlage_nr=2,
-            upload=SimpleUploadedFile("a.txt", b"x"),
-            processing_status=BVProjectFile.FAILED,
-        )
+        with patch("core.signals.start_analysis_for_file"):
+            pf = BVProjectFile.objects.create(
+                projekt=projekt,
+                anlage_nr=2,
+                upload=SimpleUploadedFile("a.txt", b"x"),
+                processing_status=BVProjectFile.FAILED,
+            )
         self.client.login(username=self.superuser.username, password="pass")
         url = reverse("hx_anlage_status", args=[pf.pk])
         resp = self.client.get(url)
@@ -554,12 +557,13 @@ class BVProjectFileTests(NoesisTestCase):
 
     def test_hx_anlage_status_pending(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        pf = BVProjectFile.objects.create(
-            projekt=projekt,
-            anlage_nr=2,
-            upload=SimpleUploadedFile("a.txt", b"x"),
-            processing_status=BVProjectFile.PENDING,
-        )
+        with patch("core.signals.start_analysis_for_file"):
+            pf = BVProjectFile.objects.create(
+                projekt=projekt,
+                anlage_nr=2,
+                upload=SimpleUploadedFile("a.txt", b"x"),
+                processing_status=BVProjectFile.PENDING,
+            )
         self.client.login(username=self.superuser.username, password="pass")
         url = reverse("hx_anlage_status", args=[pf.pk])
         resp = self.client.get(url)

--- a/templates/partials/anlage_status.html
+++ b/templates/partials/anlage_status.html
@@ -12,18 +12,22 @@
 
 {% if anlage.processing_status == 'PROCESSING' %}
 <span class="bg-purple-300 text-white px-2 py-1 rounded disabled-btn"><span class="spinner"></span> Analyse läuft...</span>
-{% elif anlage.processing_status == 'COMPLETE' %}
-<a href="{{ edit_url }}" class="bg-purple-600 text-white px-2 py-1 rounded">Analyse bearbeiten</a>
-{% elif anlage.processing_status == 'FAILED' %}
-<span class="text-red-600 mr-2">Analyse fehlgeschlagen</span>
-<form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">
-  {% csrf_token %}
-  <button class="bg-purple-600 text-white px-2 py-1 rounded">Erneut versuchen</button>
-</form>
 {% else %}
-<form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">
-  {% csrf_token %}
-  <button class="bg-purple-600 text-white px-2 py-1 rounded">Analyse starten</button>
-</form>
+  {% if anlage.processing_status == 'FAILED' %}
+  <span class="text-red-600 mr-2">Analyse fehlgeschlagen</span>
+  {% endif %}
+  {% if anlage.processing_status == 'COMPLETE' %}
+  <a href="{{ edit_url }}" class="bg-purple-600 text-white px-2 py-1 rounded mr-2">Analyse bearbeiten</a>
+  {% endif %}
+  <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">
+    {% csrf_token %}
+    {% if anlage.processing_status == 'COMPLETE' %}
+    <button class="bg-purple-600 text-white px-2 py-1 rounded">Analyse erneut starten</button>
+    {% elif anlage.processing_status == 'FAILED' %}
+    <button class="bg-purple-600 text-white px-2 py-1 rounded">Erneut versuchen</button>
+    {% else %}
+    <button class="bg-purple-600 text-white px-2 py-1 rounded">Analyse starten</button>
+    {% endif %}
+  </form>
 {% endif %}
 

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -45,7 +45,7 @@
         <tr>
             <th class="px-2 py-1">Nr.</th>
             <th class="px-2 py-1">Datei</th>
-            <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
+            <th class="px-2 py-1 text-center">Analyse-Status</th>
             <th class="px-2 py-1 text-center">Vergleich</th>
             <th class="px-2 py-1 text-center">Geprüft</th>
             <th class="px-2 py-1 text-center">Verhandlungsfähig</th>
@@ -100,7 +100,7 @@
     <thead>
         <tr>
             <th class="px-2 py-1">Datei</th>
-            <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
+            <th class="px-2 py-1 text-center">Analyse-Status</th>
             <th class="px-2 py-1 text-center">Vergleich</th>
             <th class="px-2 py-1 text-center">Geprüft</th>
             <th class="px-2 py-1 text-center">Verhandlungsfähig</th>


### PR DESCRIPTION
## Summary
- add manual analysis controls in project detail view
- show button to re-run analysis when processing is complete, pending or failed
- expose analysis status in project detail table headers
- adjust tests for new UI behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_hx_anlage_status_ready -v 2`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_hx_anlage_status_failed -v 2`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_hx_anlage_status_pending -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68832e5298d0832ba16903096b01212c