### PR TITLE
fix: starte Analyse-Tasks nach Commit

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.contrib.auth.models import Permission, Group
 
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django_q.tasks import async_task, fetch
 from pathlib import Path
 import logging
@@ -145,9 +145,11 @@ class BVProject(models.Model):
                 quelle="ki",
             ).exists()
             if not has_ai_results:
-                async_task(
-                    "core.llm_tasks.run_conditional_anlage2_check",
-                    self.pk,
+                transaction.on_commit(
+                    lambda: async_task(
+                        "core.llm_tasks.run_conditional_anlage2_check",
+                        self.pk,
+                    )
                 )
 
     def __str__(self) -> str:

--- a/core/views.py
+++ b/core/views.py
@@ -4144,10 +4144,12 @@ def projekt_functions_check(request, pk):
     projekt = get_object_or_404(BVProject, pk=pk)
     pf = BVProjectFile.objects.filter(projekt=projekt, anlage_nr=2).first()
     if pf:
-        async_task(
-            "core.llm_tasks.run_conditional_anlage2_check",
-            pf.pk,
-            model,
+        transaction.on_commit(
+            lambda: async_task(
+                "core.llm_tasks.run_conditional_anlage2_check",
+                pf.pk,
+                model,
+            )
         )
     return JsonResponse({"status": "ok"})
 


### PR DESCRIPTION
## Summary
- starte Datei-Analysen erst nach erfolgreichem DB-Commit
- plane Projekt-Prüfung erst nach Commit der Prompt-Änderung
- löse Funktionen-Check per Hook nach Transaktionsende aus

## Testing
- `DJANGO_SECRET_KEY=test python manage.py makemigrations --check`
- `DJANGO_SECRET_KEY=test python manage.py test core.tests.test_general -k get_analysis_tasks -v 2`


------
https://chatgpt.com/codex/tasks/task_e_688f7ef168e0832ba9a3c910d165cf40