### PR TITLE
Enable drag-and-drop upload in project detail

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3148,15 +3148,12 @@ def projekt_file_upload(request, pk):
             return HttpResponseBadRequest(str(e))
 
         if request.headers.get("HX-Request"):
-            files_qs = projekt.anlagen.filter(anlage_nr=saved_file.anlage_nr).order_by("-version")
             context = {
                 "projekt": projekt,
-                "anlagen": files_qs,
-                "page_obj": None,
-                "anlage_nr": saved_file.anlage_nr,
+                "anlage": saved_file,
                 "show_nr": False,
             }
-            return render(request, "partials/anlagen_tab.html", context)
+            return render(request, "partials/anlagen_row.html", context)
 
         return redirect("projekt_detail", pk=projekt.pk)
 

--- a/static/js/anlagen_dropzone.js
+++ b/static/js/anlagen_dropzone.js
@@ -1,28 +1,38 @@
-// Modul zur Handhabung von Datei-Uploads direkt im Anlagen-Tab
+// Modul zur Aktivierung der Dropzone im Anlagen-Tab
 import { getCookie } from './utils.js';
 
 function initDropzone() {
     const dropzone = document.getElementById('anlage-dropzone');
     if (!dropzone) return;
+
     const input = dropzone.querySelector('input[type=file]');
     const uploadUrl = dropzone.dataset.uploadUrl;
     const anlageNr = dropzone.dataset.anlageNr;
 
+    const tableBody = document.querySelector('#anlage-tab-content tbody');
+    const colCount = document.querySelector('#anlage-tab-content thead tr')?.children.length || 1;
+
+    const addPlaceholder = (file) => {
+        const id = 'upload-' + Math.random().toString(36).slice(2, 9);
+        const tr = document.createElement('tr');
+        tr.id = id;
+        tr.innerHTML = `<td colspan="${colCount}"><span class="spinner"></span> ${file.name}</td>`;
+        if (tableBody) {
+            tableBody.prepend(tr);
+        }
+        return id;
+    };
+
     const sendFile = (file) => {
-        const formData = new FormData();
-        formData.append('upload', file);
-        formData.append('anlage_nr', anlageNr);
-        fetch(uploadUrl, {
-            method: 'POST',
-            body: formData,
-            headers: {
-                'X-CSRFToken': getCookie('csrftoken') || '',
-                'HX-Request': 'true'
-            }
-        })
-        .then(r => r.text())
-        .then(html => {
-            document.getElementById('anlage-tab-content').innerHTML = html;
+        const placeholderId = addPlaceholder(file);
+        const values = { upload: file };
+        if (anlageNr) values['anlage_nr'] = anlageNr;
+
+        htmx.ajax('POST', uploadUrl, {
+            target: '#' + placeholderId,
+            swap: 'outerHTML',
+            headers: { 'X-CSRFToken': getCookie('csrftoken') || '' },
+            values: values
         });
     };
 
@@ -32,20 +42,21 @@ function initDropzone() {
     };
 
     dropzone.addEventListener('click', () => input && input.click());
-    dropzone.addEventListener('dragover', e => {
+    dropzone.addEventListener('dragover', (e) => {
         e.preventDefault();
         dropzone.classList.add('bg-gray-100');
     });
     dropzone.addEventListener('dragleave', () => dropzone.classList.remove('bg-gray-100'));
-    dropzone.addEventListener('drop', e => {
+    dropzone.addEventListener('drop', (e) => {
         e.preventDefault();
         dropzone.classList.remove('bg-gray-100');
         if (e.dataTransfer.files.length) {
             handleFiles(e.dataTransfer.files);
         }
     });
+
     if (input) {
-        input.addEventListener('change', e => handleFiles(e.target.files));
+        input.addEventListener('change', (e) => handleFiles(e.target.files));
     }
 }
 


### PR DESCRIPTION
## Summary
- implement client-side logic for the new dropzone
- return a single table row when uploading via HTMX

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688627b45ec8832bb63843e13ba952db