### PR TITLE
Add asynchronous project cockpit

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -352,6 +352,11 @@ urlpatterns = [
         name="hx_project_file_upload",
     ),
     path(
+        "hx/project/<int:pk>/cockpit/",
+        views.hx_project_cockpit,
+        name="hx_project_cockpit",
+    ),
+    path(
         "anlage2/notizen/<int:result_id>/",
         views.edit_gap_notes,
         name="edit_gap_notes",

--- a/core/views.py
+++ b/core/views.py
@@ -197,6 +197,31 @@ def _user_can_edit_project(user: User, projekt: BVProject) -> bool:
     return False
 
 
+def get_cockpit_context(projekt: BVProject) -> dict:
+    """Ermittelt Kennzahlen für das Projektcockpit."""
+
+    all_files = projekt.anlagen.all()
+    reviewed = all_files.filter(manual_reviewed=True).count()
+
+    software_list = projekt.software_list
+    knowledge_map = {k.software_name: k for k in projekt.softwareknowledge.all()}
+    checked = 0
+    for name in software_list:
+        entry = knowledge_map.get(name)
+        if entry and entry.last_checked:
+            checked += 1
+
+    return {
+        "projekt": projekt,
+        "history": projekt.status_history.all(),
+        "num_attachments": all_files.count(),
+        "num_reviewed": reviewed,
+        "is_verhandlungsfaehig": projekt.is_verhandlungsfaehig,
+        "knowledge_checked": checked,
+        "total_software": len(software_list),
+    }
+
+
 FIELD_RENAME = {
     "technisch_verfuegbar": "technisch_vorhanden",
     "einsatz_telefonica": "einsatz_bei_telefonica",
@@ -4553,7 +4578,9 @@ def hx_anlage_status(request, pk: int):
         return HttpResponseForbidden("Nicht berechtigt")
 
     context = {"anlage": anlage}
-    return render(request, "partials/anlage_status.html", context)
+    response = render(request, "partials/anlage_status.html", context)
+    response.headers["HX-Trigger"] = "refresh-cockpit"
+    return response
 
 
 @login_required
@@ -4625,6 +4652,15 @@ def hx_project_software_tab(request, pk: int, tab: str):
 
 
 @login_required
+def hx_project_cockpit(request, pk: int):
+    """Lädt die Cockpit-Ansicht eines Projekts per HTMX."""
+
+    projekt = get_object_or_404(BVProject, pk=pk)
+    context = get_cockpit_context(projekt)
+    return render(request, "projekt_cockpit.html", context)
+
+
+@login_required
 @require_POST
 def hx_project_file_upload(request, pk: int):
     """Lädt eine einzelne Datei per HTMX hoch."""
@@ -4654,14 +4690,18 @@ def hx_project_file_upload(request, pk: int):
             "anlage": saved_file,
             "show_nr": False,
         }
-        return render(request, "partials/anlagen_row.html", context)
+        response = render(request, "partials/anlagen_row.html", context)
+        response.headers["HX-Trigger"] = "refresh-cockpit"
+        return response
 
     context = {
         "projekt": projekt,
         "form": form,
         "show_nr": False,
     }
-    return render(request, "partials/anlagen_row.html", context, status=400)
+    response = render(request, "partials/anlagen_row.html", context, status=400)
+    response.headers["HX-Trigger"] = "refresh-cockpit"
+    return response
 
 
 @login_required

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -35,3 +35,9 @@ document.body.addEventListener('htmx:configRequest', (evt) => {
     const token = getCookie('csrftoken');
     if (token) evt.detail.headers['X-CSRFToken'] = token;
 });
+
+document.body.addEventListener('refresh-cockpit', () => {
+    if (window.htmx) {
+        htmx.trigger('#projekt-cockpit', 'refresh-cockpit');
+    }
+});

--- a/templates/projekt_cockpit.html
+++ b/templates/projekt_cockpit.html
@@ -1,0 +1,16 @@
+<div class="bg-gray-100 p-4 rounded">
+  <h3 class="font-semibold mb-2">Projektinfo</h3>
+  <p><strong>Erstellt am:</strong> {{ projekt.created_at|date:"d.m.Y" }}</p>
+  <p class="mt-1"><strong>Software:</strong> {{ projekt.software_string }}</p>
+  <p class="mt-1"><strong>Anlagen:</strong> {{ num_attachments }}</p>
+  <p class="mt-1"><strong>Gutachten vorhanden:</strong> {% if projekt.gutachten_file %}Ja{% else %}Nein{% endif %}</p>
+  <p class="mt-1"><strong>Geprüft:</strong> {{ num_reviewed }} / {{ num_attachments }}</p>
+  <p class="mt-1"><strong>Verhandlungsfähig:</strong> {% if is_verhandlungsfaehig %}Ja{% else %}Nein{% endif %}</p>
+  <p class="mt-1"><strong>Initial-Prüfung:</strong> <span id="knowledge-progress">{{ knowledge_checked }} / {{ total_software }}</span> Komponenten analysiert</p>
+  <h4 class="font-semibold mt-2">Status-Historie</h4>
+  <ul class="list-disc pl-5">
+  {% for h in history %}
+    <li>{{ h.status.name }} - {{ h.changed_at|date:"d.m.Y H:i" }}</li>
+  {% endfor %}
+  </ul>
+</div>

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -70,22 +70,9 @@
 </div>
 </div>
 <div class="lg:w-1/3 mt-4 lg:mt-0">
-  <div class="bg-gray-100 p-4 rounded">
-    <h3 class="font-semibold mb-2">Projektinfo</h3>
-    <p><strong>Erstellt am:</strong> {{ projekt.created_at|date:"d.m.Y" }}</p>
-    <p class="mt-1"><strong>Software:</strong> {{ projekt.software_string }}</p>
-    <p class="mt-1"><strong>Anlagen:</strong> {{ num_attachments }}</p>
-    <p class="mt-1"><strong>Gutachten vorhanden:</strong> {% if projekt.gutachten_file %}Ja{% else %}Nein{% endif %}</p>
-    <p class="mt-1"><strong>Geprüft:</strong> {{ num_reviewed }} / {{ num_attachments }}</p>
-    <p class="mt-1"><strong>Verhandlungsfähig:</strong> {% if is_verhandlungsfaehig %}Ja{% else %}Nein{% endif %}</p>
-    <p class="mt-1"><strong>Initial-Prüfung:</strong> <span id="knowledge-progress">{{ knowledge_checked }} / {{ total_software }}</span> Komponenten analysiert</p>
-    <h4 class="font-semibold mt-2">Status-Historie</h4>
-    <ul class="list-disc pl-5">
-    {% for h in history %}
-      <li>{{ h.status.name }} - {{ h.changed_at|date:"d.m.Y H:i" }}</li>
-    {% endfor %}
-    </ul>
-</div>
+  <div id="projekt-cockpit" hx-get="{% url 'hx_project_cockpit' projekt.pk %}" hx-trigger="load">
+    {% include 'projekt_cockpit.html' %}
+  </div>
 </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add `get_cockpit_context` helper and `hx_project_cockpit` view
- refresh cockpit after uploads or status changes
- register new HX URL
- load cockpit asynchronously on project detail page
- add global JS listener to reload cockpit

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688673482494832baad3c20a2ca5875d