### PR TITLE
fix: pass project id to run_conditional_anlage2_check

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -333,7 +333,10 @@ class BVProjectFile(models.Model):
         if self.anlage_nr == 2:
             return [
                 ("core.llm_tasks.worker_run_anlage2_analysis", self.pk),
-                ("core.llm_tasks.run_conditional_anlage2_check", self.pk),
+                (
+                    "core.llm_tasks.run_conditional_anlage2_check",
+                    self.projekt.pk,
+                ),
             ]
         if self.anlage_nr == 3:
             return [("core.llm_tasks.analyse_anlage3", self.projekt.pk)]

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -626,6 +626,22 @@ class BVProjectFileTests(NoesisTestCase):
         mock_start.assert_called_with(pf)
         self.assertRedirects(resp, reverse("projekt_detail", args=[projekt.pk]))
 
+    def test_get_analysis_tasks_returns_project_id_for_conditional_check(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+        )
+        tasks = pf.get_analysis_tasks()
+        self.assertEqual(
+            tasks,
+            [
+                ("core.llm_tasks.worker_run_anlage2_analysis", pf.pk),
+                ("core.llm_tasks.run_conditional_anlage2_check", projekt.pk),
+            ],
+        )
+
 
 class ProjektFileUploadTests(NoesisTestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- ensure BVProjectFile passes the project ID to `run_conditional_anlage2_check`
- add unit test for `get_analysis_tasks`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'selenium', AttributeError in tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6886512a0844832b93a33cea32a3125c