### PR TITLE
Add manual reanalysis option

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -526,17 +526,19 @@ class BVProjectFileTests(NoesisTestCase):
 
     def test_hx_anlage_status_ready(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        pf = BVProjectFile.objects.create(
-            projekt=projekt,
-            anlage_nr=2,
-            upload=SimpleUploadedFile("a.txt", b"x"),
-            processing_status=BVProjectFile.COMPLETE,
-            analysis_json={},
-        )
+        with patch("core.signals.start_analysis_for_file"):
+            pf = BVProjectFile.objects.create(
+                projekt=projekt,
+                anlage_nr=2,
+                upload=SimpleUploadedFile("a.txt", b"x"),
+                processing_status=BVProjectFile.COMPLETE,
+                analysis_json={},
+            )
         self.client.login(username=self.superuser.username, password="pass")
         url = reverse("hx_anlage_status", args=[pf.pk])
         resp = self.client.get(url)
         self.assertContains(resp, "Analyse bearbeiten")
+        self.assertContains(resp, "Erneut analysieren")
 
     def test_hx_anlage_status_failed(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")

--- a/templates/partials/anlage_status.html
+++ b/templates/partials/anlage_status.html
@@ -14,6 +14,10 @@
 <span class="bg-purple-300 text-white px-2 py-1 rounded disabled-btn"><span class="spinner"></span> Analyse läuft...</span>
 {% elif anlage.processing_status == 'COMPLETE' %}
 <a href="{{ edit_url }}" class="bg-purple-600 text-white px-2 py-1 rounded">Analyse bearbeiten</a>
+<form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline ml-2">
+  {% csrf_token %}
+  <button class="bg-purple-600 text-white px-2 py-1 rounded">Erneut analysieren</button>
+</form>
 {% elif anlage.processing_status == 'FAILED' %}
 <span class="text-red-600 mr-2">Analyse fehlgeschlagen</span>
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">


### PR DESCRIPTION
## Summary
- add 'Erneut analysieren' button when analysis is complete
- protect tests from auto triggered analysis

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_hx_anlage_status_ready -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6883589e7a1c832bb5832541914a9498