### PR TITLE
Fix incompatible M2M migration

### DIFF
--- a/core/migrations/0005_alter_area_groups_alter_tile_groups_and_more.py
+++ b/core/migrations/0005_alter_area_groups_alter_tile_groups_and_more.py
@@ -14,7 +14,11 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
+        migrations.RemoveField(
+            model_name="area",
+            name="groups",
+        ),
+        migrations.AddField(
             model_name="area",
             name="groups",
             field=models.ManyToManyField(
@@ -25,7 +29,11 @@ class Migration(migrations.Migration):
                 to="auth.group",
             ),
         ),
-        migrations.AlterField(
+        migrations.RemoveField(
+            model_name="tile",
+            name="groups",
+        ),
+        migrations.AddField(
             model_name="tile",
             name="groups",
             field=models.ManyToManyField(


### PR DESCRIPTION
## Summary
- recreate Area.groups and Tile.groups with through models
- restore UserAreaAccess model

## Testing
- `python manage.py makemigrations --check`
- `python manage.py migrate`


------
https://chatgpt.com/codex/tasks/task_e_688f75da8158832bb5a9bff52e6455a0