### PR TITLE
Update supervision gap logic

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -708,9 +708,14 @@ def _build_supervision_row(result: AnlagenFunktionsMetadaten, pf: BVProjectFile)
     ai_val = ai_entry.technisch_verfuegbar if ai_entry else None
     final_val = manual_entry.technisch_verfuegbar if manual_entry else None
 
-    has_discrepancy = (doc_val != ai_val) or (
-        final_val is not None and final_val != doc_val
-    )
+    if manual_entry is not None:
+        has_discrepancy = doc_val is not None and final_val != doc_val
+    else:
+        has_discrepancy = (
+            doc_val is not None
+            and ai_val is not None
+            and doc_val != ai_val
+        )
 
     return {
         "result_id": result.id,

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -39,6 +39,9 @@
     background-color: #ffc107;
     color: black;
 }
+.popover-manual {
+    font-weight: bold;
+}
 .status-unbekannt {
     background-color: #6c757d;
     color: white;

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -260,9 +260,12 @@ function updatePopoverContent(icon, input) {
         const st = input.dataset.state;
         manualVal = st === 'true' ? true : st === 'false' ? false : null;
     }
+    const manualHtml = manualVal !== null ?
+        `<span class="popover-manual">Manuell: ${manualVal}</span>` :
+        `Manuell: ${manualVal}`;
     const html = `Dokument: ${docVal}${docNote ? ' ('+docNote+')' : ''}<br>` +
                  `KI-Check: ${aiDisplay}${aiNote ? ' ('+aiNote+')' : ''}<br>` +
-                 `Manuell: ${manualVal}`;
+                 manualHtml;
     icon.dataset.popoverContent = html;
     if (window.attachCustomPopover) {
         window.attachCustomPopover(icon);


### PR DESCRIPTION
## Summary
- adjust supervision gap check to prefer manual vs. parser
- show manual result in tooltip bold
- add highlight style for manual tooltip

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6889b1e08858832b9163ce7a12a9615c