### PR TITLE
Implement baseline AI check for Anlage 2

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -360,10 +360,9 @@ def _verification_to_initial(_data: dict | None) -> dict:
             dest = target.setdefault("subquestions", {}).setdefault(
                 str(res.subquestion_id), {}
             )
-        pf = _data if isinstance(_data, BVProjectFile) else get_project_file(res.projekt, 2)
         latest = (
             FunktionsErgebnis.objects.filter(
-                anlage_datei=pf,
+                projekt=res.projekt,
                 funktion_id=res.funktion_id,
                 subquestion_id=res.subquestion_id,
                 quelle="ki",


### PR DESCRIPTION
## Summary
- only trigger AI check for Anlage 2 if no previous KI results exist
- skip AI task in subsequent versions in `get_analysis_tasks`
- always load existing KI results for Anlage 2 in the review
- add regression test for skipping AI check on later versions

## Testing
- `python -u manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_688673e9ea90832b9e1233c3c7fddcb5