### PR TITLE
Verbessere Buttons in Anlagentabelle

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -223,3 +223,44 @@ input[type="submit"]:hover {
     transition: width 0.2s;
     border-radius: 0.25rem;
 }
+/* Table action buttons */
+.table-action-btn {
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    white-space: nowrap;
+    color: #ffffff;
+    display: inline-block;
+}
+
+.table-action-primary {
+    background-color: var(--color-primary);
+}
+
+.table-action-primary:hover {
+    background-color: var(--color-primary-dark);
+}
+
+.table-action-secondary {
+    background-color: #6b7280; /* gray-500 */
+}
+
+.table-action-secondary:hover {
+    background-color: #4b5563; /* gray-700 */
+}
+
+/* Icon-based status toggle */
+.status-toggle-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font-size: 1rem;
+}
+
+.status-toggle-btn:focus {
+    outline: none;
+}
+
+.status-toggle-btn i {
+    pointer-events: none;
+}

--- a/templates/partials/anlage_status.html
+++ b/templates/partials/anlage_status.html
@@ -17,12 +17,12 @@
     {% endif %}>
 
 {% if anlage.processing_status == 'PROCESSING' %}
-<span class="bg-purple-300 text-white px-2 py-1 rounded disabled-btn"><span class="spinner"></span> Analyse läuft...</span>
+<span class="table-action-btn table-action-secondary disabled-btn"><span class="spinner"></span> Analyse läuft...</span>
 {% elif anlage.processing_status == 'COMPLETE' %}
-<a href="{{ edit_url }}" class="bg-purple-600 text-white px-2 py-1 rounded">Analyse bearbeiten</a>
+<a href="{{ edit_url }}" class="table-action-btn table-action-primary">Analyse bearbeiten</a>
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline ml-2">
   {% csrf_token %}
-  <button class="bg-purple-600 text-white px-2 py-1 rounded" title="Erneut analysieren">
+  <button class="table-action-btn table-action-primary" title="Erneut analysieren">
       <i class="fas fa-sync-alt"></i>
   </button>
 </form>
@@ -30,12 +30,12 @@
 <span class="text-red-600 mr-2">Analyse fehlgeschlagen</span>
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">
   {% csrf_token %}
-  <button class="bg-purple-600 text-white px-2 py-1 rounded">Erneut versuchen</button>
+  <button class="table-action-btn table-action-primary">Erneut versuchen</button>
 </form>
 {% else %}
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">
   {% csrf_token %}
-  <button class="bg-purple-600 text-white px-2 py-1 rounded">Analyse starten</button>
+  <button class="table-action-btn table-action-primary">Analyse starten</button>
 </form>
 {% endif %}
 

--- a/templates/partials/anlagen_tab.html
+++ b/templates/partials/anlagen_tab.html
@@ -24,15 +24,19 @@
             </td>
             <td class="px-2 py-1 text-center">
                 {% if a.parent %}
-                    <a href="{% url 'compare_versions' a.pk %}" class="bg-blue-600 text-white px-2 py-1 rounded">Mit Vorgänger vergleichen</a>
+                    <a href="{% url 'compare_versions' a.pk %}" class="table-action-btn table-action-primary">Mit Vorgänger vergleichen</a>
                 {% endif %}
             </td>
             <td class="px-2 py-1 text-center">
                 <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
                     {% csrf_token %}
                     <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
+                    <button class="status-toggle-btn" title="Geprüft umschalten">
+                        {% if a.manual_reviewed %}
+                        <i class="fas fa-check text-green-600"></i>
+                        {% else %}
+                        <i class="fas fa-times text-gray-400"></i>
+                        {% endif %}
                     </button>
                 </form>
             </td>
@@ -40,8 +44,12 @@
                 <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'verhandlungsfaehig' %}">
                     {% csrf_token %}
                     <input type="hidden" name="value" value="{{ a.verhandlungsfaehig|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.verhandlungsfaehig %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
-                        {% if a.verhandlungsfaehig %}✓{% else %}✗{% endif %}
+                    <button class="status-toggle-btn" title="Verhandlungsfähigkeit umschalten">
+                        {% if a.verhandlungsfaehig %}
+                        <i class="fas fa-check text-green-600"></i>
+                        {% else %}
+                        <i class="fas fa-times text-gray-400"></i>
+                        {% endif %}
                     </button>
                 </form>
             </td>


### PR DESCRIPTION
## Summary
- sorge für einheitliche Buttons in der Anlagentabelle
- ersetze Checkboxen durch Icon-Schalter
- führe neue CSS-Klassen für Tabellenbuttons ein

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6883af29b2b8832b8b9f60dc653bbba5