### PR TITLE
fix: log missing Anlage with number

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1712,7 +1712,8 @@ def worker_verify_feature(
         )
     except IntegrityError:
         logger.warning(
-            "Anlage-Datei %s fehlt. Prüfung wird abgebrochen.",
+            "Anlage %s (ID %s) fehlt. Prüfung wird abgebrochen.",
+            pf.anlage_nr,
             pf.pk,
         )
         return verification_result


### PR DESCRIPTION
## Summary
- log missing Anlage number and id when project file is missing during feature verification

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_selenium` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_688fb3374930832bb7ac390c4f5bb0da