### PR TITLE
Add reset function for GAP report

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -4645,3 +4645,16 @@ class GapReportTests(NoesisTestCase):
         self.pf2.refresh_from_db()
         self.assertEqual(self.pf1.gap_summary, "E1")
         self.assertEqual(self.pf2.gap_summary, "E2")
+
+    def test_delete_gap_report(self):
+        self.pf1.gap_summary = "E1"
+        self.pf2.gap_summary = "E2"
+        self.pf1.save(update_fields=["gap_summary"])
+        self.pf2.save(update_fields=["gap_summary"])
+        url = reverse("delete_gap_report", args=[self.projekt.pk])
+        resp = self.client.post(url)
+        self.assertRedirects(resp, reverse("projekt_detail", args=[self.projekt.pk]))
+        self.pf1.refresh_from_db()
+        self.pf2.refresh_from_db()
+        self.assertEqual(self.pf1.gap_summary, "")
+        self.assertEqual(self.pf2.gap_summary, "")

--- a/core/urls.py
+++ b/core/urls.py
@@ -477,6 +477,11 @@ urlpatterns = [
         name="gap_report_view",
     ),
     path(
+        "work/projekte/<int:pk>/gap-report/delete/",
+        views.delete_gap_report,
+        name="delete_gap_report",
+    ),
+    path(
         "work/projekte/<int:pk>/anlage3-review/",
         views.anlage3_review,
         name="anlage3_review",

--- a/core/views.py
+++ b/core/views.py
@@ -5143,6 +5143,28 @@ def gap_report_view(request, pk):
 
 
 @login_required
+@require_http_methods(["POST"])
+def delete_gap_report(request, pk):
+    """Verwirft vorhandene GAP-Berichte."""
+    projekt = get_object_or_404(BVProject, pk=pk)
+    if not _user_can_edit_project(request.user, projekt):
+        return HttpResponseForbidden("Nicht berechtigt")
+
+    pf1 = get_project_file(projekt, 1)
+    pf2 = get_project_file(projekt, 2)
+
+    if pf1:
+        pf1.gap_summary = ""
+        pf1.save(update_fields=["gap_summary"])
+    if pf2:
+        pf2.gap_summary = ""
+        pf2.save(update_fields=["gap_summary"])
+
+    messages.success(request, "GAP-Bericht verworfen")
+    return redirect("projekt_detail", pk=projekt.pk)
+
+
+@login_required
 @require_POST
 def ajax_start_gutachten_generation(request, project_id):
     """Startet die Gutachten-Erstellung als Hintergrund-Task."""

--- a/templates/gap_report.html
+++ b/templates/gap_report.html
@@ -5,13 +5,17 @@
 {% block title %}GAP-Bericht{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">GAP-Bericht f\u00fcr Fachbereich</h1>
-<form method="post" class="space-y-4">
+<form method="post" class="space-y-4 inline-block mr-2">
     {% csrf_token %}
     <label class="font-semibold" for="id_text1">Anlage 1</label>
     <textarea id="id_text1" name="text1" rows="10" class="w-full border rounded p-2">{{ text1 }}</textarea>
     <label class="font-semibold" for="id_text2">Anlage 2</label>
     <textarea id="id_text2" name="text2" rows="10" class="w-full border rounded p-2">{{ text2 }}</textarea>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+</form>
+<form method="post" action="{% url 'delete_gap_report' projekt.pk %}" class="inline-block">
+    {% csrf_token %}
+    <button type="submit" class="bg-red-600 text-white px-4 py-2 rounded">Bericht verwerfen &amp; neu generieren</button>
 </form>
 {% endblock %}
 {% block extra_js %}


### PR DESCRIPTION
## Summary
- add destructive button to GAP report template
- implement `delete_gap_report` view and wire it to URLs
- test deletion logic

## Testing
- `python manage.py test core.tests.test_general.GapReportTests.test_delete_gap_report -v 2`
- `python manage.py test core.tests.test_general.GapReportTests.test_view_saves_text -v 2`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_688a5371b324832ba4b032a1a0295bcc