### PR TITLE
Add unified markdown editor

### DIFF
--- a/static/js/markdown_editor.js
+++ b/static/js/markdown_editor.js
@@ -1,0 +1,41 @@
+function initMarkdownEditor(idPrefix) {
+    const view = document.getElementById(`${idPrefix}-view`);
+    const textarea = document.getElementById(`${idPrefix}-textarea`);
+    const editBtn = document.getElementById(`${idPrefix}-edit`);
+    const saveBtn = document.getElementById(`${idPrefix}-save`);
+    const cancelBtn = document.getElementById(`${idPrefix}-cancel`);
+    if (!view || !textarea || !editBtn || !saveBtn || !cancelBtn) return;
+
+    let editor = null;
+
+    editBtn.addEventListener('click', () => {
+        view.classList.add('hidden');
+        textarea.classList.remove('hidden');
+        editBtn.classList.add('hidden');
+        saveBtn.classList.remove('hidden');
+        cancelBtn.classList.remove('hidden');
+        if (!editor) {
+            editor = new EasyMDE({ element: textarea });
+        }
+    });
+
+    cancelBtn.addEventListener('click', () => {
+        if (editor) {
+            editor.toTextArea();
+            editor = null;
+        }
+        textarea.classList.add('hidden');
+        view.classList.remove('hidden');
+        editBtn.classList.remove('hidden');
+        saveBtn.classList.add('hidden');
+        cancelBtn.classList.add('hidden');
+    });
+
+    saveBtn.addEventListener('click', () => {
+        if (editor) {
+            textarea.value = editor.value();
+        }
+    });
+}
+
+window.initMarkdownEditor = initMarkdownEditor;

--- a/templates/admin_llm_role_form.html
+++ b/templates/admin_llm_role_form.html
@@ -1,8 +1,5 @@
 {% extends 'admin_base.html' %}
-{% block extra_head %}
-{{ block.super }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
-{% endblock %}
+{% block extra_head %}{{ block.super }}{% endblock %}
 {% block title %}{% if role %}Rolle bearbeiten{% else %}Neue Rolle{% endif %}{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">{% if role %}Rolle bearbeiten{% else %}Neue Rolle{% endif %}</h1>
@@ -15,8 +12,7 @@
         {{ form.name.errors }}
     </div>
     <div>
-        {{ form.role_prompt.label_tag }}<br>
-        {{ form.role_prompt }}
+        {% include 'partials/markdown_editor.html' with id_prefix='roleprompt' text=form.role_prompt.value name=form.role_prompt.name label=form.role_prompt.label %}
         {{ form.role_prompt.errors }}
     </div>
     <div>
@@ -28,13 +24,9 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    const el = document.getElementById('id_role_prompt');
-    if (el) {
-        new EasyMDE({ element: el });
-    }
+    initMarkdownEditor('roleprompt');
 });
 </script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-mK8e1zgS60F7uO3cu6UytzszbmWzxubUANe0yoyS9MhUlCT3ocOITkkpFmS6r30YIOCwRvDDDeZz7eGRIDcNQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script>
     document.addEventListener('DOMContentLoaded', function() {
@@ -62,6 +63,8 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{% static 'js/utils.js' %}"></script>
     <script src="{% static 'js/file_upload.js' %}"></script>
+    <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+    <script src="{% static 'js/markdown_editor.js' %}"></script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/edit_knowledge_description.html
+++ b/templates/edit_knowledge_description.html
@@ -1,26 +1,17 @@
 {% extends 'base.html' %}
-{% block extra_head %}
-{{ block.super }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
-{% endblock %}
+{% block extra_head %}{{ block.super }}{% endblock %}
 {% block title %}Beschreibung bearbeiten{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Beschreibung bearbeiten</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
-    {{ form.description.label_tag }}
-    {{ form.description }}
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    {% include 'partials/markdown_editor.html' with id_prefix='description' text=form.description.value name=form.description.name label=form.description.label %}
 </form>
 {% endblock %}
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    const textarea = document.getElementById('id_description');
-    if (textarea) {
-      new EasyMDE({ element: textarea });
-    }
+    initMarkdownEditor('description');
   });
 </script>
 {% endblock %}

--- a/templates/gap_report.html
+++ b/templates/gap_report.html
@@ -1,30 +1,13 @@
 {% extends 'base.html' %}
-{% block extra_head %}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
-{% endblock %}
+{% block extra_head %}{% endblock %}
 {% block title %}GAP-Bericht{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">GAP-Bericht für Fachbereich</h1>
 
-<div id="view-mode" class="space-y-4 mb-4">
-    <div>
-        <label class="font-semibold">Anlage 1</label>
-        <div id="view-text1" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text1|markdownify }}</div>
-    </div>
-    <div>
-        <label class="font-semibold">Anlage 2</label>
-        <div id="view-text2" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text2|markdownify }}</div>
-    </div>
-    <button type="button" id="edit-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Bearbeiten</button>
-</div>
-
-<form id="edit-form" method="post" class="space-y-4 inline-block mr-2 hidden">
+<form method="post" class="space-y-4 inline-block mr-2">
     {% csrf_token %}
