### PR TITLE
Add Selenium test and fix file upload form

### DIFF
--- a/core/tests/test_selenium.py
+++ b/core/tests/test_selenium.py
@@ -1,0 +1,73 @@
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+import unittest
+from django.contrib.auth.models import User
+from django.urls import reverse
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from tempfile import NamedTemporaryFile, mkdtemp
+from pathlib import Path
+from docx import Document
+from core.models import BVProject
+
+class FileUploadDuplicateTests(StaticLiveServerTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        options = webdriver.ChromeOptions()
+        options.add_argument("--headless=new")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        options.add_argument("--disable-gpu")
+        options.add_argument(f"--user-data-dir={mkdtemp()}")
+        try:
+            cls.driver = webdriver.Chrome(options=options)
+        except Exception:
+            raise unittest.SkipTest("Chrome WebDriver not available")
+        cls.driver.implicitly_wait(5)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        super().tearDownClass()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user("selenium", password="pass")
+        cls.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+
+    def _login(self):
+        self.driver.get(self.live_server_url + reverse("login"))
+        self.driver.find_element(By.ID, "id_username").send_keys(self.user.username)
+        pwd = self.driver.find_element(By.ID, "id_password")
+        pwd.send_keys("pass")
+        pwd.submit()
+
+    def test_duplicate_files_show_warning(self):
+        self._login()
+        url = self.live_server_url + reverse("projekt_file_upload", args=[self.projekt.pk])
+        self.driver.get(url)
+        input_el = self.driver.find_element(By.ID, "id_upload")
+
+        doc = Document()
+        doc.add_paragraph("x")
+        f1 = NamedTemporaryFile(prefix="Anlage_1", suffix=".docx", delete=False)
+        doc.save(f1.name)
+        f1.close()
+        f2 = NamedTemporaryFile(prefix="Anlage_1", suffix=".docx", delete=False)
+        doc.save(f2.name)
+        f2.close()
+
+        input_el.send_keys(f1.name + "\n" + f2.name)
+
+        WebDriverWait(self.driver, 5).until(
+            EC.presence_of_element_located((By.ID, "duplicate-warning"))
+        )
+        warning = self.driver.find_element(By.ID, "duplicate-warning")
+        self.assertTrue(warning.is_displayed())
+        submit_btn = self.driver.find_element(By.CSS_SELECTOR, "form button[type=submit]")
+        self.assertFalse(submit_btn.is_enabled())
+
+        Path(f1.name).unlink(missing_ok=True)
+        Path(f2.name).unlink(missing_ok=True)

--- a/templates/projekt_file_form.html
+++ b/templates/projekt_file_form.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load static %}
 {% block title %}Anlage hochladen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage hochladen f\u00fcr {{ projekt.title }}</h1>


### PR DESCRIPTION
## Summary
- enable static tag on file upload form
- test `_save_project_file` preserves provided `anlage_nr`
- add Selenium-based test for duplicate upload detection

## Testing
- `python manage.py test core.tests.test_general.ProjektFileUploadTests.test_save_project_file_respects_form_value`
- `python manage.py test core.tests.test_selenium.FileUploadDuplicateTests.test_duplicate_files_show_warning` *(skipped if WebDriver is unavailable)*
- `python manage.py makemigrations --check`
- `python manage.py migrate`
- `python manage.py test` *(fails: AttributeError in `parse_anlage2_text` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6883c74d8f70832bba7ccb1eb80a0651