### PR TITLE
Fix parse view test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2706,7 +2706,7 @@ class ProjektFileCheckResultTests(NoesisTestCase):
         mock_func.assert_called_with(self.projekt.pk, model_name=None)
 
     def test_parse_view_runs_parser(self):
-        url = reverse("projekt_file_parse_anlage2", args=[self.file2.pk])
+        url = reverse("projekt_file_check_view", args=[self.file2.pk])
         with patch("core.views.run_anlage2_analysis") as mock_func:
             mock_func.return_value = []
             resp = self.client.get(url)


### PR DESCRIPTION
## Summary
- update `test_parse_view_runs_parser` to call `projekt_file_check_view`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ProjektFileCheckResultTests.test_parse_view_runs_parser -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6883abafd8e4832ba66faa82e555a9db