### PR TITLE
fix: Metadatenlöschung auf geprüfte Anlage beschränken

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1395,9 +1395,10 @@ def run_conditional_anlage2_check(
         pf.processing_status = BVProjectFile.PROCESSING
         pf.save(update_fields=["processing_status"])
 
-        # Alle bisherigen Prüfergebnisse entfernen
+        # Alle bisherigen Prüfergebnisse der geprüften Anlage entfernen
         AnlagenFunktionsMetadaten.objects.filter(
-            anlage_datei__projekt=projekt
+            anlage_datei=pf,
+            anlage_datei__anlage_nr=2,
         ).delete()
 
         for func in Anlage2Function.objects.prefetch_related(


### PR DESCRIPTION
## Summary
- lösche nur Metadaten der aktuellen Anlage 2 in `run_conditional_anlage2_check`
- teste, dass andere Anlagen von der Löschung unberührt bleiben

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ResetTests.test_conditional_check_deletes_only_current_file_metadata -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689051dd1240832bb0b3ca23c8ba1e26