### PR TITLE
Add GAP report generation assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ Alle Antworten der LLMs enthalten Markdown. Im Web werden sie mit
 3. Über `/work/projekte/<pk>/gutachten/edit/` kann der Text im Browser bearbeitet und erneut gespeichert werden.
 4. Ein POST-Request an `/work/projekte/<pk>/gutachten/delete/` entfernt das Dokument wieder aus dem Projekt.
 
+### GAP-Berichts-Assistent
+
+1. Sobald in Anlage 1 oder Anlage 2 GAPs vorliegen, erscheint in der Projekt-Detailansicht der Button **GAP-Bericht f\u00fcr Fachbereich erstellen**.
+2. Nach dem Klick erzeugt das LLM zwei Zusammenfassungen der offenen Punkte aus beiden Anlagen.
+3. Die Texte lassen sich bearbeiten und werden beim Speichern in den jeweiligen Anlagen hinterlegt.
+
 ### Anlage 1 prüfen
 
 Der Aufruf

--- a/core/migrations/0050_gap_report_prompts.py
+++ b/core/migrations/0050_gap_report_prompts.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+
+
+def add_prompts(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    prompts = [
+        (
+            'gap_report_anlage1',
+            'Fasse alle Hinweise und Vorschl\u00e4ge aus Anlage 1 zu einem kurzen Text f\u00fcr den Fachbereich. Nutze {fragen} als Input.'
+        ),
+        (
+            'gap_report_anlage2',
+            'Fasse alle GAP-Notizen aus Anlage 2 f\u00fcr den Fachbereich zusammen. Nutze {funktionen} als Input.'
+        ),
+    ]
+    for name, text in prompts:
+        Prompt.objects.update_or_create(name=name, defaults={'text': text, 'use_system_role': True})
+
+
+def remove_prompts(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    Prompt.objects.filter(name__in=['gap_report_anlage1', 'gap_report_anlage2']).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0049_add_gap_fields_to_projectfile'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_prompts, reverse_code=remove_prompts),
+    ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -472,6 +472,11 @@ urlpatterns = [
         name="projekt_management_summary",
     ),
     path(
+        "work/projekte/<int:pk>/gap-report/",
+        views.gap_report_view,
+        name="gap_report_view",
+    ),
+    path(
         "work/projekte/<int:pk>/anlage3-review/",
         views.anlage3_review,
         name="anlage3_review",

--- a/templates/gap_report.html
+++ b/templates/gap_report.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block extra_head %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+{% endblock %}
+{% block title %}GAP-Bericht{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">GAP-Bericht f\u00fcr Fachbereich</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    <label class="font-semibold" for="id_text1">Anlage 1</label>
+    <textarea id="id_text1" name="text1" rows="10" class="w-full border rounded p-2">{{ text1 }}</textarea>
+    <label class="font-semibold" for="id_text2">Anlage 2</label>
+    <textarea id="id_text2" name="text2" rows="10" class="w-full border rounded p-2">{{ text2 }}</textarea>
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+</form>
+{% endblock %}
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+<script>
+  new EasyMDE({ element: document.getElementById('id_text1') });
+  new EasyMDE({ element: document.getElementById('id_text2') });
+</script>
+{% endblock %}

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -36,6 +36,13 @@
     |
     <a href="{% url 'projekt_management_summary' projekt.pk %}" class="text-blue-700 underline">Management Summary herunterladen</a>
 </p>
+<p class="mb-4">
+    {% if can_gap_report %}
+    <a href="{% url 'gap_report_view' projekt.pk %}" class="bg-blue-600 text-white px-4 py-2 rounded">GAP-Bericht f\u00fcr Fachbereich erstellen</a>
+    {% else %}
+    <button class="bg-gray-300 text-gray-500 px-4 py-2 rounded" disabled>GAP-Bericht f\u00fcr Fachbereich erstellen</button>
+    {% endif %}
+</p>
 </div>
 
 <div class="bg-white rounded-lg shadow p-4">


### PR DESCRIPTION
## Summary
- add summarization functions for Anlage 1 and 2 gaps
- wire up new `gap_report_view` with URL and button
- template for editing generated GAP reports
- seed default prompts via migration
- extend tests for new logic
- document GAP-Berichts-Assistent in README

## Testing
- `python manage.py makemigrations --check` *(fails: Couldn't import Django)*
- `python manage.py test core.tests.test_general.GapReportTests --verbosity 2` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_688a05607e14832ba0055238f1890fb2