### PR TITLE
feat: add docx preview

### DIFF
--- a/static/js/file_upload.js
+++ b/static/js/file_upload.js
@@ -109,8 +109,14 @@
             // PDF-Vorschau (vereinfacht, da komplex)
             thumb.textContent = '📄 PDF Vorschau';
         } else if (acceptedDocxTypes.includes(file.type)) {
-             // DOCX-Vorschau (vereinfacht)
-            thumb.textContent = '📄 DOCX Vorschau';
+            const docxContainer = document.createElement('div');
+            docxContainer.className = 'preview-docx';
+            thumb.appendChild(docxContainer);
+            loadScript('https://cdn.jsdelivr.net/npm/docx-preview@0.3.6/dist/docx-preview.min.js')
+                .then(() => docx.renderAsync(file, docxContainer))
+                .catch(() => {
+                    docxContainer.textContent = 'Vorschau konnte nicht geladen werden';
+                });
         }
 
         const barContainer = document.createElement('div');


### PR DESCRIPTION
## Summary
- load docx-preview from CDN when needed
- render DOCX files in upload preview
- show an error message on rendering failure

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6883c72d667c832bb8041931e4d869e8