### PR TITLE
fix: fallback to analysis data when parser results missing

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2647,6 +2647,19 @@ class Anlage2ReviewTests(NoesisTestCase):
         field = f"func{self.func.id}_technisch_vorhanden"
         self.assertTrue(resp.context["form"].initial[field])
 
+    def test_prefill_with_metadaten_no_ergebnis(self):
+        """Analysewerte werden auch ohne FunktionsErgebnisse angezeigt."""
+        self.file.manual_analysis_json = None
+        self.file.save()
+        AnlagenFunktionsMetadaten.objects.create(
+            anlage_datei=self.file,
+            funktion=self.func,
+        )
+        url = reverse("projekt_file_edit_json", args=[self.file.pk])
+        resp = self.client.get(url)
+        field = f"func{self.func.id}_technisch_vorhanden"
+        self.assertTrue(resp.context["form"].initial[field])
+
     def test_rows_include_lookup_key(self):
         url = reverse("projekt_file_edit_json", args=[self.file.pk])
         resp = self.client.get(url)


### PR DESCRIPTION
## Summary
- ensure `_analysis_to_initial` loads analysis_json when parser results are absent and fills missing function fields
- add regression test for AnlagenFunktionsMetadaten without FunktionsErgebnis

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ReviewTests.test_prefill_with_metadaten_no_ergebnis -v 2`
- `python manage.py test core.tests.test_general.Anlage2ReviewTests.test_prefill_from_analysis -v 2`


------
https://chatgpt.com/codex/tasks/task_e_688fb7f2e930832b8ad40e7291f49045