### PR TITLE
Remove manual analysis field from upload

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -211,7 +211,6 @@ class BVProjectFileForm(forms.ModelForm):
             "upload",
             "parser_mode",
             "parser_order",
-            "manual_analysis_json",
         ]
         labels = {
             "anlage_nr": "Anlage Nr",
@@ -219,7 +218,6 @@ class BVProjectFileForm(forms.ModelForm):
             "parser_mode": "Parser-Modus",
             "parser_order": "Parser-Reihenfolge",
             "manual_comment": "Kommentar",
-            "manual_analysis_json": "Manuelle Analyse (JSON)",
             "manual_reviewed": "Manuell geprüft",
             "verhandlungsfaehig": "Verhandlungsfähig",
         }
@@ -233,9 +231,6 @@ class BVProjectFileForm(forms.ModelForm):
             ),
             "manual_comment": forms.Textarea(
                 attrs={"class": "border rounded p-2", "rows": 3}
-            ),
-            "manual_analysis_json": forms.Textarea(
-                attrs={"class": "border rounded p-2", "rows": 5}
             ),
             "manual_reviewed": forms.CheckboxInput(attrs={"class": "mr-2"}),
             "verhandlungsfaehig": forms.CheckboxInput(attrs={"class": "mr-2"}),

--- a/templates/projekt_file_form.html
+++ b/templates/projekt_file_form.html
@@ -41,13 +41,6 @@
     {{ form.manual_comment }}
     {{ form.manual_comment.errors }}
 </div>
-{% if form.manual_analysis_json %}
-<div>
-    {{ form.manual_analysis_json.label_tag }}<br>
-    {{ form.manual_analysis_json }}
-    {{ form.manual_analysis_json.errors }}
-</div>
-{% endif %}
 <div>
     {{ form.manual_reviewed }} {{ form.manual_reviewed.label_tag }}
     {{ form.manual_reviewed.errors }}


### PR DESCRIPTION
## Summary
- remove unused `manual_analysis_json` field from `BVProjectFileForm`
- drop manual analysis textarea from the upload form

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6883d4d6f540832b8832536b84215daf