### PR TITLE
Fix parser order in Anlage2ConfigView tests

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -3659,14 +3659,14 @@ class Anlage2ConfigViewTests(NoesisTestCase):
             url,
             self._build_general_data(
                 parser_mode="text_only",
-                parser_order=["text"],
+                parser_order=["exact"],
                 action="save_general",
                 active_tab="general",
             ),
         )
         self.assertRedirects(resp, url + "?tab=general")
         self.cfg.refresh_from_db()
-        self.assertEqual(self.cfg.parser_order, ["text"])
+        self.assertEqual(self.cfg.parser_order, ["exact"])
 
     def test_update_parser_order(self):
         url = reverse("anlage2_config")
@@ -3674,14 +3674,14 @@ class Anlage2ConfigViewTests(NoesisTestCase):
             url,
             self._build_general_data(
                 parser_mode=self.cfg.parser_mode,
-                parser_order=["text"],
+                parser_order=["exact"],
                 action="save_general",
                 active_tab="general",
             ),
         )
         self.assertRedirects(resp, url + "?tab=general")
         self.cfg.refresh_from_db()
-        self.assertEqual(self.cfg.parser_order, ["text"])
+        self.assertEqual(self.cfg.parser_order, ["exact"])
 
     def test_save_table_tab(self):
         url = reverse("anlage2_config")


### PR DESCRIPTION
## Summary
- update parser order for Anlage2ConfigView tests so the form validates

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6883ae85cc4c832bb5b0743a372561c4