### PR TITLE
Remove duplicate import/export buttons

### DIFF
--- a/templates/parser_rules/rule_list.html
+++ b/templates/parser_rules/rule_list.html
@@ -7,10 +7,6 @@
     <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
     <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
 </div>
-<div class="mb-4 space-x-2">
-    <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
-    <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
-</div>
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">


### PR DESCRIPTION
## Summary
- fix duplicated import/export buttons on parser rule list page

## Testing
- `python manage.py makemigrations --check` *(fails: conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_688bb2077bb0832b81c422b3a7f89b0f