### PR TITLE
Fix tests for new hx_anlage_status URL

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -485,7 +485,7 @@ class BVProjectFileTests(NoesisTestCase):
         self.client.login(username=self.superuser.username, password="pass")
         with patch("core.models.fetch") as mock_fetch:
             mock_fetch.return_value = SimpleNamespace(success=None)
-            url = reverse("hx_project_file_status", args=[pf.pk])
+            url = reverse("hx_anlage_status", args=[pf.pk])
             resp = self.client.get(url)
         self.assertContains(resp, "hx-trigger")
         self.assertContains(resp, "spinner")
@@ -501,7 +501,7 @@ class BVProjectFileTests(NoesisTestCase):
         self.client.login(username=self.superuser.username, password="pass")
         with patch("core.models.fetch") as mock_fetch:
             mock_fetch.return_value = SimpleNamespace(success=True)
-            url = reverse("hx_project_file_status", args=[pf.pk])
+            url = reverse("hx_anlage_status", args=[pf.pk])
             resp = self.client.get(url)
         self.assertNotContains(resp, "hx-trigger")
         self.assertContains(resp, "Prüfen")


### PR DESCRIPTION
## Summary
- update hx status tests to use `hx_anlage_status`

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6883ae826b00832ba4ccb6a9471416be