### PR TITLE
fix: make FunktionsErgebnis queries version-aware

### DIFF
--- a/core/tests/test_versioned_results.py
+++ b/core/tests/test_versioned_results.py
@@ -1,0 +1,53 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from core.models import (
+    Anlage2Function,
+    AnlagenFunktionsMetadaten,
+    BVProject,
+    BVProjectFile,
+    FunktionsErgebnis,
+)
+from core.views import _verification_to_initial
+
+
+def test_funktions_ergebnisse_sind_versionsabhaengig(db):
+    """Prüft, dass Ergebnisse pro Anlagen-Version getrennt gespeichert werden."""
+    projekt = BVProject.objects.create(title="P")
+    funktion = Anlage2Function.objects.create(name="Login")
+    pf1 = BVProjectFile.objects.create(
+        project=projekt,
+        anlage_nr=2,
+        upload=SimpleUploadedFile("a.txt", b"a"),
+        version=1,
+    )
+    pf2 = BVProjectFile.objects.create(
+        project=projekt,
+        anlage_nr=2,
+        upload=SimpleUploadedFile("b.txt", b"b"),
+        version=2,
+    )
+
+    AnlagenFunktionsMetadaten.objects.create(anlage_datei=pf1, funktion=funktion)
+    AnlagenFunktionsMetadaten.objects.create(anlage_datei=pf2, funktion=funktion)
+
+    FunktionsErgebnis.objects.create(
+        project=projekt,
+        anlage_datei=pf1,
+        funktion=funktion,
+        quelle="ki",
+        technisch_verfuegbar=True,
+    )
+    FunktionsErgebnis.objects.create(
+        project=projekt,
+        anlage_datei=pf2,
+        funktion=funktion,
+        quelle="ki",
+        technisch_verfuegbar=False,
+    )
+
+    data1 = _verification_to_initial(pf1)
+    data2 = _verification_to_initial(pf2)
+
+    fid = str(funktion.id)
+    assert data1["functions"][fid]["technisch_vorhanden"] is True
+    assert data2["functions"][fid]["technisch_vorhanden"] is False

--- a/core/views.py
+++ b/core/views.py
@@ -425,7 +425,7 @@ def _verification_to_initial(pf: BVProjectFile | None) -> dict:
             )
         latest = (
             FunktionsErgebnis.objects.filter(
-                projekt=res.anlage_datei.project,
+                anlage_datei=res.anlage_datei,
                 funktion_id=res.funktion_id,
                 subquestion_id=res.subquestion_id,
                 quelle="ki",


### PR DESCRIPTION
## Summary
- scope FunktionsErgebnis KI lookups by anlage_datei to respect file versions
- add regression test ensuring separate results per BVProjectFile version

## Testing
- `python manage.py makemigrations --check` *(fails: SyntaxError: expected 'except' or 'finally' block in core/llm_tasks.py)*
- `python manage.py test core.tests.test_versioned_results -v 2` *(fails: SyntaxError: expected 'except' or 'finally' block in core/llm_tasks.py)*

------
https://chatgpt.com/codex/tasks/task_e_6890ba8b6b90832bbe896b0aea5868f5