### PR TITLE
Allow saving with duplicate attachments

### DIFF
--- a/static/js/file_upload.js
+++ b/static/js/file_upload.js
@@ -199,10 +199,11 @@
                 dupWarning.textContent = hasMissing
                     ? 'Bitte jeder Datei eine eindeutige Nummer zuweisen.'
                     : 'Mehrere Dateien besitzen dieselbe Anlage-Nummer.';
-                if (submitButton) submitButton.disabled = true;
+                // Der Submit-Button bleibt aktiv, Nutzer wird nur gewarnt
+                // if (submitButton) submitButton.disabled = true;
             } else {
                 dupWarning.classList.add('hidden');
-                if (submitButton) submitButton.disabled = false;
+                // if (submitButton) submitButton.disabled = false;
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid disabling submit button when duplicate attachments are detected

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688614b71fd4832b9da3039df03c983f