### PR TITLE
Add version column for attachments

### DIFF
--- a/core/templatetags/recording_extras.py
+++ b/core/templatetags/recording_extras.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import re
 import markdown
 from django import template
 from django.utils.safestring import mark_safe
@@ -10,6 +11,20 @@ register = template.Library()
 @register.filter
 def basename(value):
     return Path(value).name
+
+
+@register.filter
+def clean_filename(value: str) -> str:
+    """Entfernt automatisch angehängte Suffixe aus Dateinamen."""
+    name = Path(value).name
+    stem = Path(name).stem
+    suffix = Path(name).suffix
+    parts = stem.split("_")
+    if len(parts) > 1:
+        last = parts[-1]
+        if re.fullmatch(r"[0-9a-f]{7,}", last) or re.fullmatch(r"v\d+", last):
+            stem = "_".join(parts[:-1])
+    return f"{stem}{suffix}"
 
 
 @register.filter

--- a/templates/partials/anlagen_tab.html
+++ b/templates/partials/anlagen_tab.html
@@ -6,6 +6,7 @@
         <tr>
             {% if show_nr %}<th class="px-2 py-1">Nr.</th>{% endif %}
             <th class="px-2 py-1">Datei</th>
+            <th class="px-2 py-1">Version</th>
             <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
             <th class="px-2 py-1 text-center">Vergleich</th>
             <th class="px-2 py-1 text-center">Geprüft</th>
@@ -16,7 +17,8 @@
     {% for a in anlagen %}
         <tr class="border-t">
             {% if show_nr %}<td class="px-2 py-1">{{ a.anlage_nr }}</td>{% endif %}
-            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name|basename }}</a></td>
+            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name|clean_filename }}</a></td>
+            <td class="px-2 py-1">{{ a.version }}</td>
             <td class="px-2 py-1 text-center" id="anlage-edit-{{ a.pk }}">
                 {% include 'partials/anlage_status.html' with anlage=a %}
             </td>
@@ -45,7 +47,7 @@
             </td>
         </tr>
     {% empty %}
-        <tr><td colspan="{% if show_nr %}6{% else %}5{% endif %}">Keine Anlagen vorhanden</td></tr>
+        <tr><td colspan="{% if show_nr %}7{% else %}6{% endif %}">Keine Anlagen vorhanden</td></tr>
     {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- show project file versions in attachments table
- clean attachment names by stripping autogenerated suffixes

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'pypandoc')*

------
https://chatgpt.com/codex/tasks/task_e_68837eddec18832b8f9b7f24d47d0e25