### PR TITLE
Improve Anlage2 action column toggle

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -59,6 +59,16 @@
     display: none;
 }
 
+/* Spalte für Aktionsbuttons standardmäßig verstecken */
+.action-column {
+    display: none;
+}
+
+/* Tabelle zeigt Aktionsspalte an, wenn Klasse actions-visible gesetzt ist */
+.actions-visible .action-column {
+    display: table-cell;
+}
+
 /* Status-Badges für Projektübersichten */
 .status-badge-new,
 .status-badge-classified {

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -41,14 +41,6 @@
         <span class="text-muted small source-indicator"><i class="fas fa-question"></i></span>
         {% endif %}
     </td>
-    <td class="border px-2 text-center">
-        <button type="button" class="btn btn-sm btn-light review-cycle-btn"
-            data-state="robot" title="KI-Prüfung starten"
-            data-project-file-id="{{ anlage.pk }}"
-            data-function-id="{{ row.func_id }}"
-            data-justification-url="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-            {% if row.sub %}data-subquestion-id="{{ row.sub_id }}"{% endif %}>🤖</button>
-    </td>
     {% for field in fields %}
     {% with f=row.form_fields|get_item:field %}
     {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
@@ -65,5 +57,13 @@
         {% if row.requires_manual_review %}
         <div class="text-danger text-sm">Manueller Review erforderlich</div>
         {% endif %}
+    </td>
+    <td class="border px-2 text-center action-column">
+        <button type="button" class="btn btn-sm btn-light review-cycle-btn"
+            data-state="robot" title="KI-Prüfung starten"
+            data-project-file-id="{{ anlage.pk }}"
+            data-function-id="{{ row.func_id }}"
+            data-justification-url="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
+            {% if row.sub %}data-subquestion-id="{{ row.sub_id }}"{% endif %}>🤖</button>
     </td>
 </tr>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -46,13 +46,13 @@
     <div class="mb-3">
         <button type="button" id="expand-all-subquestions" class="bg-gray-300 text-black px-2 py-1 rounded">Alle aufklappen</button>
         <button type="button" id="collapse-all-subquestions" class="bg-gray-300 text-black px-2 py-1 rounded">Alle einklappen</button>
+        <button type="button" id="toggle-actions" class="bg-gray-300 text-black px-2 py-1 rounded ml-4">Aktionen einblenden</button>
     </div>
     <div class="overflow-x-auto">
-    <table class="table-auto w-full border">
+    <table id="anlage2-review-table" class="table-auto w-full border">
         <thead>
             <tr>
                 <th class="border px-2">Funktion</th>
-                <th class="border px-2">Aktion</th>
                 {% for field,label in field_pairs %}
                 {% if field == 'technisch_vorhanden' %}
                 <th class="border px-2">Status: Technisch verfügbar?</th>
@@ -64,6 +64,7 @@
                 {% endfor %}
                 <th class="border px-2">Verhandlungsfähig</th>
                 <th class="border px-2">Gap</th>
+                <th class="border px-2 action-column">Aktion</th>
             </tr>
         </thead>
         <tbody id="anlage2-table-body">
@@ -118,14 +119,6 @@
                     <span class="text-muted small source-indicator"><i class="fas fa-question"></i></span>
                     {% endif %}
                 </td>
-                <td class="border px-2 text-center">
-                    <button type="button" class="btn btn-sm btn-light review-cycle-btn"
-                        data-state="robot" title="KI-Prüfung starten"
-                        data-project-file-id="{{ anlage.pk }}"
-                        data-function-id="{{ row.func_id }}"
-                        data-justification-url="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                        {% if row.sub %}data-subquestion-id="{{ row.sub_id }}"{% endif %}>🤖</button>
-                </td>
                 {% for field in fields %}
                 {% with f=row.form_fields|get_item:field %}
                 {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
@@ -144,6 +137,14 @@
                     {% if row.requires_manual_review %}
                     <div class="text-danger text-sm">Manueller Review erforderlich</div>
                     {% endif %}
+                </td>
+                <td class="border px-2 text-center action-column">
+                    <button type="button" class="btn btn-sm btn-light review-cycle-btn"
+                        data-state="robot" title="KI-Prüfung starten"
+                        data-project-file-id="{{ anlage.pk }}"
+                        data-function-id="{{ row.func_id }}"
+                        data-justification-url="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
+                        {% if row.sub %}data-subquestion-id="{{ row.sub_id }}"{% endif %}>🤖</button>
                 </td>
             </tr>
         {% endfor %}
@@ -177,6 +178,8 @@ function initAnlage2Review() {
     const expandAllBtn = document.getElementById('expand-all-subquestions');
     const collapseAllBtn = document.getElementById('collapse-all-subquestions');
     const individualToggleButtons = document.querySelectorAll('.toggle-button');
+    const toggleActionsBtn = document.getElementById('toggle-actions');
+    const reviewTable = document.getElementById('anlage2-review-table');
 
     individualToggleButtons.forEach(btn => {
         btn.addEventListener('click', () => {
@@ -199,6 +202,14 @@ function initAnlage2Review() {
         collapseAllBtn.addEventListener('click', () => {
             document.querySelectorAll('.subquestion-row').forEach(r => r.classList.add('hidden-row'));
             individualToggleButtons.forEach(b => b.textContent = '+');
+        });
+    }
+
+    if (toggleActionsBtn && reviewTable) {
+        toggleActionsBtn.addEventListener('click', () => {
+            reviewTable.classList.toggle('actions-visible');
+            const visible = reviewTable.classList.contains('actions-visible');
+            toggleActionsBtn.textContent = visible ? 'Aktionen ausblenden' : 'Aktionen einblenden';
         });
     }
 


### PR DESCRIPTION
## Summary
- hide "Aktion" column by default and move it to the end
- allow users to toggle action column visibility via button
- update row partial and add supporting CSS/JS

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688717ff03fc832b9ba146afcc3135e4