### PR TITLE
Fix race condition by disabling HTMX uploads

### DIFF
--- a/templates/partials/anlagen_row.html
+++ b/templates/partials/anlagen_row.html
@@ -2,7 +2,7 @@
 {% if form %}
 <tr>
     <td colspan="{% if show_nr %}7{% else %}6{% endif %}">
-        <form hx-post="{% url 'hx_project_file_upload' projekt.pk %}" hx-target="closest tr" hx-swap="outerHTML" hx-encoding="multipart/form-data" enctype="multipart/form-data" method="post">
+        <form method="post" enctype="multipart/form-data" action="{% url 'hx_project_file_upload' projekt.pk %}">
             {% csrf_token %}
             <input type="hidden" name="anlage_nr" value="{{ form.anlage_nr }}">
             {{ form.non_field_errors }}

--- a/templates/projekt_file_form.html
+++ b/templates/projekt_file_form.html
@@ -3,9 +3,7 @@
 {% block title %}Anlage hochladen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage(n) hochladen für {{ projekt.title }}</h1>
-<form method="post" enctype="multipart/form-data" class="space-y-4"
-      hx-post="{% url 'projekt_file_upload' projekt.pk %}"
-      hx-target="#anlage-tab-content" hx-swap="innerHTML" hx-encoding="multipart/form-data">
+<form method="post" enctype="multipart/form-data" class="space-y-4" action="{% url 'projekt_file_upload' projekt.pk %}">
     {% csrf_token %}
     {{ form.non_field_errors }}
     <div>


### PR DESCRIPTION
## Summary
- disable `hx-post` usage in project upload forms
- keep Dropzone JS handler as the sole upload mechanism

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6886322070e4832ba341bdd7ee107581