### PR TITLE
Fix htmx polling in project files

### DIFF
--- a/templates/partials/anlage_status.html
+++ b/templates/partials/anlage_status.html
@@ -10,6 +10,12 @@
   {% url 'projekt_file_edit_json' anlage.pk as edit_url %}
 {% endif %}
 
+<div id="anlage-edit-{{ anlage.pk }}" hx-swap="outerHTML"
+    {% if anlage.processing_status == 'PROCESSING' or anlage.processing_status == 'PENDING' %}
+        hx-get="{% url 'hx_anlage_status' anlage.pk %}"
+        hx-trigger="load, every 5s"
+    {% endif %}>
+
 {% if anlage.processing_status == 'PROCESSING' %}
 <span class="bg-purple-300 text-white px-2 py-1 rounded disabled-btn"><span class="spinner"></span> Analyse läuft...</span>
 {% elif anlage.processing_status == 'COMPLETE' %}
@@ -30,4 +36,6 @@
   <button class="bg-purple-600 text-white px-2 py-1 rounded">Analyse starten</button>
 </form>
 {% endif %}
+
+</div>
 

--- a/templates/partials/anlagen_tab.html
+++ b/templates/partials/anlagen_tab.html
@@ -17,10 +17,7 @@
         <tr class="border-t">
             {% if show_nr %}<td class="px-2 py-1">{{ a.anlage_nr }}</td>{% endif %}
             <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name|basename }}</a></td>
-            <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}"
-                hx-get="{% url 'hx_anlage_status' a.pk %}"
-                hx-trigger="load, every 5s"
-                hx-swap="outerHTML">
+            <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}">
                 {% include 'partials/anlage_status.html' with anlage=a %}
             </td>
             <td class="px-2 py-1 text-center">


### PR DESCRIPTION
## Summary
- keep htmx polling alive for project file analysis
- move polling attributes to `anlage_status` partial

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test -v 0` *(fails: ImportError: cannot import name '_ANLAGE1_INTRO')*

------
https://chatgpt.com/codex/tasks/task_e_68837a4b1988832bb36f11992820b1fb