### PR TITLE
Fix parser retrieval per version

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -949,13 +949,7 @@ class AnlagenFunktionsMetadaten(models.Model):
         if self.is_negotiable_manual_override is not None:
             return self.is_negotiable_manual_override
 
-        pf = (
-            self.anlage_datei.projekt.anlagen.filter(anlage_nr=2)
-            .order_by("id")
-            .first()
-        )
-        if not pf:
-            return False
+        pf = self.anlage_datei
 
         parser_entry = (
             FunktionsErgebnis.objects.filter(

--- a/core/views.py
+++ b/core/views.py
@@ -496,19 +496,10 @@ def _build_row_data(
         result_obj = result_map.get(parent_key)
 
     if result_obj:
-        pf = (
-            result_obj.anlage_datei.projekt.anlagen
-            .filter(anlage_nr=2)
-            .order_by("id")
-            .first()
-        )
+        pf = result_obj.anlage_datei
         parser_entry = (
             FunktionsErgebnis.objects.filter(
-
-
                 anlage_datei=pf,
-
-
                 funktion=result_obj.funktion,
                 subquestion=result_obj.subquestion,
                 quelle="parser",
@@ -518,10 +509,7 @@ def _build_row_data(
         )
         ai_entry = (
             FunktionsErgebnis.objects.filter(
-
-
                 anlage_datei=pf,
-
                 funktion=result_obj.funktion,
                 subquestion=result_obj.subquestion,
                 quelle="ki",


### PR DESCRIPTION
## Summary
- load parser results using the current file
- use current file in negotiable property

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_688670afcf88832badbe2a1fb86f891b