### PR TITLE
Add admin option to delete GAP report

### DIFF
--- a/core/tests/test_admin_views.py
+++ b/core/tests/test_admin_views.py
@@ -72,6 +72,25 @@ class AdminProjectCleanupTests(NoesisTestCase):
         resp = self.client.post(url, {"action": "delete_classification"})
         self.assertRedirects(resp, url)
         self.projekt.refresh_from_db()
+
+    def test_delete_gap_report(self):
+        self.file.gap_summary = "foo"
+        self.file.save()
+        pf2 = BVProjectFile.objects.create(
+            projekt=self.projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("b.txt", b"data"),
+            text_content="Text",
+        )
+        pf2.gap_summary = "bar"
+        pf2.save()
+        url = reverse("admin_project_cleanup", args=[self.projekt.pk])
+        resp = self.client.post(url, {"action": "delete_gap_report"})
+        self.assertRedirects(resp, url)
+        self.file.refresh_from_db()
+        pf2.refresh_from_db()
+        self.assertEqual(self.file.gap_summary, "")
+        self.assertEqual(pf2.gap_summary, "")
 class AdminPromptsViewTests(NoesisTestCase):
     def setUp(self):
         admin_group = Group.objects.create(name="admin")

--- a/core/views.py
+++ b/core/views.py
@@ -1518,8 +1518,24 @@ def admin_project_cleanup(request, pk):
             )
             messages.success(request, "Summary gelöscht")
             return redirect("admin_project_cleanup", pk=projekt.pk)
+        if action == "delete_gap_report":
+            pf1 = get_project_file(projekt, 1)
+            pf2 = get_project_file(projekt, 2)
+            if pf1:
+                pf1.gap_summary = ""
+                pf1.save(update_fields=["gap_summary"])
+            if pf2:
+                pf2.gap_summary = ""
+                pf2.save(update_fields=["gap_summary"])
+            messages.success(request, "GAP-Bericht gelöscht")
+            return redirect("admin_project_cleanup", pk=projekt.pk)
 
-    context = {"projekt": projekt, "files": projekt.anlagen.all()}
+    gap_report_exists = projekt.anlagen.filter(anlage_nr__in=[1, 2]).exclude(gap_summary="").exists()
+    context = {
+        "projekt": projekt,
+        "files": projekt.anlagen.all(),
+        "gap_report_exists": gap_report_exists,
+    }
     return render(request, "admin_project_cleanup.html", context)
 
 

--- a/templates/admin_project_cleanup.html
+++ b/templates/admin_project_cleanup.html
@@ -56,5 +56,16 @@
 <p class="mb-4">Keine Bewertung vorhanden.</p>
 {% endif %}
 
+<h2 class="text-xl font-semibold mt-4">GAP-Bericht</h2>
+{% if gap_report_exists %}
+<form method="post" class="mb-4">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="delete_gap_report">
+    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded" onclick="return confirm('GAP-Bericht wirklich löschen?');">GAP-Bericht löschen</button>
+</form>
+{% else %}
+<p class="mb-4">Kein GAP-Bericht vorhanden.</p>
+{% endif %}
+
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow removing GAP report for a project via the cleanup view
- show new button if a GAP report exists
- test admin cleanup GAP report deletion

## Testing
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688a535b93b4832b9bfbfaad7a985ffe