### PR TITLE
Fix validation allowing filenames without pattern

### DIFF
--- a/static/js/file_upload.js
+++ b/static/js/file_upload.js
@@ -26,10 +26,6 @@
         const nrDropdown = anlageNrDropdown ? parseInt(anlageNrDropdown.value, 10) : null;
         const nrFilename = getAnlageNrFromName(file.name);
         const anlageNr = nrFilename !== null ? nrFilename : nrDropdown;
-
-        if (nrFilename === null) {
-            return 'Dateiname muss dem Muster anlage_[1-6] entsprechen.';
-        }
         if (maxSize && file.size > maxSize) {
             const mb = Math.round(maxSize / 1024 / 1024);
             return `Datei zu groß (max. ${mb} MB).`;


### PR DESCRIPTION
## Summary
- relax filename validation to allow uploads without `anlage_[1-6]`

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6883d96978ac832bb8c8dd691306aef5