### PR TITLE
Fix projekt cockpit template

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2782,6 +2782,8 @@ def projekt_detail(request, pk):
     activities = activities[:5]
 
     cockpit_ctx = get_cockpit_context(projekt)
+    last_anlagen_files = {nr: projekt.anlagen.filter(anlage_nr=nr).last() for nr in range(1, 7)}
+
 
 
     context = {
@@ -2794,6 +2796,7 @@ def projekt_detail(request, pk):
         "is_verhandlungsfaehig": projekt.is_verhandlungsfaehig,
         "is_admin": is_admin,
         "anlage_numbers": list(range(1, 7)),
+        "last_anlagen_files": last_anlagen_files,
 
         "knowledge_rows": knowledge_rows,
         "knowledge_checked": checked,

--- a/templates/partials/projekt_cockpit.html
+++ b/templates/partials/projekt_cockpit.html
@@ -1,3 +1,4 @@
+{% load recording_extras %}
 <div class="bg-gray-100 p-4 rounded space-y-4">
   <section>
     <h3 class="font-semibold mb-2">Projekt-Steckbrief</h3>
@@ -28,7 +29,7 @@
     <h3 class="font-semibold mb-2">Anlagen-Übersicht</h3>
     <ul class="space-y-1 text-sm">
       {% for nr in anlage_numbers %}
-      {% with file=projekt.anlagen.filter(anlage_nr=nr).last %}
+      {% with file=last_anlagen_files|get_item:nr %}
       <li>
         Anlage {{ nr }}:
         {% if file %}


### PR DESCRIPTION
## Summary
- fix Projekt Cockpit template with `last_anlagen_files`
- provide data from view instead of calling QuerySet in template

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_688679e2b37c832b9d1499907285a350