### PR TITLE
fix: korrigiere UniqueConstraint in Migration

### DIFF
--- a/core/migrations/0007_alter_anlagenfunktionsmetadaten_unique.py
+++ b/core/migrations/0007_alter_anlagenfunktionsmetadaten_unique.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0006_alter_anlagenfunktionsmetadaten_anlage_datei"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="anlagenfunktionsmetadaten",
+            unique_together={("anlage_datei", "funktion", "subquestion")},
+        ),
+    ]


### PR DESCRIPTION
## Summary
- verschiebe UniqueConstraint von der initialen Migration in eine neue Datei
- erzwinge Eindeutigkeit für `anlage_datei`, `funktion` und `subquestion`

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6890867709f4832b9632915cb0633b6a