### PR TITLE
Implement dropzone upload fixes

### DIFF
--- a/templates/partials/anlagen_assign_row.html
+++ b/templates/partials/anlagen_assign_row.html
@@ -1,0 +1,15 @@
+<tr>
+    <td colspan="{% if show_nr %}7{% else %}6{% endif %}">
+        <form hx-post="{% url 'projekt_file_upload' projekt.pk %}" hx-target="closest tr" hx-swap="outerHTML" class="space-x-2">
+            {% csrf_token %}
+            <input type="hidden" name="temp_id" value="{{ temp_id }}">
+            <span>Zu welcher Anlage gehört '{{ filename }}'?</span>
+            <select name="anlage_nr" class="border rounded p-1 mx-2">
+                {% for n in numbers %}
+                <option value="{{ n }}">{{ n }}</option>
+                {% endfor %}
+            </select>
+            <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Speichern</button>
+        </form>
+    </td>
+</tr>

--- a/templates/partials/anlagen_tab.html
+++ b/templates/partials/anlagen_tab.html
@@ -35,7 +35,7 @@
 </div>
 
 <div id="anlage-dropzone" data-upload-url="{% url 'projekt_file_upload' projekt.pk %}"
-     data-anlage-nr="{{ anlage_nr }}" data-colspan="{% if show_nr %}7{% else %}6{% endif %}"
+     data-colspan="{% if show_nr %}7{% else %}6{% endif %}"
      class="border-2 border-dashed border-gray-400 p-6 text-center cursor-pointer mt-4">
     Dateien hierher ziehen oder klicken zum Auswählen
     <input type="file" class="hidden" multiple>


### PR DESCRIPTION
## Summary
- make dropzone init idempotent and handle server response
- move upload logic to backend and add manual assignment form
- reload tab on success and highlight selected tab
- add tests for new workflow

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_688636b231a0832bb212f76743c544d9