### PR TITLE
docs: mention seed command after migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Datenbank: SQLite für die Entwicklung, für den Produktivbetrieb ist PostgreSQL
 ## Projektstruktur
 core/: Zentrale Django-App mit Modellen, Views, Formularen und den meisten Geschäftslogiken.
 migrations/: Django-Migrationsdateien, inklusive Daten-Migrationen für Standard-Prompts und -Rollen.
+Nach `python manage.py migrate` füllt `python manage.py seed_initial_data` die Datenbank mit Standarddaten.
 templatetags/: Eigene Template-Erweiterungen (z.B. für Markdown-Rendering).
 management/commands/: Eigene manage.py-Befehle.
 noesis/: Projekteinstellungen und URL-Konfiguration.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Vor jedem Commit **muss** laut `AGENTS.md` folgender Befehl erfolgreich laufen:
 python manage.py makemigrations --check
 ```
 
-Im Anschluss empfiehlt es sich, noch `python manage.py migrate` und
-`python manage.py test` auszuführen.
+Im Anschluss empfiehlt es sich, noch `python manage.py migrate`,
+`python manage.py seed_initial_data` und `python manage.py test`
+auszuführen.
 
 ### Commit-Richtlinien
 
@@ -83,7 +84,7 @@ Projektordner bestehen.
 
 ## Datenbankmigrationen
 
-Führe nach dem Einspielen neuer Code-Änderungen immer `python manage.py migrate` aus. Damit werden Datenbankanpassungen, wie etwa das Entfernen von Unique-Constraints, wirksam. Mit
+Führe nach dem Einspielen neuer Code-Änderungen immer `python manage.py migrate` aus. Damit werden Datenbankanpassungen, wie etwa das Entfernen von Unique-Constraints, wirksam. Anschließend legt `python manage.py seed_initial_data` die Standarddaten erneut an. Mit
 
 ```bash
 python manage.py showmigrations


### PR DESCRIPTION
## Summary
- reference the seed command in project setup docs
- briefly mention the same command in AGENTS.md

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_688bbd623940832bb55e64f0e36155b9