### PR TITLE
Remove manual gap note inputs

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -315,23 +315,11 @@ class BVProjectFileJSONForm(forms.ModelForm):
 
 
 class BVGapNotesForm(forms.ModelForm):
-    """Formular f\u00fcr zusammengefasste GAP-Notizen."""
+    """Formular f\u00fcr GAP-Notizen ohne Benutzereingabe."""
 
     class Meta:
         model = BVProjectFile
-        fields = ["gap_summary", "gap_notiz"]
-        labels = {
-            "gap_summary": "(Extern) Zusammenfassung",
-            "gap_notiz": "Interne Arbeitsanmerkung (Gap-Analyse)",
-        }
-        widgets = {
-            "gap_summary": forms.Textarea(
-                attrs={"class": "border rounded p-2", "rows": 4}
-            ),
-            "gap_notiz": forms.Textarea(
-                attrs={"class": "border rounded p-2", "rows": 4}
-            ),
-        }
+        fields: list[str] = []
 
 
 class Anlage1ReviewForm(forms.Form):

--- a/core/views.py
+++ b/core/views.py
@@ -4899,21 +4899,12 @@ def trigger_file_analysis(request, pk: int):
 
 @login_required
 def edit_gap_notes(request, result_id: int):
-    """Bearbeitet die Gap-Notizen für ein Ergebnis."""
+    """Zeigt einen Hinweis für automatisch erzeugte Gap-Notizen."""
 
     result = get_object_or_404(AnlagenFunktionsMetadaten, pk=result_id)
 
     if not _user_can_edit_project(request.user, result.anlage_datei.projekt):
         return HttpResponseForbidden("Nicht berechtigt")
-
-    if request.method == "POST":
-        result.gap_summary = request.POST.get("gap_summary", "")
-        result.gap_notiz = request.POST.get("gap_notiz", "")
-        result.save(update_fields=["gap_summary", "gap_notiz"])
-        pf = get_project_file(result.anlage_datei.projekt, 2)
-        if pf:
-            return redirect("projekt_file_edit_json", pk=pf.pk)
-        return redirect("projekt_detail", pk=result.anlage_datei.projekt.pk)
 
     pf = get_project_file(result.anlage_datei.projekt, 2)
     context = {"result": result, "project_file": pf}

--- a/templates/gap_notes_form.html
+++ b/templates/gap_notes_form.html
@@ -2,35 +2,12 @@
 {% block title %}Notizen bearbeiten{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Notizen für {{ result.funktion.name }} bearbeiten</h1>
-<form method="post">
-    {% csrf_token %}
-    <div class="mb-4">
-        <label for="id_gap_summary" class="block font-semibold">(Extern) Anmerkungen für den Fachbereich</label>
-        <textarea id="id_gap_summary" name="gap_summary" rows="6" class="border rounded w-full p-2">{{ result.gap_summary }}</textarea>
-    </div>
-    <div class="mb-4">
-        <label for="id_gap_notiz" class="block font-semibold">Interne Arbeitsanmerkung (Gap-Analyse)</label>
-        <textarea id="id_gap_notiz" name="gap_notiz" rows="6" class="border rounded w-full p-2">{{ result.gap_notiz }}</textarea>
-    </div>
-    <div class="space-x-2">
-        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
-        {% if project_file %}
-        <a href="{% url 'projekt_file_edit_json' project_file.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück</a>
-        {% else %}
-        <a href="{% url 'projekt_detail' result.projekt.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück</a>
-        {% endif %}
-    </div>
-</form>
-{% endblock %}
-{% block extra_head %}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
-{% endblock %}
-{% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    new EasyMDE({ element: document.getElementById('id_gap_summary') });
-    new EasyMDE({ element: document.getElementById('id_gap_notiz') });
-  });
-</script>
+<p>Diese Notizen werden automatisch erstellt und können hier nicht mehr bearbeitet werden.</p>
+<div class="space-x-2 mt-4">
+    {% if project_file %}
+    <a href="{% url 'projekt_file_edit_json' project_file.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück</a>
+    {% else %}
+    <a href="{% url 'projekt_detail' result.projekt.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück</a>
+    {% endif %}
+</div>
 {% endblock %}

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -29,16 +29,7 @@
         {% endfor %}
         </tbody>
     </table>
