### PR TITLE
Fix async_task mock in ProjektFileUploadTests

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -655,7 +655,8 @@ class ProjektFileUploadTests(NoesisTestCase):
         Anlage2Function.objects.create(name="Login")
 
         url = reverse("projekt_file_upload", args=[self.projekt.pk])
-        with patch("core.views.async_task", return_value="tid1") as mock_async:
+        with patch("core.views.async_task") as mock_async:
+            mock_async.return_value = SimpleNamespace(id="tid1")
             resp = self.client.post(
                 url,
                 {"anlage_nr": 2, "upload": upload, "manual_comment": ""},


### PR DESCRIPTION
## Summary
- adjust mocked async_task to mimic real Task object

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6883ae7c3e48832b94387211e4c76147