### PR TITLE
Fix status persistence when analysis tasks fail

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -13,7 +13,7 @@ from django.db import DatabaseError
 from django.utils import timezone
 from django_q.tasks import async_task
 
-from .utils import get_project_file
+from .utils import get_project_file, update_file_status
 
 from .models import (
     BVProject,
@@ -873,6 +873,7 @@ def check_anlage1(projekt_id: int, model_name: str | None = None) -> dict:
         save_fields.append("analysis_json")
     except Exception:
         anlage.processing_status = BVProjectFile.FAILED
+        update_file_status(anlage.pk, BVProjectFile.FAILED)
         anlage1_logger.exception("Fehler bei der Analyse von Anlage 1")
         raise
     finally:
@@ -1379,6 +1380,7 @@ def run_conditional_anlage2_check(
     except Exception:
         if pf:
             pf.processing_status = BVProjectFile.FAILED
+            update_file_status(pf.pk, BVProjectFile.FAILED)
             pf.save(update_fields=["processing_status"])
         raise
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from django_q.tasks import async_task
+from django.db import transaction
 
 from .models import BVProject, BVProjectFile
 
@@ -53,4 +54,13 @@ def start_analysis_for_file(file_obj: BVProjectFile) -> None:
             async_task(func, arg)
         except Exception:
             logger.exception("Fehler beim Starten der Analyse")
+
+
+@transaction.atomic
+def update_file_status(file_id: int, status: str) -> None:
+    """Aktualisiert den Verarbeitungsstatus einer Projektdatei."""
+
+    pf = BVProjectFile.objects.get(pk=file_id)
+    pf.processing_status = status
+    pf.save(update_fields=["processing_status"])
 


### PR DESCRIPTION
## Summary
- add `update_file_status` helper with `transaction.atomic`
- update error handling in `check_anlage1` and `run_conditional_anlage2_check`

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6883807c27d0832bb8cd9e9e1aa788f1