### PR TITLE
Fix admin check in base template

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,12 @@
+"""Kontextprozessoren für die Django-Templates."""
+
+from django.http import HttpRequest
+
+
+def is_admin(request: HttpRequest) -> dict[str, bool]:
+    """Gibt an, ob der aktuelle Benutzer zur Admin-Gruppe gehört."""
+
+    if request.user.is_authenticated:
+        return {"is_admin": request.user.groups.filter(name__iexact="admin").exists()}
+    return {"is_admin": False}
+

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -79,6 +79,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "core.context_processors.is_admin",
             ],
         },
     },

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
                 <a href="/" class="hover:underline">Startseite</a>
                 {% if user.is_authenticated %}
                     <a href="/account/" class="hover:underline">Mein Konto</a>
-                    {% if user.is_superuser or user.groups.filter(name='admin').exists %}
+                    {% if user.is_superuser or is_admin %}
                         <a href="/projects-admin/" class="hover:underline">Projekt-Admin</a>
                     {% endif %}
                     {% if user.is_staff %}


### PR DESCRIPTION
## Summary
- add a context processor to inject `is_admin`
- wire the processor into Django settings
- use `is_admin` flag in the base template

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688bc261fb14832b9a0e435f5005b102