### PR TITLE
Remove filename-based Anlage detection

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -3,7 +3,6 @@ from django.forms import Textarea, modelformset_factory
 import json
 import logging
 from pathlib import Path
-import re
 from django.conf import settings
 
 
@@ -247,17 +246,6 @@ class BVProjectFileForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        file_obj = (self.files or {}).get("upload")
-        if file_obj and not (self.data.get("anlage_nr") or self.initial.get("anlage_nr")):
-            match = re.search(r"anlage_(\d)", file_obj.name, re.IGNORECASE)
-            if match:
-                num = int(match.group(1))
-                if 1 <= num <= 6:
-                    if self.is_bound:
-                        data = self.data.copy()
-                        data["anlage_nr"] = str(num)
-                        self.data = data
-                    self.initial.setdefault("anlage_nr", num)
         nr = self.data.get("anlage_nr") or self.initial.get("anlage_nr") or getattr(self.instance, "anlage_nr", None)
         if str(nr) != "2":
             self.fields.pop("parser_mode", None)
@@ -268,19 +256,13 @@ class BVProjectFileForm(forms.ModelForm):
                 self.initial["parser_order"] = self.instance.parser_order
 
     def clean_upload(self):
-        """Prüft Dateiname, Größe und Endung abhängig von der Anlagen-Nummer."""
+        """Prüft Größe und Endung abhängig von der Anlagen-Nummer."""
 
         f = self.cleaned_data["upload"]
         ext = Path(f.name).suffix.lower()
         nr = self.cleaned_data.get("anlage_nr") or getattr(
             self.instance, "anlage_nr", None
         )
-
-        name_match = re.search(r"anlage_(\d)", f.name, re.IGNORECASE)
-        if not name_match:
-            raise forms.ValidationError(
-                "Dateiname muss dem Muster anlage_[1-6] entsprechen"
-            )
 
         if f.size > settings.MAX_UPLOAD_SIZE:
             raise forms.ValidationError(

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -250,7 +250,7 @@ class BVProjectFileFormTests(NoesisTestCase):
         form = BVProjectFileForm(
             {"anlage_nr": 1}, {"upload": SimpleUploadedFile("foo.docx", b"d")}
         )
-        self.assertFalse(form.is_valid())
+        self.assertTrue(form.is_valid())
 
     def test_max_size(self):
         form = BVProjectFileForm(


### PR DESCRIPTION
## Summary
- stop auto-detecting `anlage_nr` from uploaded filename
- relax filename validation for BVProjectFileForm uploads
- adjust corresponding form test

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6883d981b794832baa995ec08a381793