### PR TITLE
Backend parses upload filename for anlage

### DIFF
--- a/static/js/file_upload.js
+++ b/static/js/file_upload.js
@@ -25,7 +25,7 @@
     function validateFile(file, anlageNrDropdown) {
         const nrDropdown = anlageNrDropdown ? parseInt(anlageNrDropdown.value, 10) : null;
         const nrFilename = getAnlageNrFromName(file.name);
-        const anlageNr = nrDropdown || nrFilename;
+        const anlageNr = nrFilename !== null ? nrFilename : nrDropdown;
 
         if (nrFilename === null) {
             return 'Dateiname muss dem Muster anlage_[1-6] entsprechen.';


### PR DESCRIPTION
## Summary
- make backend ignore incoming `anlage_nr` and derive it from upload filename
- fail upload if filename doesn't specify anlage number
- ensure javascript validation relies on the filename number

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6883b5c7bf1c832b9b60b4a3a8d88a8a