### PR TITLE
feat: show rendered GAP report by default

### DIFF
--- a/templates/gap_report.html
+++ b/templates/gap_report.html
@@ -4,8 +4,21 @@
 {% endblock %}
 {% block title %}GAP-Bericht{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">GAP-Bericht f\u00fcr Fachbereich</h1>
-<form method="post" class="space-y-4 inline-block mr-2">
+<h1 class="text-2xl font-semibold mb-4">GAP-Bericht für Fachbereich</h1>
+
+<div id="view-mode" class="space-y-4 mb-4">
+    <div>
+        <label class="font-semibold">Anlage 1</label>
+        <div id="view-text1" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text1|markdownify }}</div>
+    </div>
+    <div>
+        <label class="font-semibold">Anlage 2</label>
+        <div id="view-text2" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text2|markdownify }}</div>
+    </div>
+    <button type="button" id="edit-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Bearbeiten</button>
+</div>
+
+<form id="edit-form" method="post" class="space-y-4 inline-block mr-2 hidden">
     {% csrf_token %}
     <label class="font-semibold" for="id_text1">Anlage 1</label>
     <textarea id="id_text1" name="text1" rows="10" class="w-full border rounded p-2">{{ text1 }}</textarea>
@@ -13,6 +26,7 @@
     <textarea id="id_text2" name="text2" rows="10" class="w-full border rounded p-2">{{ text2 }}</textarea>
     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
 </form>
+
 <form method="post" action="{% url 'delete_gap_report' projekt.pk %}" class="inline-block">
     {% csrf_token %}
     <button type="submit" class="bg-red-600 text-white px-4 py-2 rounded">Bericht verwerfen &amp; neu generieren</button>
@@ -21,7 +35,12 @@
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
-  new EasyMDE({ element: document.getElementById('id_text1') });
-  new EasyMDE({ element: document.getElementById('id_text2') });
+    document.getElementById('edit-btn').addEventListener('click', function() {
+        document.getElementById('view-mode').classList.add('hidden');
+        const form = document.getElementById('edit-form');
+        form.classList.remove('hidden');
+        new EasyMDE({ element: document.getElementById('id_text1') });
+        new EasyMDE({ element: document.getElementById('id_text2') });
+    });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- render GAP report markdown as HTML by default
- add button to switch to edit mode with EasyMDE

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688a627bcdf4832b80f8999e122bd270