### PR TITLE
Fix template filter loading for markdown

### DIFF
--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -1,3 +1,4 @@
+{% load recording_extras %}
 <div class="overflow-x-auto">
 <table id="knowledge-table" class="mb-4 w-full text-left">
     <thead>


### PR DESCRIPTION
## Summary
- load `recording_extras` in the software tab partial so `markdownify` works

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6885287f730c832bb66f79147736c04f