### PR TITLE
fix: ersetzen von lambda in migrations

### DIFF
--- a/core/migrations/0006_formatbparserrule.py
+++ b/core/migrations/0006_formatbparserrule.py
@@ -3,6 +3,19 @@
 from django.db import migrations, models
 
 
+def create_initial_formatb_rules(apps, schema_editor):
+    """Legt die Standard-Parser-Regeln für Format B an."""
+    FormatBParserRule = apps.get_model("core", "FormatBParserRule")
+    FormatBParserRule.objects.bulk_create(
+        [
+            FormatBParserRule(key="tv", target_field="technisch_verfuegbar", ordering=1),
+            FormatBParserRule(key="tel", target_field="einsatz_telefonica", ordering=2),
+            FormatBParserRule(key="lv", target_field="zur_lv_kontrolle", ordering=3),
+            FormatBParserRule(key="ki", target_field="ki_beteiligung", ordering=4),
+        ]
+    )
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -41,14 +54,5 @@ class Migration(migrations.Migration):
                 "ordering": ["ordering", "key"],
             },
         ),
-        migrations.RunPython(
-            lambda apps, schema_editor: apps.get_model("core", "FormatBParserRule").objects.bulk_create(
-                [
-                    apps.get_model("core", "FormatBParserRule")(key="tv", target_field="technisch_verfuegbar", ordering=1),
-                    apps.get_model("core", "FormatBParserRule")(key="tel", target_field="einsatz_telefonica", ordering=2),
-                    apps.get_model("core", "FormatBParserRule")(key="lv", target_field="zur_lv_kontrolle", ordering=3),
-                    apps.get_model("core", "FormatBParserRule")(key="ki", target_field="ki_beteiligung", ordering=4),
-                ]
-            )
-        ),
+        migrations.RunPython(create_initial_formatb_rules),
     ]

--- a/core/migrations/0019_zweckkategoriea.py
+++ b/core/migrations/0019_zweckkategoriea.py
@@ -3,6 +3,44 @@
 from django.db import migrations, models
 
 
+def seed_zweckkategoriea(apps, schema_editor):
+    """Füllt die Tabelle ZweckKategorieA mit Standardwerten."""
+    ZweckKategorieA = apps.get_model("core", "ZweckKategorieA")
+    ZweckKategorieA.objects.bulk_create(
+        [
+            ZweckKategorieA(
+                beschreibung="Leistungsvergleiche von Mitarbeitern oder Mitarbeitergruppen (wenn eine der Gruppen nicht größer als 5 Personen ist)."
+            ),
+            ZweckKategorieA(
+                beschreibung="Abgleich von Verhalten oder Leistung eines Mitarbeiters oder einer Mitarbeitergruppe (wenn eine der Gruppen nicht größer als 5 Personen ist) mit bestimmten Durchschnittsleistungen von Mitarbeitergruppen."
+            ),
+            ZweckKategorieA(
+                beschreibung="Messung der Qualität oder Quantität der Leistung eines Mitarbeiters oder von Kenntnissen oder Fähigkeiten, um das Ergebnis der Messung mit einem Sollwert oder Vorgaben (z. B. betriebliche Ziele) abzugleichen."
+            ),
+            ZweckKategorieA(beschreibung="Messung der Auslastung von Mitarbeitern."),
+            ZweckKategorieA(
+                beschreibung="Feststellung der vergangenheitsbezogenen Termine bzw. Erreichbarkeit oder persönlichen Verfügbarkeit eines Mitarbeiters."
+            ),
+            ZweckKategorieA(
+                beschreibung="Feststellung der Termine bzw. Erreichbarkeit oder persönlichen Verfügbarkeit des Mitarbeiters in Echtzeit."
+            ),
+            ZweckKategorieA(
+                beschreibung="Feststellung der zukünftigen Termine bzw. Erreichbarkeit oder persönlichen Verfügbarkeit des Mitarbeiters in Echtzeit."
+            ),
+            ZweckKategorieA(
+                beschreibung="Erstellung von Bewertungen von Leistung oder Verhalten von Mitarbeitern (z. B. Zeugnisse, Scorecards etc.)."
+            ),
+            ZweckKategorieA(
+                beschreibung="Identifikation von Mitarbeitern nach bestimmten Skills (Kenntnisse, Fähigkeiten und Erfahrungen)."
+            ),
+            ZweckKategorieA(beschreibung="Erstellung von Persönlichkeitsprofilen."),
+            ZweckKategorieA(
+                beschreibung="Ermittlung des aktuellen Arbeitsortes/Aufenthaltsortes."
+            ),
+        ]
+    )
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("core", "0018_bvprojectfile_verification_task_id"),
@@ -29,46 +67,5 @@ class Migration(migrations.Migration):
                 "ordering": ["id"],
             },
         ),
