### PR TITLE
Analyse-Task für Datei-IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Alle Antworten der LLMs enthalten Markdown. Im Web werden sie mit
 Der Aufruf
 
 ```bash
-python manage.py check_anlage1 42
+python manage.py check_anlage1 <file_id>
 ```
 
 führt eine hybride Analyse der Systembeschreibung durch. Zunächst versucht der

--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -823,11 +823,10 @@ def _check_anlage(projekt_id: int, nr: int, model_name: str | None = None) -> di
     return data
 
 
-def check_anlage1(projekt_id: int, model_name: str | None = None) -> dict:
+def check_anlage1(file_id: int, model_name: str | None = None) -> dict:
     """Pr\xfcft die erste Anlage nach neuem Schema."""
-    projekt = BVProject.objects.get(pk=projekt_id)
     try:
-        anlage = projekt.anlagen.get(anlage_nr=1)
+        anlage = BVProjectFile.objects.get(pk=file_id)
     except (
         BVProjectFile.DoesNotExist
     ) as exc:  # pragma: no cover - sollte selten passieren

--- a/core/management/commands/check_anlage1.py
+++ b/core/management/commands/check_anlage1.py
@@ -7,10 +7,10 @@ class Command(BaseCommand):
     """Prüft Anlage 1 eines BVProjects."""
 
     def add_arguments(self, parser):
-        parser.add_argument("projekt_id", type=int)
+        parser.add_argument("file_id", type=int)
         parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, model=None, **options):
-        data = check_anlage1(projekt_id, model_name=model)
+    def handle(self, file_id, model=None, **options):
+        data = check_anlage1(file_id, model_name=model)
         text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
         print_markdown(text)

--- a/core/utils.py
+++ b/core/utils.py
@@ -31,7 +31,7 @@ def start_analysis_for_file(file_obj: BVProjectFile) -> None:
     """
 
     task_map: dict[int, list[tuple[str, int]]] = {
-        1: [("core.llm_tasks.check_anlage1", file_obj.projekt.pk)],
+        1: [("core.llm_tasks.check_anlage1", file_obj.pk)],
         2: [
             ("core.llm_tasks.worker_run_anlage2_analysis", file_obj.pk),
             ("core.llm_tasks.run_conditional_anlage2_check", file_obj.pk),


### PR DESCRIPTION
## Summary
- Aufgabe `check_anlage1` akzeptiert nun eine Dateiid
- Analyseaufrufe entsprechend angepasst
- CLI-Befehl und Doku aktualisiert

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688380059a7c832b9887d51a97a5ef45