### PR TITLE
Implement context-sensitive upload preselection

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -674,6 +674,11 @@ class ProjektFileUploadTests(NoesisTestCase):
             pf.pk,
         )
 
+    def test_upload_form_prefills_anlage_nr(self):
+        url = reverse("projekt_file_upload", args=[self.projekt.pk])
+        resp = self.client.get(f"{url}?anlage_nr=4")
+        self.assertContains(resp, '<option value="4" selected>')
+
 
 class AutoApprovalTests(NoesisTestCase):
     """Tests für die automatische Genehmigung von Dokumenten."""

--- a/core/views.py
+++ b/core/views.py
@@ -3074,7 +3074,13 @@ def projekt_file_upload(request, pk):
                     logger.exception("Fehler beim Seitenzählen")
             return redirect("projekt_detail", pk=projekt.pk)
     else:
-        form = BVProjectFileForm()
+        anlage_param = request.GET.get("anlage_nr")
+        initial = {}
+        if anlage_param and anlage_param.isdigit():
+            nr_val = int(anlage_param)
+            if 1 <= nr_val <= 6:
+                initial["anlage_nr"] = nr_val
+        form = BVProjectFileForm(initial=initial)
     return render(request, "projekt_file_form.html", {"form": form, "projekt": projekt})
 
 

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -43,13 +43,16 @@
   {% for nr in anlage_numbers %}
   <button class="anlage-tab-btn px-3 py-1 border-b-2 {% if forloop.first %}border-blue-600 text-blue-600{% else %}border-transparent text-gray-600{% endif %}"
           hx-get="{% url 'hx_project_anlage_tab' projekt.pk nr %}"
-          hx-target="#anlage-tab-content" hx-swap="innerHTML" hx-push-url="false">
+          hx-target="#anlage-tab-content" hx-swap="innerHTML" hx-push-url="false"
+          data-nr="{{ nr }}">
     Anlage {{ nr }}
   </button>
   {% endfor %}
 </nav>
 <div id="anlage-tab-content" hx-get="{% url 'hx_project_anlage_tab' projekt.pk 1 %}" hx-trigger="load"></div>
-<a href="{% url 'projekt_file_upload' projekt.pk %}" class="bg-blue-600 text-white px-4 py-2 rounded mt-4 inline-block">Anlage hochladen</a>
+<a id="upload-link" data-base-url="{% url 'projekt_file_upload' projekt.pk %}"
+   href="{% url 'projekt_file_upload' projekt.pk %}?anlage_nr=1"
+   class="bg-blue-600 text-white px-4 py-2 rounded mt-4 inline-block">Anlage hochladen</a>
 </div>
 
 
@@ -335,6 +338,8 @@ document.addEventListener('htmx:beforeRequest',function(e){
     });
     t.classList.remove('border-transparent','text-gray-600');
     t.classList.add('border-blue-600','text-blue-600');
+    const link=document.getElementById('upload-link');
+    if(link){link.href=`${link.dataset.baseUrl}?anlage_nr=${t.dataset.nr}`;}
   }
 });
 });


### PR DESCRIPTION
## Summary
- make "Anlage hochladen" button aware of active tab
- prefill upload form based on optional `anlage_nr` query parameter
- test that the upload form respects preselection

## Testing
- `python manage.py test core.tests.test_general.ProjektFileUploadTests.test_upload_form_prefills_anlage_nr -v 2`

------
https://chatgpt.com/codex/tasks/task_e_688333f07540832b948f5ced180c709f