### PR TITLE
Update management notes and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Für alle Django-Managementbefehle muss die Umgebungsvariable
 `DJANGO_SECRET_KEY` gesetzt sein. Beim Aufruf von
 `python manage.py test` wird automatisch `dummy_test_key` verwendet,
 falls keine Variable vorhanden ist.
+Vor dem Einsatz der Managementbefehle muss zudem `pip install -r requirements.txt` ausgeführt worden sein, damit alle benötigten Module verfügbar sind.
 
 ## Tests und Checks
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -6,3 +6,9 @@ pip install -r requirements.txt
 # Entwicklungswerkzeuge installieren
 pip install -r requirements-dev.txt
 
+# Systemabhängigkeiten installieren (pandoc wird für DOCX-Exporte benötigt)
+if command -v apt-get >/dev/null; then
+    sudo apt-get update
+    sudo apt-get install -y pandoc
+fi
+


### PR DESCRIPTION
## Summary
- note that manage.py commands need `requirements.txt`
- add apt-based pandoc install to `setup_env.sh`

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688bbd63afec832bbfaf8c489298f042