### PR TITLE
feat: log Anlage-2-Schreibzugriffe

### DIFF
--- a/noesis/logging_filters.py
+++ b/noesis/logging_filters.py
@@ -1,0 +1,27 @@
+"""Hilfsfilter für Logging-Konfiguration."""
+
+import logging
+
+
+class Anlage2DBWriteFilter(logging.Filter):
+    """Filtert SQL-Schreiboperationen für Anlage 2."""
+
+    TARGET_TABLES = (
+        "core_anlagenfunktionsmetadaten",
+        "core_funktionsergebnis",
+    )
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Gibt nur Schreiboperationen auf Anlage 2-Tabellen frei."""
+
+        sql: str = getattr(record, "sql", "")
+        if not sql:
+            return False
+        upper_sql = sql.upper()
+        if not (
+            upper_sql.startswith("INSERT")
+            or upper_sql.startswith("UPDATE")
+            or upper_sql.startswith("DELETE")
+        ):
+            return False
+        return any(table in upper_sql for table in self.TARGET_TABLES)

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -210,6 +210,11 @@ LOGGING = {
             "style": "{",
         },
     },
+    "filters": {
+        "anlage2_db_writes": {
+            "()": "noesis.logging_filters.Anlage2DBWriteFilter",
+        },
+    },
     "handlers": {
         "console": {
             "level": "INFO",  # Zeigt nur Informationen und Fehler in der Konsole an
@@ -241,6 +246,14 @@ LOGGING = {
             "filename": BASE_DIR / "anlage2-debug.log",
             "formatter": "verbose",
             "encoding": "utf-8",
+        },
+        "postgres_anlage2_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "postgres-anlage2.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+            "filters": ["anlage2_db_writes"],
         },
         "anlage2_ergebnis_file": {
             "level": "DEBUG",
@@ -308,6 +321,11 @@ LOGGING = {
         "django": {  # Der Django-spezifische Logger
             "handlers": ["console", "file"],
             "level": "INFO",  # Django selbst loggt nicht alles auf DEBUG standardmäßig, INFO ist oft ausreichend
+            "propagate": False,
+        },
+        "django.db.backends": {
+            "handlers": ["postgres_anlage2_file"],
+            "level": "DEBUG",
             "propagate": False,
         },
         "llm_debugger": {


### PR DESCRIPTION
## Summary
- add filter to log SQL write operations of Anlage 2 tables
- route `django.db.backends` queries to new `postgres-anlage2.log`

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_689094a6a7b4832b8d26c1a9ab9dfdac