### PR TITLE
Add HTMX toggle for project file flags

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -603,6 +603,26 @@ class BVProjectFileTests(NoesisTestCase):
         self.assertContains(resp, "a.txt")
         self.assertContains(resp, "hx-trigger")
 
+    def test_hx_toggle_project_file_flag(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+        )
+        self.client.login(username=self.superuser.username, password="pass")
+        url = reverse("hx_toggle_project_file_flag", args=[pf.pk, "manual_reviewed"])
+        resp = self.client.post(
+            url,
+            {"value": "1"},
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(resp.status_code, 200)
+        pf.refresh_from_db()
+        self.assertTrue(pf.manual_reviewed)
+        self.assertContains(resp, "<tr")
+        self.assertContains(resp, "fa-check")
+
     def test_hx_project_software_tab(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         SoftwareKnowledge.objects.create(projekt=projekt, software_name="A")

--- a/core/urls.py
+++ b/core/urls.py
@@ -307,6 +307,11 @@ urlpatterns = [
         name="hx_toggle_negotiable",
     ),
     path(
+        "hx/anlage/<int:pk>/toggle/<str:field>/",
+        views.hx_toggle_project_file_flag,
+        name="hx_toggle_project_file_flag",
+    ),
+    path(
         "hx/supervision/confirm/<int:result_id>/",
         views.hx_supervision_confirm,
         name="hx_supervision_confirm",

--- a/templates/partials/anlagen_row.html
+++ b/templates/partials/anlagen_row.html
@@ -36,7 +36,8 @@
         {% endif %}
     </td>
     <td class="px-2 py-1 text-center">
-        <form method="post" action="{% url 'project_file_toggle_flag' anlage.pk 'manual_reviewed' %}">
+        <form hx-post="{% url 'hx_toggle_project_file_flag' anlage.pk 'manual_reviewed' %}"
+              hx-target="closest tr" hx-swap="outerHTML" method="post">
             {% csrf_token %}
             <input type="hidden" name="value" value="{{ anlage.manual_reviewed|yesno:'0,1' }}">
             <button class="status-toggle-btn" title="Geprüft umschalten">
@@ -49,7 +50,8 @@
         </form>
     </td>
     <td class="px-2 py-1 text-center">
-        <form method="post" action="{% url 'project_file_toggle_flag' anlage.pk 'verhandlungsfaehig' %}">
+        <form hx-post="{% url 'hx_toggle_project_file_flag' anlage.pk 'verhandlungsfaehig' %}"
+              hx-target="closest tr" hx-swap="outerHTML" method="post">
             {% csrf_token %}
             <input type="hidden" name="value" value="{{ anlage.verhandlungsfaehig|yesno:'0,1' }}">
             <button class="status-toggle-btn" title="Verhandlungsfähigkeit umschalten">


### PR DESCRIPTION
## Summary
- add `hx_toggle_project_file_flag` view returning a rendered row
- register the view in URL config
- update toggle forms in `anlagen_row.html` to use HTMX
- test HTMX toggling of project file flags

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_hx_toggle_project_file_flag -v 2`
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68886a65425c832b8cac710c8d00bb9b