### PR TITLE
Fix manual review merge on Anlage4

### DIFF
--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1183,23 +1183,23 @@ class Anlage4ReviewViewTests(NoesisTestCase):
             anlage_nr=4,
             upload=SimpleUploadedFile("a.txt", b""),
             analysis_json={"items": [{"text": "A"}, {"text": "B"}]},
-            manual_analysis_json={"functions": {}},
+            manual_analysis_json={
+                "0": {"ok": True, "nego": False, "note": "alt"},
+                "1": {"ok": False, "nego": True, "note": "vorher"},
+            },
             verification_json={"functions": {}},
         )
 
     def test_post_saves_manual_review(self):
         url = reverse("anlage4_review", args=[self.file.pk])
-        resp = self.client.post(
-            url,
-            {"item0_ok": "on", "item0_note": "gut", "item1_note": "schlecht"},
-        )
+        resp = self.client.post(url, {"item1_note": "neu"})
         self.assertRedirects(resp, reverse("projekt_detail", args=[self.projekt.pk]))
         self.file.refresh_from_db()
         self.assertEqual(
             self.file.manual_analysis_json,
             {
-                "0": {"ok": True, "nego": False, "note": "gut"},
-                "1": {"ok": False, "nego": False, "note": "schlecht"},
+                "0": {"ok": True, "nego": False, "note": "alt"},
+                "1": {"ok": False, "nego": True, "note": "neu"},
             },
         )
 

--- a/core/views.py
+++ b/core/views.py
@@ -2926,7 +2926,11 @@ def anlage4_review(request, pk):
         items = project_file.analysis_json.get("items") or []
 
     if request.method == "POST":
-        form = Anlage4ReviewForm(request.POST, items=items)
+        form = Anlage4ReviewForm(
+            request.POST,
+            items=items,
+            initial=project_file.manual_analysis_json,
+        )
         if form.is_valid():
             project_file.manual_analysis_json = form.get_json()
             project_file.save(update_fields=["manual_analysis_json"])


### PR DESCRIPTION
## Summary
- merge previous Anlage4 review data when saving
- test that POST only changes specified rows

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68889c048e24832ba2b62d2a425d8093