### PR TITLE
fix: load static tags in projekt detail template

### DIFF
--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load static %}
 {% load recording_extras %}
 {% block title %}Projekt {{ projekt.title }}{% endblock %}
 {% block content %}


### PR DESCRIPTION
## Summary
- load static tags in projekt detail template to avoid invalid tag error

## Testing
- `DJANGO_SECRET_KEY=foo python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_688624d5f39c832b9bbeeb2e2841d9ec