-        migrations.RunPython(
-            lambda apps, schema_editor: apps.get_model(
-                "core", "ZweckKategorieA"
-            ).objects.bulk_create(
-                [
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Leistungsvergleiche von Mitarbeitern oder Mitarbeitergruppen (wenn eine der Gruppen nicht größer als 5 Personen ist)."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Abgleich von Verhalten oder Leistung eines Mitarbeiters oder einer Mitarbeitergruppe (wenn eine der Gruppen nicht größer als 5 Personen ist) mit bestimmten Durchschnittsleistungen von Mitarbeitergruppen."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Messung der Qualität oder Quantität der Leistung eines Mitarbeiters oder von Kenntnissen oder Fähigkeiten, um das Ergebnis der Messung mit einem Sollwert oder Vorgaben (z. B. betriebliche Ziele) abzugleichen."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Messung der Auslastung von Mitarbeitern."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Feststellung der vergangenheitsbezogenen Termine bzw. Erreichbarkeit oder persönlichen Verfügbarkeit eines Mitarbeiters."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Feststellung der Termine bzw. Erreichbarkeit oder persönlichen Verfügbarkeit des Mitarbeiters in Echtzeit."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Feststellung der zukünftigen Termine bzw. Erreichbarkeit oder persönlichen Verfügbarkeit des Mitarbeiters in Echtzeit."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Erstellung von Bewertungen von Leistung oder Verhalten von Mitarbeitern (z. B. Zeugnisse, Scorecards etc.)."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Identifikation von Mitarbeitern nach bestimmten Skills (Kenntnisse, Fähigkeiten und Erfahrungen)."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Erstellung von Persönlichkeitsprofilen."
-                    ),
-                    apps.get_model("core", "ZweckKategorieA")(
-                        beschreibung="Ermittlung des aktuellen Arbeitsortes/Aufenthaltsortes."
-                    ),
-                ]
-            ),
-            reverse_code=migrations.RunPython.noop,
-        ),
+        migrations.RunPython(seed_zweckkategoriea, reverse_code=migrations.RunPython.noop),
     ]

--- a/core/migrations/0031_anlage3_parser_rule.py
+++ b/core/migrations/0031_anlage3_parser_rule.py
@@ -3,6 +3,31 @@
 from django.db import migrations, models
 
 
+def seed_anlage3_parser_rules(apps, schema_editor):
+    """Erzeugt die Standardregeln für Anlage 3."""
+    Anlage3ParserRule = apps.get_model("core", "Anlage3ParserRule")
+    Anlage3ParserRule.objects.create(
+        field_name="name",
+        aliases=["name der auswertung", "name", "bezeichnung"],
+        ordering=1,
+    )
+    Anlage3ParserRule.objects.create(
+        field_name="beschreibung",
+        aliases=["beschreibung", "kurzbeschreibung"],
+        ordering=2,
+    )
+    Anlage3ParserRule.objects.create(
+        field_name="zeitraum",
+        aliases=["zeitraum", "auswertungszeitraum"],
+        ordering=3,
+    )
+    Anlage3ParserRule.objects.create(
+        field_name="art",
+        aliases=["art der auswertung", "auswertungsart", "typ"],
+        ordering=4,
+    )
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -43,29 +68,5 @@ class Migration(migrations.Migration):
                 "ordering": ["ordering", "id"],
             },
         ),
-        migrations.RunPython(
-            lambda apps, schema_editor: [
-                apps.get_model("core", "Anlage3ParserRule").objects.create(
-                    field_name="name",
-                    aliases=["name der auswertung", "name", "bezeichnung"],
-                    ordering=1,
-                ),
-                apps.get_model("core", "Anlage3ParserRule").objects.create(
-                    field_name="beschreibung",
-                    aliases=["beschreibung", "kurzbeschreibung"],
-                    ordering=2,
-                ),
-                apps.get_model("core", "Anlage3ParserRule").objects.create(
-                    field_name="zeitraum",
-                    aliases=["zeitraum", "auswertungszeitraum"],
-                    ordering=3,
-                ),
-                apps.get_model("core", "Anlage3ParserRule").objects.create(
-                    field_name="art",
-                    aliases=["art der auswertung", "auswertungsart", "typ"],
-                    ordering=4,
-                ),
-            ],
-            reverse_code=migrations.RunPython.noop,
-        ),
+        migrations.RunPython(seed_anlage3_parser_rules, reverse_code=migrations.RunPython.noop),
     ]


### PR DESCRIPTION
## Summary
- ersetzen Lambda-Funktionen in mehreren Migrationen durch benannte Funktionen

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_688bc9927fe8832ba0075e8936c5f8e1