### PR TITLE
Add SQLite fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Projektwurzelverzeichnis (`BASE_DIR`). Existiert die Datei nicht, kann sie
 einfach als leere Datei angelegt werden, sofern Schreibrechte im
 Projektordner bestehen.
 
+## Datenbank
+
+Ohne gesetzte PostgreSQL-Variablen (`DB_NAME`, `DB_USER`, `DB_PASSWORD` und
+`DB_HOST`) verwendet NOESIS automatisch SQLite. Die Datei `db.sqlite3` wird im
+Projektverzeichnis angelegt. Für den Produktivbetrieb ist PostgreSQL
+empfohlen.
+
 ## Datenbankmigrationen
 
 Führe nach dem Einspielen neuer Code-Änderungen immer `python manage.py migrate` aus. Damit werden Datenbankanpassungen, wie etwa das Entfernen von Unique-Constraints, wirksam. Anschließend legt `python manage.py seed_initial_data` die Standarddaten erneut an. Mit

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import os
 import sys
 import secrets
+from typing import Any, Dict
 from dotenv import load_dotenv
 from django.core.exceptions import ImproperlyConfigured
 
@@ -92,8 +93,12 @@ WSGI_APPLICATION = "noesis.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-DATABASES = {
-    "default": {
+POSTGRES_VARS = ["DB_NAME", "DB_USER", "DB_PASSWORD", "DB_HOST"]
+
+def _postgres_config() -> Dict[str, Any]:
+    """Liefert die Einstellungen für PostgreSQL."""
+
+    return {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": os.environ.get("DB_NAME", "noesis_db"),
         "USER": os.environ.get("DB_USER", secrets.token_hex(8)),
@@ -101,7 +106,18 @@ DATABASES = {
         "HOST": os.environ.get("DB_HOST", "localhost"),
         "PORT": os.environ.get("DB_PORT", "5432"),
     }
-}
+
+if all(os.environ.get(var) for var in POSTGRES_VARS):
+    # Verwendung der konfigurierten PostgreSQL-Datenbank
+    DATABASES = {"default": _postgres_config()}
+else:
+    # Fallback auf SQLite in der Entwicklungsumgebung
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+    }
 
 
 # Password validation


### PR DESCRIPTION
## Summary
- enable SQLite fallback when PostgreSQL variables aren't set
- document automatic fallback to SQLite

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: UNIQUE constraint failed)*

------
https://chatgpt.com/codex/tasks/task_e_688d1cc4f904832bb8e73bfa72b76624