### PR TITLE
Implement status decorator for analysis tasks

### DIFF
--- a/core/management/commands/analyse_anlage4.py
+++ b/core/management/commands/analyse_anlage4.py
@@ -7,10 +7,10 @@ class Command(BaseCommand):
     """Analysiert Anlage 4 eines BVProjects."""
 
     def add_arguments(self, parser):
-        parser.add_argument("projekt_id", type=int)
+        parser.add_argument("file_id", type=int)
         parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, model=None, **options):
-        data = analyse_anlage4_async(projekt_id, model_name=model)
+    def handle(self, file_id, model=None, **options):
+        data = analyse_anlage4_async(file_id, model_name=model)
         text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
         print_markdown(text)

--- a/core/management/commands/check_anlage2_functions.py
+++ b/core/management/commands/check_anlage2_functions.py
@@ -8,9 +8,9 @@ class Command(BaseCommand):
     """Pr\u00fcft alle Anlage-2-Funktionen eines Projekts."""
 
     def add_arguments(self, parser):
-        parser.add_argument("projekt_id", type=int)
+        parser.add_argument("file_id", type=int)
         parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, model=None, **options):
-        run_conditional_anlage2_check(projekt_id, model_name=model)
+    def handle(self, file_id, model=None, **options):
+        run_conditional_anlage2_check(file_id, model_name=model)
         print_markdown("Prüfung abgeschlossen")

--- a/core/management/commands/check_anlage5.py
+++ b/core/management/commands/check_anlage5.py
@@ -7,9 +7,9 @@ class Command(BaseCommand):
     """Prüft Anlage 5 eines BVProjects."""
 
     def add_arguments(self, parser):
-        parser.add_argument("projekt_id", type=int)
+        parser.add_argument("file_id", type=int)
 
-    def handle(self, projekt_id, **options):
-        data = check_anlage5(projekt_id)
+    def handle(self, file_id, **options):
+        data = check_anlage5(file_id)
         text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
         print_markdown(text)

--- a/core/models.py
+++ b/core/models.py
@@ -333,17 +333,14 @@ class BVProjectFile(models.Model):
         if self.anlage_nr == 2:
             return [
                 ("core.llm_tasks.worker_run_anlage2_analysis", self.pk),
-                (
-                    "core.llm_tasks.run_conditional_anlage2_check",
-                    self.projekt.pk,
-                ),
+                ("core.llm_tasks.run_conditional_anlage2_check", self.pk),
             ]
         if self.anlage_nr == 3:
-            return [("core.llm_tasks.analyse_anlage3", self.projekt.pk)]
+            return [("core.llm_tasks.analyse_anlage3", self.pk)]
         if self.anlage_nr == 4:
-            return [("core.llm_tasks.analyse_anlage4_async", self.projekt.pk)]
+            return [("core.llm_tasks.analyse_anlage4_async", self.pk)]
         if self.anlage_nr == 5:
-            return [("core.llm_tasks.check_anlage5", self.projekt.pk)]
+            return [("core.llm_tasks.check_anlage5", self.pk)]
         return []
 
 

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1138,7 +1138,7 @@ class AnalyseAnlage4AsyncTests(NoesisTestCase):
             "core.llm_tasks.query_llm",
             return_value='{"plausibilitaet":"hoch","score":0.8,"begruendung":"ok"}',
         ):
-            analyse_anlage4_async(projekt.pk)
+            analyse_anlage4_async(pf.pk)
 
         pf.refresh_from_db()
         results = pf.analysis_json["items"]
@@ -1168,7 +1168,7 @@ class AnalyseAnlage4AsyncTests(NoesisTestCase):
         ) as m_std, patch("core.llm_tasks.async_task") as m_task, patch(
             "core.llm_tasks.query_llm", return_value="{}"
         ):
-            analyse_anlage4_async(projekt.pk)
+            analyse_anlage4_async(pf.pk)
         m_dual.assert_called_once_with(pf)
         m_std.assert_not_called()
 
@@ -1225,7 +1225,7 @@ class ProjektFileAnalyseAnlage4ViewTests(NoesisTestCase):
             mock_func.return_value = {}
             resp = self.client.get(url)
         self.assertRedirects(resp, reverse("anlage4_review", args=[self.file.pk]))
-        mock_func.assert_called_with(self.projekt.pk)
+        mock_func.assert_called_with(self.file.pk)
 
     def test_post_runs_analysis_and_redirects(self):
         url = reverse("projekt_file_analyse_anlage4", args=[self.file.pk])
@@ -1233,7 +1233,7 @@ class ProjektFileAnalyseAnlage4ViewTests(NoesisTestCase):
             mock_func.return_value = {}
             resp = self.client.post(url)
         self.assertRedirects(resp, reverse("anlage4_review", args=[self.file.pk]))
-        mock_func.assert_called_with(self.projekt.pk)
+        mock_func.assert_called_with(self.file.pk)
 
 
 class WorkerAnlage4EvaluateTests(NoesisTestCase):

--- a/core/views.py
+++ b/core/views.py
@@ -3381,7 +3381,7 @@ def projekt_file_analyse_anlage4(request, pk):
     anlage = get_object_or_404(BVProjectFile, pk=pk)
     if anlage.anlage_nr != 4:
         raise Http404
-    analyse_anlage4_async(anlage.projekt_id)
+    analyse_anlage4_async(anlage.pk)
     return redirect("anlage4_review", pk=pk)
 
 
@@ -3884,11 +3884,13 @@ def projekt_functions_check(request, pk):
     """Löst die Einzelprüfung der Anlage-2-Funktionen aus."""
     model = request.POST.get("model")
     projekt = get_object_or_404(BVProject, pk=pk)
-    async_task(
-        "core.llm_tasks.run_conditional_anlage2_check",
-        projekt.pk,
-        model,
-    )
+    pf = BVProjectFile.objects.filter(projekt=projekt, anlage_nr=2).first()
+    if pf:
+        async_task(
+            "core.llm_tasks.run_conditional_anlage2_check",
+            pf.pk,
+            model,
+        )
     return JsonResponse({"status": "ok"})
 
 


### PR DESCRIPTION
## Summary
- add `updates_file_status` decorator
- use decorator for Anlage 3, 4 and 5 async tasks
- pass file IDs in `get_analysis_tasks`
- adjust management commands, views and tests

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688665ba4918832b809c9bcfa35a27a8