### PR TITLE
Fix missing template filter in gutachten tab

### DIFF
--- a/templates/partials/software_tab_gutachten.html
+++ b/templates/partials/software_tab_gutachten.html
@@ -1,3 +1,4 @@
+{% load recording_extras %}
 <div class="overflow-x-auto">
 <table class="mb-4 w-full text-left">
     <thead>


### PR DESCRIPTION
## Summary
- load `recording_extras` in `software_tab_gutachten.html`

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68868198ab34832b937fd9fa0afdbee2