### PR TITLE
Fix missing project lookup in verification

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -387,7 +387,7 @@ def _verification_to_initial(_data: dict | None) -> dict:
             )
         latest = (
             FunktionsErgebnis.objects.filter(
-                projekt=res.projekt,
+                projekt=res.anlage_datei.projekt,
                 funktion_id=res.funktion_id,
                 subquestion_id=res.subquestion_id,
                 quelle="ki",


### PR DESCRIPTION
## Summary
- correct project lookup when loading KI verification results

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688684191a68832ba50516c3cd91a3e2