### PR TITLE
feat: konfigurierbare Q-Workerzahl

### DIFF
--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -379,14 +379,14 @@ if sys.version_info >= (3, 12):
 # Django-Q Konfiguration
 Q_CLUSTER = {
     "name": "noesis_q",
-    "workers": 1,
+    # Anzahl der Worker aus ENV oder der Anzahl der CPU-Kerne ableiten
+    "workers": int(os.environ.get("Q_CLUSTER_WORKERS", os.cpu_count() or 1)),
     "recycle": 500,
     "timeout": 1200,
     "retry": 1300,
     "compress": True,
     "save_limit": 250,
     "queue_limit": 500,
-    "cpu_affinity": 1,
     "label": "Django Q",
     "orm": "default",
 }


### PR DESCRIPTION
## Summary
- konfigurierbare Anzahl von django-q Workern über `Q_CLUSTER_WORKERS` oder CPU-Kerne
- entfernt `cpu_affinity` aus den Q-Cluster-Einstellungen

## Testing
- `pre-commit run --files noesis/settings.py`
- `DJANGO_SECRET_KEY=dummy python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_688fb32dd7d8832ba2c54efe01c6820d