### PR TITLE
Update project context test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -3025,10 +3025,13 @@ class ModelSelectionTests(NoesisTestCase):
         )
 
     def test_prompt_save_triggers_async_check(self):
-        url = reverse("projekt_detail", args=[self.projekt.pk])
-        with patch("core.views.async_task") as mock_task:
+        url = reverse("edit_project_context", args=[self.projekt.pk])
+        with patch("core.models.async_task") as mock_task:
             resp = self.client.post(url, {"project_prompt": "Test"})
-        self.assertRedirects(resp, url)
+        self.assertRedirects(
+            resp,
+            reverse("projekt_detail", args=[self.projekt.pk]),
+        )
         mock_task.assert_called_with(
             "core.llm_tasks.run_conditional_anlage2_check",
             self.projekt.pk,


### PR DESCRIPTION
## Summary
- post to `edit_project_context` to trigger async check
- patch `core.models.async_task` when saving project context

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: TemplateSyntaxError: Invalid block tag)*

------
https://chatgpt.com/codex/tasks/task_e_6883aba8f01c832bbf54ec0d092ba9a8