### PR TITLE
Remove parser config from admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ erzeugt
 ### Anlage 4 Parser konfigurieren
 
 Der optionale Parser für die vierte Anlage arbeitet ohne LLM-Extraktion. Er
-durchsucht den Freitext anhand konfigurierbarer Phrasen, die im Admin-Bereich
-bearbeitet werden können. Folgende Felder bestimmen das Parsing:
+durchsucht den Freitext anhand konfigurierbarer Phrasen, die unter
+`/projects-admin/anlage4/config/` angepasst werden können. Folgende Felder bestimmen das Parsing:
 
 - `delimiter_phrase`: Regulärer Ausdruck, der den Beginn einer neuen Auswertung markiert.
 - `gesellschaften_phrase`: Phrase, die den Wert für „Gesellschaften“ einleitet.

--- a/core/admin.py
+++ b/core/admin.py
@@ -20,7 +20,6 @@ from .models import (
     FunktionsErgebnis,
     FormatBParserRule,
     AntwortErkennungsRegel,
-    Anlage4ParserConfig,
     Anlage3ParserRule,
     Anlage5Review,
     SupervisionStandardNote,
@@ -239,22 +238,7 @@ class AntwortErkennungsRegelAdmin(admin.ModelAdmin):
     list_editable = ("regel_anwendungsbereich", "prioritaet")
 
 
-@admin.register(Anlage4ParserConfig)
-class Anlage4ParserConfigAdmin(admin.ModelAdmin):
-    fieldsets = (
-        (
-            "Text-Parsing Regeln",
-            {
-                "fields": (
-                    "delimiter_phrase",
-                    "gesellschaften_phrase",
-                    "fachbereiche_phrase",
-                )
-            },
-        ),
-        ("Tabellen-Spalten", {"fields": ("table_columns",)}),
-        ("Prompts", {"fields": ("prompt_plausibility",)}),
-    )
+
 
 
 # Registrierung der Modelle


### PR DESCRIPTION
## Summary
- remove `Anlage4ParserConfig` from standard admin
- mention new location `/projects-admin/anlage4/config/` in README

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688b694ee858832ba6373ee5ae306ff3