### PR TITLE
Add server-side DOCX preview

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -488,6 +488,11 @@ urlpatterns = [
         name="ajax_rerun_initial_check",
     ),
     path(
+        "ajax/docx-preview/",
+        views.ajax_docx_preview,
+        name="ajax_docx_preview",
+    ),
+    path(
         "knowledge/<int:knowledge_id>/edit/",
         views.edit_knowledge_description,
         name="edit_knowledge_description",

--- a/static/js/file_upload.js
+++ b/static/js/file_upload.js
@@ -106,11 +106,22 @@
             thumb.textContent = '📄 PDF Vorschau';
         } else if (acceptedDocxTypes.includes(file.type)) {
             const docxContainer = document.createElement('div');
-            docxContainer.className = 'preview-docx';
+            docxContainer.className = 'preview-docx flex items-center justify-center';
+            docxContainer.innerHTML = '<span class="spinner"></span> wird geladen...';
             thumb.appendChild(docxContainer);
-            loadScript('/static/vendor/jszip.min.js')
-                .then(() => loadScript('/static/vendor/docx-preview.min.js'))
-                .then(() => docx.renderAsync(file, docxContainer))
+
+            const token = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value;
+            const formData = new FormData();
+            formData.append('docx', file);
+            fetch(window.DOCX_PREVIEW_URL, {
+                method: 'POST',
+                headers: token ? { 'X-CSRFToken': token } : {},
+                body: formData
+            })
+                .then(r => r.json())
+                .then(data => {
+                    docxContainer.innerHTML = data.html || 'Keine Vorschau verfügbar';
+                })
                 .catch(() => {
                     docxContainer.textContent = 'Vorschau konnte nicht geladen werden';
                 });

--- a/templates/projekt_file_form.html
+++ b/templates/projekt_file_form.html
@@ -49,6 +49,9 @@
 {% endblock %}
 
 {% block extra_js %}
-<script>window.MAX_UPLOAD_SIZE = {{ max_size|default:10485760 }};</script>
+<script>
+    window.MAX_UPLOAD_SIZE = {{ max_size|default:10485760 }};
+    window.DOCX_PREVIEW_URL = "{% url 'ajax_docx_preview' %}";
+</script>
 <script src="{% static 'js/file_upload.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add asynchronous route to convert DOCX files using pypandoc
- expose the new route in `projekt_file_form.html`
- switch JS preview logic to fetch the server-side conversion

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6884c6bece5c832ba61ce6440d00ad0b