### PR TITLE
Implement auto-negotiable reset on manual gap

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -1258,6 +1258,49 @@ class BuildRowDataTests(NoesisTestCase):
         )
         self.assertFalse(row["manual_flags"]["technisch_vorhanden"])
 
+    def test_manual_gap_sets_negotiable_false(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+        )
+        res = AnlagenFunktionsMetadaten.objects.create(
+            anlage_datei=pf,
+            funktion=self.func,
+        )
+        FunktionsErgebnis.objects.create(
+            projekt=projekt,
+            anlage_datei=pf,
+            funktion=self.func,
+            quelle="parser",
+            technisch_verfuegbar=True,
+        )
+        FunktionsErgebnis.objects.create(
+            projekt=projekt,
+            anlage_datei=pf,
+            funktion=self.func,
+            quelle="ki",
+            technisch_verfuegbar=True,
+        )
+        manual = {"Testfunktion": {"technisch_vorhanden": False}}
+        result_map = {res.get_lookup_key(): res}
+
+        row = _build_row_data(
+            "Testfunktion",
+            "Testfunktion",
+            self.func.id,
+            f"func{self.func.id}_",
+            self.form,
+            {},
+            {},
+            {},
+            manual,
+            result_map,
+        )
+
+        self.assertFalse(row["is_negotiable"])
+
     def test_doc_ai_from_result_map_main(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         pf = BVProjectFile.objects.create(

--- a/core/views.py
+++ b/core/views.py
@@ -611,6 +611,16 @@ def _build_row_data(
     auto_val = _calc_auto_negotiable(
         doc_data.get("technisch_vorhanden"), ai_data.get("technisch_vorhanden")
     )
+    manual_val = manual_lookup.get(lookup_key, {}).get("technisch_vorhanden")
+    if (
+        manual_val is not None
+        and doc_data.get("technisch_vorhanden") is not None
+        and ai_data.get("technisch_vorhanden") is not None
+        and doc_data.get("technisch_vorhanden") == ai_data.get("technisch_vorhanden")
+        and manual_val != doc_data.get("technisch_vorhanden")
+    ):
+        auto_val = False
+
     is_negotiable = override_val if override_val is not None else auto_val
     gap_widget = form[f"{form_prefix}gap_summary"]
     note_widget = form[f"{form_prefix}gap_notiz"]


### PR DESCRIPTION
## Summary
- check for manual conflicts when building review rows
- mark row as non-negotiable if parser and AI agree but manual value differs
- add regression test for this behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BuildRowDataTests.test_manual_gap_sets_negotiable_false --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_6889bb28c2dc832b9134cd8447cbd4f5