### PR TITLE
Auto assign attachments from filename

### DIFF
--- a/static/js/file_upload.js
+++ b/static/js/file_upload.js
@@ -25,7 +25,7 @@
     function validateFile(file, anlageNrDropdown) {
         const nrDropdown = anlageNrDropdown ? parseInt(anlageNrDropdown.value, 10) : null;
         const nrFilename = getAnlageNrFromName(file.name);
-        const anlageNr = nrDropdown || nrFilename;
+        const anlageNr = nrFilename !== null ? nrFilename : nrDropdown;
 
         if (nrFilename === null) {
             return 'Dateiname muss dem Muster anlage_[1-6] entsprechen.';
@@ -49,7 +49,7 @@
         }
         
         // Anlage-Nr im Dropdown automatisch setzen
-        if (anlageNrDropdown && !nrDropdown && nrFilename) {
+        if (anlageNrDropdown && nrFilename !== null) {
             anlageNrDropdown.value = nrFilename;
         }
 


### PR DESCRIPTION
## Summary
- infer attachment number in `projekt_file_upload` from the uploaded filename
- ensure the dropdown reflects the filename and validation uses that number

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6883b5c7bf1c832b9b60b4a3a8d88a8a