### PR TITLE
Add admin area documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,13 @@ templates/: HTML-Vorlagen, inklusive eines admin-Unterordners zum Überschreiben
 llm-debug.log: Dediziertes Logfile für alle LLM-Prompts und -Antworten.
 Procfile: Definiert die Prozesse (web, worker) für den Start mit honcho.
 
+## Admin-Bereiche
+
+- `/projects-admin/` – Projekt-Admin für alle projektbezogenen Modelle und
+  Einstellungen (z.B. Funktionskatalog, Parser-Regeln).
+- `/admin/` – System-Admin (das reguläre Django-Admin) für globale
+  Konfiguration wie Benutzer und Gruppen.
+
 ## Tests und Checks
 - Vor jedem Commit `python manage.py makemigrations --check` ausführen.
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,15 @@ Das Django-Admin wurde optisch überarbeitet. Eine Seitenleiste listet alle
 Modelle übersichtlich auf und bietet eine Suchleiste. Die neue Datei
 `static/css/admin.css` steuert das Layout.
 
+### Admin-Bereiche
+
+NOESIS unterscheidet zwei Verwaltungsoberflächen:
+
+* **Projekt-Admin** unter `/projects-admin/` – hier werden projektspezifische
+  Daten wie Funktionskatalog oder Parser-Regeln bearbeitet.
+* **System-Admin** unter `/admin/` – das klassische Django-Admin für globale
+  Einstellungen, Benutzer und Gruppen.
+
 ### Funktionskatalog verwalten
 
 Administratorinnen und Administratoren erreichen die Übersicht aller Anlage‑2-Funktionen unter `/projects-admin/anlage2/`. Dort lassen sich neue Einträge anlegen, vorhandene Funktionen bearbeiten und auch wieder löschen. Über den Button **Importieren** kann eine JSON-Datei hochgeladen werden, die den Funktionskatalog enthält. Ist `/projects-admin/anlage2/import/` aufrufbar, bietet das Formular zudem die Option, die Datenbank vor dem Import zu leeren. Mit **Exportieren** wird der aktuelle Katalog als JSON unter `/projects-admin/anlage2/export/` heruntergeladen. Der Zugriff auf alle genannten URLs erfordert Mitgliedschaft in der Gruppe `admin`.


### PR DESCRIPTION
## Summary
- document Projekt-Admin vs System-Admin in README
- mention this split in `AGENTS.md`

## Testing
- `python manage.py makemigrations --check` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_688bb206a0cc832b969562d1ad84893f