### PR TITLE
Remove deprecated GAP prompts

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1900,27 +1900,8 @@ def worker_generate_gap_summary(result_id: int, model_name: str | None = None) -
         "ki_begruendung": getattr(ai_entry, "begruendung", ""),
     }
 
-    prompt_internal = Prompt.objects.filter(name="gap_summary_internal").first()
-    if not prompt_internal:
-        prompt_internal = Prompt(name="tmp", text="Formuliere eine technische Zusammenfassung des Konflikts.")
-    internal = query_llm(
-        prompt_internal,
-        context,
-        model_name=model_name,
-        model_type="gutachten",
-        project_prompt=projekt.project_prompt if prompt_internal.use_project_context else None,
-    ).strip()
-
-    prompt_external = Prompt.objects.filter(name="gap_communication_external").first()
-    if not prompt_external:
-        prompt_external = Prompt(name="tmp", text="Formuliere eine freundliche Rückfrage an den Fachbereich.")
-    external = query_llm(
-        prompt_external,
-        context,
-        model_name=model_name,
-        model_type="gutachten",
-        project_prompt=projekt.project_prompt if prompt_external.use_project_context else None,
-    ).strip()
+    internal = ""
+    external = ""
 
     res.gap_notiz = internal
     res.gap_summary = external
@@ -1932,8 +1913,6 @@ def worker_generate_gap_summary(result_id: int, model_name: str | None = None) -
         funktion=res.funktion,
         subquestion=res.subquestion,
         quelle="gap",
-        gap_begruendung_intern=internal,
-        gap_begruendung_extern=external,
     )
 
     logger.info("worker_generate_gap_summary beendet für Result %s", result_id)

--- a/core/migrations/0051_remove_gap_prompt_fields.py
+++ b/core/migrations/0051_remove_gap_prompt_fields.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def delete_gap_prompts(apps, schema_editor):
+    Prompt = apps.get_model('core', 'Prompt')
+    Prompt.objects.filter(
+        name__in=['gap_summary_internal', 'gap_communication_external']
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0050_gap_report_prompts'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='funktionsergebnis',
+            name='gap_begruendung_intern',
+        ),
+        migrations.RemoveField(
+            model_name='funktionsergebnis',
+            name='gap_begruendung_extern',
+        ),
+        migrations.RunPython(delete_gap_prompts, reverse_code=migrations.RunPython.noop),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -1030,8 +1030,6 @@ class FunktionsErgebnis(models.Model):
     ki_beteiligung = models.BooleanField(null=True)
     ki_beteiligt_begruendung = models.TextField(blank=True, null=True)
     begruendung = models.TextField(blank=True, null=True)
-    gap_begruendung_intern = models.TextField(blank=True, null=True)
-    gap_begruendung_extern = models.TextField(blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -4117,25 +4117,18 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
             self.assertEqual(name, "core.llm_tasks.worker_generate_gap_summary")
             worker_generate_gap_summary(*args)
 
-        with (
-            patch("core.views.async_task", side_effect=immediate),
-            patch(
-                "core.llm_tasks.query_llm",
-                side_effect=["Intern", "Extern"],
-            ),
-        ):
+        with patch("core.views.async_task", side_effect=immediate):
             resp = self.client.post(gap_url)
         self.assertEqual(resp.status_code, 200)
         res.refresh_from_db()
-        self.assertEqual(res.gap_notiz, "Intern")
-        self.assertEqual(res.gap_summary, "Extern")
+        self.assertEqual(res.gap_notiz, "")
+        self.assertEqual(res.gap_summary, "")
         gap_entry = FunktionsErgebnis.objects.filter(
             anlage_datei=self.pf,
             funktion=self.func,
             quelle="gap",
         ).latest("created_at")
-        self.assertEqual(gap_entry.gap_begruendung_intern, "Intern")
-        self.assertEqual(gap_entry.gap_begruendung_extern, "Extern")
+        self.assertIsNotNone(gap_entry)
 
     def test_manual_sets_negotiable(self):
         AnlagenFunktionsMetadaten.objects.create(

--- a/core/views.py
+++ b/core/views.py
@@ -1672,12 +1672,11 @@ def admin_prompts(request):
         "anlage3": [],
         "anlage4": [],
     }
-    anlage2_extra = {"gap_summary_internal", "gap_communication_external"}
     for p in prompts:
         name = p.name.lower()
         if "anlage1" in name:
             groups["anlage1"].append(p)
-        elif "anlage2" in name or p.name in anlage2_extra:
+        elif "anlage2" in name:
             groups["anlage2"].append(p)
         elif "anlage3" in name:
             groups["anlage3"].append(p)


### PR DESCRIPTION
## Summary
- drop obsolete GAP prompts from initial migration
- remove prompt fields and usages
- clean up admin prompt display
- adjust tests
- provide migration to remove stale GAP prompts
- restore original migration for safe history

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: missing selenium, missing LLM credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688b5ffdf728832b99427aeafe056623