### PR TITLE
Add Anlage 3 parser rule admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -227,10 +227,6 @@ class FormatBParserRuleAdmin(admin.ModelAdmin):
     list_editable = ("target_field", "ordering")
 
 
-@admin.register(Anlage3ParserRule)
-class Anlage3ParserRuleAdmin(admin.ModelAdmin):
-    list_display = ("field_name", "ordering")
-    list_editable = ("ordering",)
 
 
 @admin.register(AntwortErkennungsRegel)

--- a/core/forms.py
+++ b/core/forms.py
@@ -27,6 +27,7 @@ from .models import (
     AntwortErkennungsRegel,
     Anlage4Config,
     Anlage4ParserConfig,
+    Anlage3ParserRule,
     ZweckKategorieA,
     SupervisionStandardNote,
 
@@ -1165,5 +1166,35 @@ class ActionForm(forms.Form):
         label="Feld",
     )
     value = forms.BooleanField(label="Wert", required=False)
+
+
+class Anlage3ParserRuleForm(forms.ModelForm):
+    """Formular für eine Parser-Regel von Anlage 3."""
+
+    aliases = forms.CharField(widget=Textarea(attrs={"rows": 3}), required=False)
+
+    class Meta:
+        model = Anlage3ParserRule
+        fields = ["field_name", "aliases", "ordering"]
+        labels = {
+            "field_name": "Feldname",
+            "aliases": "Alias-Phrasen (eine pro Zeile)",
+            "ordering": "Reihenfolge",
+        }
+        widgets = {
+            "field_name": forms.Select(attrs={"class": "border rounded p-2"}),
+            "ordering": forms.NumberInput(attrs={"class": "border rounded p-2"}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and not self.is_bound:
+            self.initial["aliases"] = "\n".join(self.instance.aliases or [])
+
+    def save(self, commit: bool = True) -> Anlage3ParserRule:
+        aliases_raw = self.cleaned_data.get("aliases", "")
+        alias_list = [v.strip() for v in aliases_raw.splitlines() if v.strip()]
+        self.instance.aliases = alias_list
+        return super().save(commit=commit)
 
 

--- a/core/templates/core/anlage3_rule_confirm_delete.html
+++ b/core/templates/core/anlage3_rule_confirm_delete.html
@@ -1,0 +1,11 @@
+{% extends 'admin_base.html' %}
+{% block title %}Regel löschen{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Regel löschen</h1>
+<p>Möchten Sie die Regel für '{{ object.get_field_name_display }}' wirklich löschen?</p>
+<form method="post" class="mt-4 space-x-2">
+    {% csrf_token %}
+    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Bestätigen</button>
+    <a href="{% url 'anlage3_rule_list' %}" class="px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
+</form>
+{% endblock %}

--- a/core/templates/core/anlage3_rule_form.html
+++ b/core/templates/core/anlage3_rule_form.html
@@ -1,0 +1,25 @@
+{% extends 'admin_base.html' %}
+{% block title %}{% if object %}Regel bearbeiten{% else %}Neue Regel{% endif %}{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">{% if object %}Regel bearbeiten{% else %}Neue Regel{% endif %}</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    <div>
+        {{ form.field_name.label_tag }}<br>
+        {{ form.field_name }}
+        {{ form.field_name.errors }}
+    </div>
+    <div>
+        {{ form.aliases.label_tag }}<br>
+        {{ form.aliases }}
+        {{ form.aliases.errors }}
+    </div>
+    <div>
+        {{ form.ordering.label_tag }}<br>
+        {{ form.ordering }}
+        {{ form.ordering.errors }}
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+</form>
+{% endblock %}

--- a/core/templates/core/anlage3_rule_list.html
+++ b/core/templates/core/anlage3_rule_list.html
@@ -1,0 +1,34 @@
+{% extends 'admin_base.html' %}
+{% block title %}Anlage 3 Parser Regeln{% endblock %}
+{% block admin_content %}
+<h1 class="text-2xl font-semibold mb-4">Anlage 3 Parser Regeln</h1>
+<a href="{% url 'anlage3_rule_add' %}" class="inline-block mb-4 px-4 py-2 bg-blue-600 text-white rounded">Neue Regel hinzufügen</a>
+<div class="overflow-x-auto">
+<table class="min-w-full">
+    <thead>
+        <tr class="border-b text-left">
+            <th class="py-2">Feld</th>
+            <th class="py-2">Reihenfolge</th>
+            <th class="py-2 text-center">Bearbeiten</th>
+            <th class="py-2 text-center">Löschen</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for r in object_list %}
+        <tr class="border-b text-sm">
+            <td class="py-1">{{ r.get_field_name_display }}</td>
+            <td class="py-1">{{ r.ordering }}</td>
+            <td class="py-1 text-center">
+                <a href="{% url 'anlage3_rule_edit' r.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
+            </td>
+            <td class="py-1 text-center">
+                <a href="{% url 'anlage3_rule_delete' r.id %}" class="px-2 py-1 bg-red-600 text-white rounded">Löschen</a>
+            </td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="4" class="py-2">Keine Regeln vorhanden.</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+</div>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -179,6 +179,26 @@ urlpatterns = [
         name="anlage2_parser_rule_import",
     ),
     path(
+        "projects-admin/anlage3/rules/",
+        views.Anlage3ParserRuleListView.as_view(),
+        name="anlage3_rule_list",
+    ),
+    path(
+        "projects-admin/anlage3/rules/add/",
+        views.Anlage3ParserRuleCreateView.as_view(),
+        name="anlage3_rule_add",
+    ),
+    path(
+        "projects-admin/anlage3/rules/<int:pk>/edit/",
+        views.Anlage3ParserRuleUpdateView.as_view(),
+        name="anlage3_rule_edit",
+    ),
+    path(
+        "projects-admin/anlage3/rules/<int:pk>/delete/",
+        views.Anlage3ParserRuleDeleteView.as_view(),
+        name="anlage3_rule_delete",
+    ),
+    path(
         "projects-admin/anlage2/",
         views.anlage2_function_list,
         name="anlage2_function_list",

--- a/core/views.py
+++ b/core/views.py
@@ -78,6 +78,7 @@ from .forms import (
     Anlage4ParserConfigForm,
     ParserSettingsForm,
     ActionForm,
+    Anlage3ParserRuleForm,
 
 )
 from .text_parser import PHRASE_TYPE_CHOICES
@@ -108,6 +109,7 @@ from .models import (
     Anlage4ParserConfig,
     ZweckKategorieA,
     Anlage5Review,
+    Anlage3ParserRule,
     Anlage3Metadata,
     SupervisionStandardNote,
 )
@@ -5327,6 +5329,39 @@ class SupervisionNoteDeleteView(LoginRequiredMixin, StaffRequiredMixin, DeleteVi
     model = SupervisionStandardNote
     template_name = "core/supervisionnote_confirm_delete.html"
     success_url = reverse_lazy("supervisionnote_list")
+
+
+class Anlage3ParserRuleListView(LoginRequiredMixin, StaffRequiredMixin, ListView):
+    """Listet alle Parser-Regeln für Anlage 3 auf."""
+
+    model = Anlage3ParserRule
+    template_name = "core/anlage3_rule_list.html"
+
+
+class Anlage3ParserRuleCreateView(LoginRequiredMixin, StaffRequiredMixin, CreateView):
+    """Erstellt eine neue Parser-Regel für Anlage 3."""
+
+    model = Anlage3ParserRule
+    form_class = Anlage3ParserRuleForm
+    template_name = "core/anlage3_rule_form.html"
+    success_url = reverse_lazy("anlage3_rule_list")
+
+
+class Anlage3ParserRuleUpdateView(LoginRequiredMixin, StaffRequiredMixin, UpdateView):
+    """Bearbeitet eine vorhandene Parser-Regel für Anlage 3."""
+
+    model = Anlage3ParserRule
+    form_class = Anlage3ParserRuleForm
+    template_name = "core/anlage3_rule_form.html"
+    success_url = reverse_lazy("anlage3_rule_list")
+
+
+class Anlage3ParserRuleDeleteView(LoginRequiredMixin, StaffRequiredMixin, DeleteView):
+    """Löscht eine Parser-Regel für Anlage 3 nach Bestätigung."""
+
+    model = Anlage3ParserRule
+    template_name = "core/anlage3_rule_confirm_delete.html"
+    success_url = reverse_lazy("anlage3_rule_list")
 
 
 @login_required

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -23,6 +23,7 @@
                 <a href="{% url 'anlage2_function_list' %}">Anlage 2 Funktionen</a><br>
                 <a href="{% url 'anlage2_config' %}">Anlage 2 Globale Phrasen</a><br>
                 <a href="{% url 'parser_rule_list' %}">Exakter Parser Regeln</a><br>
+                <a href="{% url 'anlage3_rule_list' %}">Anlage 3 Parser Regeln</a><br>
                 <a href="{% url 'anlage4_config' %}">Anlage 4 Konfiguration</a><br>
                 <a href="{% url 'zweckkategoriea_list' %}">Zwecke verwalten</a><br>
                 <a href="{% url 'supervisionnote_list' %}">Supervision-Notizen</a><br>


### PR DESCRIPTION
## Summary
- remove Anlage3ParserRule from Django admin
- add CRUD endpoints for Anlage3ParserRule in custom admin
- implement form and views
- create templates for rule management
- link new section in admin navigation

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688b62c03638832b81d4b843fba163c4