### PR TITLE
fix: mark Anlage2 analysis as complete

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -512,6 +512,7 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
             )
             project_file.analysis_json = {"functions": results}
             project_file.save(update_fields=["analysis_json"])
+            update_file_status(project_file.pk, BVProjectFile.COMPLETE)
             return results
         FunktionsErgebnis.objects.create(
             projekt=project_file.projekt,
@@ -527,6 +528,7 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
 
     project_file.analysis_json = {"functions": results}
     project_file.save(update_fields=["analysis_json"])
+    update_file_status(project_file.pk, BVProjectFile.COMPLETE)
     return results
 
 
@@ -546,6 +548,7 @@ def worker_run_anlage2_analysis(file_id: int) -> list[dict[str, object]]:
         return []
     pf = qs.first()
     result = run_anlage2_analysis(pf)
+    update_file_status(pf.pk, BVProjectFile.COMPLETE)
     anlage2_logger.info(
         "worker_run_anlage2_analysis beendet für Datei %s",
         file_id,

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -1876,6 +1876,23 @@ class LLMTasksTests(NoesisTestCase):
         }]
         self.assertEqual(result, expected)
 
+    def test_run_anlage2_analysis_sets_complete_status(self):
+        """Prüft, dass der Status nach der Analyse auf COMPLETE gesetzt wird."""
+
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            projekt=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("a.txt", b"x"),
+            text_content="",
+        )
+        Anlage2Function.objects.create(name="Login")
+
+        run_anlage2_analysis(pf)
+
+        pf.refresh_from_db()
+        self.assertEqual(pf.processing_status, BVProjectFile.COMPLETE)
+
     def test_check_anlage2_table_error_fallback(self):
         class P1(AbstractParser):
             name = "p1"


### PR DESCRIPTION
## Summary
- mark Anlage 2 parser analysis as complete when done
- ensure background worker sets file status
- test that Anlage 2 analysis marks file as complete

## Testing
- `DJANGO_SECRET_KEY=test python manage.py makemigrations --check`
- `DJANGO_SECRET_KEY=test python manage.py test core.tests.test_general.LLMTasksTests.test_run_anlage2_analysis_sets_complete_status -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68905dbc8e10832bafca514fdd317e63