### PR TITLE
Allow filename based uploads

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -720,6 +720,26 @@ class ProjektFileUploadTests(NoesisTestCase):
         pf = _save_project_file(self.projekt, form)
         self.assertEqual(pf.anlage_nr, 1)
 
+    def test_upload_uses_filename_when_no_anlage_nr(self):
+        doc = Document()
+        doc.add_paragraph("x")
+        tmp = NamedTemporaryFile(delete=False, suffix=".docx")
+        doc.save(tmp.name)
+        tmp.close()
+        with open(tmp.name, "rb") as fh:
+            upload = SimpleUploadedFile("Anlage_4.docx", fh.read())
+        Path(tmp.name).unlink(missing_ok=True)
+
+        url = reverse("projekt_file_upload", args=[self.projekt.pk])
+        resp = self.client.post(
+            url,
+            {"upload": upload, "manual_comment": ""},
+            format="multipart",
+        )
+        self.assertEqual(resp.status_code, 302)
+        pf = self.projekt.anlagen.get()
+        self.assertEqual(pf.anlage_nr, 4)
+
 
 class AutoApprovalTests(NoesisTestCase):
     """Tests für die automatische Genehmigung von Dokumenten."""

--- a/core/views.py
+++ b/core/views.py
@@ -3128,10 +3128,17 @@ def projekt_file_upload(request, pk):
         upload = request.FILES.get("upload")
         anlage_nr_raw = request.POST.get("anlage_nr")
 
-        if not upload or not anlage_nr_raw or not anlage_nr_raw.isdigit():
+        if not upload:
             return HttpResponseBadRequest("invalid")
 
-        anlage_nr = int(anlage_nr_raw)
+        if not anlage_nr_raw or not anlage_nr_raw.isdigit():
+            try:
+                anlage_nr = extract_anlage_nr(upload.name)
+            except ValueError:
+                return HttpResponseBadRequest("invalid")
+        else:
+            anlage_nr = int(anlage_nr_raw)
+
         if not 1 <= anlage_nr <= 6:
             return HttpResponseBadRequest("invalid")
 


### PR DESCRIPTION
## Summary
- infer the Anlage number from file names when none is posted
- exercise filename extraction in tests

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest core/tests/test_general.py::ProjektFileUploadTests::test_upload_uses_filename_when_no_anlage_nr -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6885e757c680832b99868d58cd82c4c5