-    <label class="font-semibold" for="id_text1">Anlage 1</label>
-    <textarea id="id_text1" name="text1" rows="10" class="w-full border rounded p-2">{{ text1 }}</textarea>
-    <label class="font-semibold" for="id_text2">Anlage 2</label>
-    <textarea id="id_text2" name="text2" rows="10" class="w-full border rounded p-2">{{ text2 }}</textarea>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    {% include 'partials/markdown_editor.html' with id_prefix='text1' text=text1 name='text1' label='Anlage 1' %}
+    {% include 'partials/markdown_editor.html' with id_prefix='text2' text=text2 name='text2' label='Anlage 2' %}
 </form>
 
 <form method="post" action="{% url 'delete_gap_report' projekt.pk %}" class="inline-block">
@@ -33,14 +16,10 @@
 </form>
 {% endblock %}
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
-    document.getElementById('edit-btn').addEventListener('click', function() {
-        document.getElementById('view-mode').classList.add('hidden');
-        const form = document.getElementById('edit-form');
-        form.classList.remove('hidden');
-        new EasyMDE({ element: document.getElementById('id_text1') });
-        new EasyMDE({ element: document.getElementById('id_text2') });
+    document.addEventListener('DOMContentLoaded', function() {
+        initMarkdownEditor('text1');
+        initMarkdownEditor('text2');
     });
 </script>
 {% endblock %}

--- a/templates/gutachten_edit.html
+++ b/templates/gutachten_edit.html
@@ -4,18 +4,14 @@
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }} bearbeiten</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
-    <textarea id="gutachten-text" name="text" rows="20" class="w-full border rounded p-2">{{ text }}</textarea>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    {% include 'partials/markdown_editor.html' with id_prefix='gutachten' text=text name='text' %}
 </form>
 {% endblock %}
-{% block extra_head %}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
-{% endblock %}
+{% block extra_head %}{% endblock %}
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    new EasyMDE({ element: document.getElementById('gutachten-text') });
+    initMarkdownEditor('gutachten');
   });
 </script>
 {% endblock %}

--- a/templates/partials/markdown_editor.html
+++ b/templates/partials/markdown_editor.html
@@ -1,0 +1,13 @@
+{% load recording_extras %}
+<div id="{{ id_prefix }}-wrapper" class="markdown-editor space-y-2">
+  {% if label %}
+  <label for="{{ id_prefix }}-textarea" class="font-semibold">{{ label }}</label>
+  {% endif %}
+  <div id="{{ id_prefix }}-view" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
+  <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border rounded p-2">{{ text }}</textarea>
+  <div class="flex space-x-2">
+    <button type="button" id="{{ id_prefix }}-edit" class="bg-blue-600 text-white px-4 py-2 rounded">Bearbeiten</button>
+    <button type="submit" id="{{ id_prefix }}-save" class="hidden bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    <button type="button" id="{{ id_prefix }}-cancel" class="hidden bg-gray-300 text-black px-4 py-2 rounded">Abbrechen</button>
+  </div>
+</div>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -2,7 +2,6 @@
 {% load static %}
 {% block extra_head %}
 {{ block.super }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
 <link rel="stylesheet" href="{% static 'css/popover.css' %}">
 {% endblock %}
 {% load recording_extras %}

--- a/templates/projekt_file_anlage4_review.html
+++ b/templates/projekt_file_anlage4_review.html
@@ -2,7 +2,6 @@
 {% load recording_extras %}
 {% block extra_head %}
 {{ block.super }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
 {% endblock %}
 {% block title %}Anlage 4 Review{% endblock %}
 {% block content %}

--- a/templates/projekt_file_json_form.html
+++ b/templates/projekt_file_json_form.html
@@ -1,8 +1,5 @@
 {% extends 'base.html' %}
-{% block extra_head %}
-{{ block.super }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
-{% endblock %}
+{% block extra_head %}{{ block.super }}{% endblock %}
 {% block title %}Analyse bearbeiten{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Analyse f\u00fcr Anlage {{ anlage.anlage_nr }} bearbeiten</h1>
@@ -36,10 +33,9 @@
 </form>
 {% endblock %}
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('textarea').forEach(el => new EasyMDE({ element: el }));
+    document.querySelectorAll('textarea').forEach(el => initMarkdownEditor(el.id));
 });
 </script>
 {% endblock %}

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -1,8 +1,5 @@
 {% extends 'base.html' %}
-{% block extra_head %}
-{{ block.super }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
-{% endblock %}
+{% block extra_head %}{{ block.super }}{% endblock %}
 {% block title %}{% if projekt %}Projekt bearbeiten{% else %}Neues Projekt{% endif %}{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">{% if projekt %}Projekt bearbeiten{% else %}Neues Projekt{% endif %}</h1>
@@ -50,7 +47,6 @@
 
 {% block extra_js %}
 {{ block.super }}
-<script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const addSoftwareBtn = document.getElementById('add-software-btn');
@@ -71,7 +67,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const desc = document.getElementById('id_beschreibung');
     if (desc) {
-        new EasyMDE({ element: desc });
+        initMarkdownEditor('id_beschreibung');
     }
 });
 </script>


### PR DESCRIPTION
## Summary
- central partial for read/edit mode markdown fields
- JavaScript helper to toggle EasyMDE editors
- include markdown editor in base template
- refactor various templates to use the partial

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'selenium' and missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688a640395b4832b97e3bbb5fdff382b