### PR TITLE
Verbesserte Upload-Funktion mit HTMX

### DIFF
--- a/templates/projekt_file_form.html
+++ b/templates/projekt_file_form.html
@@ -2,7 +2,9 @@
 {% block title %}Anlage hochladen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage hochladen f\u00fcr {{ projekt.title }}</h1>
-<form method="post" enctype="multipart/form-data" class="space-y-4">
+<form method="post" enctype="multipart/form-data" class="space-y-4"
+      hx-post="{% url 'projekt_file_upload' projekt.pk %}"
+      hx-target="#anlage-tab-content" hx-swap="innerHTML" hx-encoding="multipart/form-data">
     {% csrf_token %}
     {{ form.non_field_errors }}
     <div>
@@ -11,8 +13,10 @@
         {{ form.anlage_nr.errors }}
     </div>
     <div>
-        {{ form.upload.label_tag }}<br>
-        {{ form.upload }}
+        {{ form.upload.as_widget(attrs={'class':'hidden','id':'id_upload'}) }}
+        <div id="dropzone" class="border-2 border-dashed p-6 text-center cursor-pointer">
+            Dateien hierher ziehen oder klicken, um auszuwählen
+        </div>
         {{ form.upload.errors }}
     </div>
     {% if form.parser_mode %}
@@ -47,6 +51,23 @@
         {{ form.verhandlungsfaehig }} {{ form.verhandlungsfaehig.label_tag }}
         {{ form.verhandlungsfaehig.errors }}
     </div>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+<button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
 </form>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const dropzone = document.getElementById('dropzone');
+    const input = document.getElementById('id_upload');
+    dropzone.addEventListener('click', () => input.click());
+    dropzone.addEventListener('dragover', e => {e.preventDefault(); dropzone.classList.add('bg-gray-100');});
+    dropzone.addEventListener('dragleave', () => dropzone.classList.remove('bg-gray-100'));
+    dropzone.addEventListener('drop', e => {
+        e.preventDefault();
+        dropzone.classList.remove('bg-gray-100');
+        input.files = e.dataTransfer.files;
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement automatic detection of `anlage_nr` from file name
- allow multi file upload via new `MultiFileInput`
- handle multiple files in `projekt_file_upload` view
- add drag & drop area and HTMX posting for uploads
- test filename detection and multi upload

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ProjektFileUploadTests.test_filename_sets_anlage_nr -v 2` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_688392e8b028832b8348f2bea9e30e01