-    <div>
-        {{ gap_form.gap_summary.label_tag }}<br>
-        {{ gap_form.gap_summary }}
-        {{ gap_form.gap_summary.errors }}
-    </div>
-    <div>
-        {{ gap_form.gap_notiz.label_tag }}<br>
-        {{ gap_form.gap_notiz }}
-        {{ gap_form.gap_notiz.errors }}
-    </div>
+    <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <div class="space-x-2 mt-2">
         <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
     </div>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -114,16 +114,7 @@
         <a href="{% url 'projekt_file_parse_anlage2' anlage.pk %}" class="bg-blue-600 text-white px-2 py-1 rounded ml-4">Parser-Analyse starten</a>
     </div>
     </div>
-    <div>
-        {{ gap_form.gap_summary.label_tag }}<br>
-        {{ gap_form.gap_summary }}
-        {{ gap_form.gap_summary.errors }}
-    </div>
-    <div>
-        {{ gap_form.gap_notiz.label_tag }}<br>
-        {{ gap_form.gap_notiz }}
-        {{ gap_form.gap_notiz.errors }}
-    </div>
+    <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <div class="space-x-2 mt-2">
         <button type="reset" id="reset-fields" class="bg-gray-300 text-black px-4 py-2 rounded">Reset</button>
         <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-black px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>

--- a/templates/projekt_file_anlage3_review.html
+++ b/templates/projekt_file_anlage3_review.html
@@ -6,16 +6,7 @@
 <form method="post" class="space-y-4">
     {% csrf_token %}
     {{ form.as_p }}
-    <div>
-        {{ gap_form.gap_summary.label_tag }}<br>
-        {{ gap_form.gap_summary }}
-        {{ gap_form.gap_summary.errors }}
-    </div>
-    <div>
-        {{ gap_form.gap_notiz.label_tag }}<br>
-        {{ gap_form.gap_notiz }}
-        {{ gap_form.gap_notiz.errors }}
-    </div>
+    <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage4_review.html
+++ b/templates/projekt_file_anlage4_review.html
@@ -44,16 +44,7 @@
 {% endfor %}
         </tbody>
     </table>
-    <div>
-        {{ gap_form.gap_summary.label_tag }}<br>
-        {{ gap_form.gap_summary }}
-        {{ gap_form.gap_summary.errors }}
-    </div>
-    <div>
-        {{ gap_form.gap_notiz.label_tag }}<br>
-        {{ gap_form.gap_notiz }}
-        {{ gap_form.gap_notiz.errors }}
-    </div>
+    <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage5_review.html
+++ b/templates/projekt_file_anlage5_review.html
@@ -12,16 +12,7 @@
         {{ form.sonstige.label_tag }}<br>
         {{ form.sonstige }}
     </div>
-    <div>
-        {{ gap_form.gap_summary.label_tag }}<br>
-        {{ gap_form.gap_summary }}
-        {{ gap_form.gap_summary.errors }}
-    </div>
-    <div>
-        {{ gap_form.gap_notiz.label_tag }}<br>
-        {{ gap_form.gap_notiz }}
-        {{ gap_form.gap_notiz.errors }}
-    </div>
+    <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage6_review.html
+++ b/templates/projekt_file_anlage6_review.html
@@ -18,16 +18,7 @@
         {{ form.verhandlungsfaehig }} {{ form.verhandlungsfaehig.label_tag }}
         {{ form.verhandlungsfaehig.errors }}
     </div>
-    <div>
-        {{ gap_form.gap_summary.label_tag }}<br>
-        {{ gap_form.gap_summary }}
-        {{ gap_form.gap_summary.errors }}
-    </div>
-    <div>
-        {{ gap_form.gap_notiz.label_tag }}<br>
-        {{ gap_form.gap_notiz }}
-        {{ gap_form.gap_notiz.errors }}
-    </div>
+    <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- disable manual gap note form fields
- remove gap summary/notiz editors from note page
- drop note widgets from review templates
- drop POST logic for editing gap notes

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6889eaef5878832ba8b62d1d5b53940f