### PR TITLE
feat: add config transfer export import

### DIFF
--- a/core/management/commands/__init__.py
+++ b/core/management/commands/__init__.py
@@ -4,3 +4,5 @@ from . import check_anlage2  # noqa: F401
 from . import check_anlage2_functions  # noqa: F401
 from . import check_anlage5  # noqa: F401
 from . import seed_initial_data  # noqa: F401
+from . import export_configs  # noqa: F401
+from . import import_configs  # noqa: F401

--- a/core/management/commands/export_configs.py
+++ b/core/management/commands/export_configs.py
@@ -1,0 +1,38 @@
+from django.core.management.base import BaseCommand
+from django.core import serializers
+
+from core.models import (
+    Prompt,
+    LLMRole,
+    FormatBParserRule,
+    ProjectStatus,
+    Area,
+    Tile,
+    Anlage2Config,
+    Anlage2Function,
+    SupervisionStandardNote,
+)
+
+
+class Command(BaseCommand):
+    """Exportiert Konfigurationsdaten als JSON."""
+
+    help = "Exportiert Konfigurationsmodelle als JSON."  # noqa: A003
+
+    def handle(self, *args, **options) -> None:  # noqa: ANN001
+        """Serialisiert alle wichtigen Konfigurationsmodelle."""
+        objects = []
+        for model in [
+            Prompt,
+            LLMRole,
+            FormatBParserRule,
+            ProjectStatus,
+            Area,
+            Tile,
+            Anlage2Config,
+            Anlage2Function,
+            SupervisionStandardNote,
+        ]:
+            objects.extend(model.objects.all())
+        data = serializers.serialize("json", objects, ensure_ascii=False, indent=2)
+        self.stdout.write(data)

--- a/core/management/commands/import_configs.py
+++ b/core/management/commands/import_configs.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from django.core import serializers
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """Importiert Konfigurationsdaten aus einer JSON-Datei."""
+
+    help = "Importiert Konfigurationsmodelle aus einer JSON-Datei."  # noqa: A003
+
+    def add_arguments(self, parser) -> None:  # noqa: ANN001
+        parser.add_argument("json_file", type=str, help="Pfad zur JSON-Datei")
+
+    def handle(self, *args, **options) -> None:  # noqa: ANN001
+        """Deserialisiert und speichert die Konfigurationsmodelle."""
+        json_path = Path(options["json_file"])
+        data = json_path.read_text(encoding="utf-8")
+        for deserialized in serializers.deserialize("json", data):
+            obj = deserialized.object
+            model = obj.__class__
+            defaults = {}
+            for field in model._meta.fields:
+                if field.primary_key:
+                    continue
+                defaults[field.name] = getattr(obj, field.name)
+            instance, _ = model.objects.update_or_create(pk=obj.pk, defaults=defaults)
+            for field, value in deserialized.m2m_data.items():
+                getattr(instance, field).set(value)
+        self.stdout.write(self.style.SUCCESS("Konfigurationen importiert"))

--- a/core/urls.py
+++ b/core/urls.py
@@ -41,6 +41,11 @@ urlpatterns = [
     ),
     path("recording/delete/<int:pk>/", views.recording_delete, name="recording_delete"),
     path("talkdiary-admin/", views.admin_talkdiary, name="admin_talkdiary"),
+    path(
+        "admin/config-transfer/",
+        views.config_export_import_view,
+        name="config_transfer",
+    ),
     path("projects-admin/", views.admin_projects, name="admin_projects"),
     path(
         "projects-admin/export/",

--- a/noesis/urls.py
+++ b/noesis/urls.py
@@ -20,8 +20,8 @@ from django.conf import settings
 from django.conf.urls.static import static
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
     path('', include('core.urls')),
+    path('admin/', admin.site.urls),
 ]
 
 if settings.DEBUG:

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -62,6 +62,10 @@
                         <i class="fas fa-check-square fa-fw mr-2"></i>
                         Rollen &amp; Rechte
                     </a>
+                    <a href="{% url 'config_transfer' %}" class="nav-link {% if request.resolver_match.url_name == 'config_transfer' %}active-nav-link{% endif %}">
+                        <i class="fas fa-exchange-alt fa-fw mr-2"></i>
+                        Konfigurationen übertragen
+                    </a>
                 </div>
                 {% endwith %}
             </div>

--- a/templates/admin/config_transfer.html
+++ b/templates/admin/config_transfer.html
@@ -1,0 +1,14 @@
+{% extends "admin/base_site.html" %}
+
+{% block admin_content %}
+<h1 class="text-xl font-bold mb-4">Konfigurationen exportieren / importieren</h1>
+<form method="post" class="mb-6">
+    {% csrf_token %}
+    <button type="submit" name="export" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</button>
+</form>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    <input type="file" name="config_file" accept="application/json" required>
+    <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add management commands to export and import configuration models
- add staff-only admin view to trigger JSON config export or import
- expose config transfer page at `/admin/config-transfer/` and link from admin navigation

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_688f780cbad8832b822486544f847fda