### PR TITLE
Improve status handling for Anlage1 analysis

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -876,11 +876,11 @@ def check_anlage1(projekt_id: int, model_name: str | None = None) -> dict:
     )
 
     save_fields = ["processing_status"]
+    data: dict = {}
     try:
         parsed = parse_anlage1_questions(anlage.text_content)
         answers: dict[str, str | list | None]
         found_nums: dict[str, str | None] = {}
-        data: dict
 
         if parsed:
             anlage1_logger.info("Strukturiertes Dokument erkannt. Parser wird verwendet.")
@@ -1007,9 +1007,11 @@ def check_anlage1(projekt_id: int, model_name: str | None = None) -> dict:
     except Exception:
         anlage.processing_status = BVProjectFile.FAILED
         anlage1_logger.exception("Fehler bei der Analyse von Anlage 1")
-        raise
     finally:
-        anlage.save(update_fields=save_fields)
+        try:
+            anlage.save(update_fields=save_fields)
+        except DatabaseError:
+            anlage1_logger.exception("Fehler beim Speichern des Analyseergebnisses")
 
     return data
 


### PR DESCRIPTION
## Summary
- ensure check_anlage1 initializes `data` before processing
- on failure, avoid raising exception and log instead
- wrap saving in try/except to avoid silent DB errors

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'pypandoc')*

------
https://chatgpt.com/codex/tasks/task_e_688371c8a798832bb568762a0393860b