### PR TITLE
Implement anlage_nr upload improvements

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -265,7 +265,3 @@ input[type="submit"]:hover {
     pointer-events: none;
 }
 
-/* Rote Hervorhebung für doppelt gewählte Anlagen */
-.preview-item.duplicate {
-    border-color: #dc3545;
-}

--- a/static/js/file_upload.js
+++ b/static/js/file_upload.js
@@ -172,39 +172,6 @@
 
         let currentFiles = [];
 
-        function updateDuplicateStatus() {
-            const counts = {};
-            let hasDuplicate = false;
-
-            for (const item of currentFiles) {
-                counts[item.anlageNr] = (counts[item.anlageNr] || 0) + 1;
-            }
-
-            for (const item of currentFiles) {
-                item.wrapper.classList.remove('duplicate');
-                if (counts[item.anlageNr] > 1) {
-                    item.wrapper.classList.add('duplicate');
-                    hasDuplicate = true;
-                }
-            }
-
-            let warning = document.getElementById('duplicate-warning');
-            if (hasDuplicate) {
-                if (!warning) {
-                    warning = document.createElement('div');
-                    warning.id = 'duplicate-warning';
-                    warning.className = 'text-red-600 p-2 border border-red-400 rounded mb-2';
-                    warning.textContent = 'Mehrere Dateien f\u00fcr dieselbe Anlage ausgew\u00e4hlt.';
-                    container.insertBefore(warning, container.firstChild);
-                }
-            } else if (warning) {
-                warning.remove();
-            }
-
-            const submitButton = form.querySelector('[type=submit]');
-            if (submitButton) submitButton.disabled = hasDuplicate;
-        }
-
         function handleFiles(files) {
             container.innerHTML = ''; // Alte Vorschauen löschen
             currentFiles = [];
@@ -223,17 +190,14 @@
                 const preview = createPreview(file, container, () => {
                     const idx = currentFiles.findIndex(it => it.file === file);
                     if (idx !== -1) currentFiles.splice(idx, 1);
-                    updateDuplicateStatus();
                 }, detectedNr);
                 const item = { file, bar: preview.bar, wrapper: preview.wrapper, select: preview.select, anlageNr: detectedNr };
                 currentFiles.push(item);
                 preview.select.addEventListener('change', () => {
                     item.anlageNr = parseInt(preview.select.value, 10);
-                    updateDuplicateStatus();
                 });
             }
 
-            updateDuplicateStatus();
         }
 
         dropzone.addEventListener('click', () => input.click());


### PR DESCRIPTION
## Summary
- allow passing `anlageNr` when uploading each file
- rely on the provided number in `_save_project_file`
- drop duplicate upload checks from frontend

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6883c745aac0832bbf0dacd639024054