### PR TITLE
fix: remove metadata only for current file

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -358,11 +358,9 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
         project_file.projekt_id,
     )
 
-    # Alte Ergebnisse zum Projekt entfernen, damit nur die aktuelle Datei
-    # berücksichtigt wird
-    AnlagenFunktionsMetadaten.objects.filter(
-        anlage_datei__projekt=project_file.projekt
-    ).delete()
+    # Alte Ergebnisse zur Datei entfernen, damit nur aktuelle Resultate
+    # berücksichtigt werden
+    AnlagenFunktionsMetadaten.objects.filter(anlage_datei=project_file).delete()
 
     cfg = Anlage2Config.get_instance()
     token_map = build_token_map(cfg)


### PR DESCRIPTION
## Summary
- restrict cleanup to `AnlagenFunktionsMetadaten` for the currently analyzed file

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ResetTests.test_run_anlage2_analysis_resets_results` *(fails: AttributeError: parse_anlage2_text missing)*

------
https://chatgpt.com/codex/tasks/task_e_689086785c10832ba2746c622bcd0fbe