### PR TITLE
Add initial answer detection rules

### DIFF
--- a/core/initial_data_constants.py
+++ b/core/initial_data_constants.py
@@ -444,4 +444,22 @@ INITIAL_ANLAGE2_CONFIG = {
     ],
 }
 
+# 7. Antwort-Erkennungsregeln
+INITIAL_ANSWER_RULES = [
+    {
+        "regel_name": "Antwort Ja",
+        "erkennungs_phrase": "ja",
+        "actions": [{"field": "einsatz_telefonica", "value": True}],
+        "regel_anwendungsbereich": "Hauptfunktion",
+        "prioritaet": 1,
+    },
+    {
+        "regel_name": "Antwort Nein",
+        "erkennungs_phrase": "nein",
+        "actions": [{"field": "einsatz_telefonica", "value": False}],
+        "regel_anwendungsbereich": "Hauptfunktion",
+        "prioritaet": 2,
+    },
+]
+
 # --- Hauptfunktion der Migration ---

--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -14,6 +14,7 @@ from core.initial_data_constants import (
     INITIAL_ANLAGE1_QUESTIONS,
     INITIAL_ANLAGE2_FUNCTIONS,
     INITIAL_ANLAGE2_CONFIG,
+    INITIAL_ANSWER_RULES,
 )
 
 
@@ -44,6 +45,7 @@ def create_initial_data(apps) -> None:
     FormatBParserRule = apps.get_model("core", "FormatBParserRule")
     ZweckKategorieA = apps.get_model("core", "ZweckKategorieA")
     Anlage3ParserRule = apps.get_model("core", "Anlage3ParserRule")
+    AntwortErkennungsRegel = apps.get_model("core", "AntwortErkennungsRegel")
     Prompt = apps.get_model("core", "Prompt")
     SupervisionStandardNote = apps.get_model("core", "SupervisionStandardNote")
     standard_group, _ = Group.objects.get_or_create(name="Standard-Benutzer")
@@ -170,8 +172,21 @@ def create_initial_data(apps) -> None:
     for rule in parser_rules:
         Anlage3ParserRule.objects.update_or_create(field_name=rule["field_name"], defaults=rule)
 
-    # 10. Prompts
-    print("\n[10] Verarbeite Prompts...")
+    # 10. AntwortErkennungsRegeln
+    print("\n[10] Verarbeite AntwortErkennungsRegeln...")
+    for rule in INITIAL_ANSWER_RULES:
+        AntwortErkennungsRegel.objects.update_or_create(
+            regel_name=rule["regel_name"],
+            defaults={
+                "erkennungs_phrase": rule["erkennungs_phrase"],
+                "actions_json": rule["actions"],
+                "regel_anwendungsbereich": rule["regel_anwendungsbereich"],
+                "prioritaet": rule["prioritaet"],
+            },
+        )
+
+    # 11. Prompts
+    print("\n[11] Verarbeite Prompts...")
     # Zusätzliche Prompt-Texte vorbereiten
     prompts = [
         (
@@ -273,8 +288,8 @@ def create_initial_data(apps) -> None:
     for name, text, use_system_role in prompts:
         Prompt.objects.update_or_create(name=name, defaults={"text": text, "use_system_role": use_system_role})
 
-    # 11. SupervisionStandardNote
-    print("\n[11] Verarbeite SupervisionStandardNotes...")
+    # 12. SupervisionStandardNote
+    print("\n[12] Verarbeite SupervisionStandardNotes...")
     notes = [
         "Kein mitbest. relevanter Einsatz",
         "Lizenz-/kostenpflichtig",
@@ -286,8 +301,8 @@ def create_initial_data(apps) -> None:
             defaults={"display_order": order, "is_active": True},
         )
 
-    # 12. Standard-Benutzer
-    print("\n[12] Erstelle Standard-Benutzer...")
+    # 13. Standard-Benutzer
+    print("\n[13] Erstelle Standard-Benutzer...")
     User = get_user_model()
     user, created = User.objects.get_or_create(username="frank")
     if created:

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -370,6 +370,28 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
         )
 
 
+class SeedInitialDataTests(TestCase):
+    """Tests für das Seeding der Antwortregeln."""
+
+    def test_answer_rules_seeded(self) -> None:
+        """Prüft, ob die Antwortregeln angelegt werden."""
+        call_command("seed_initial_data")
+        from ..initial_data_constants import INITIAL_ANSWER_RULES
+
+        for rule in INITIAL_ANSWER_RULES:
+            obj = AntwortErkennungsRegel.objects.get(
+                regel_name=rule["regel_name"]
+            )
+            self.assertEqual(
+                obj.erkennungs_phrase,
+                rule["erkennungs_phrase"],
+            )
+            self.assertEqual(
+                obj.actions_json,
+                rule["actions"],
+            )
+
+
 class NoesisTestCase(TestCase):
     """Basisklasse für alle Tests mit gefüllter Datenbank."""
 


### PR DESCRIPTION
## Summary
- seed initial answer detection rules with actions and priorities
- include answer rule seeding in `seed_initial_data` command
- test that seeding creates defined answer rules

## Testing
- `DJANGO_SECRET_KEY=dev DJANGO_SETTINGS_MODULE=noesis.settings python manage.py makemigrations --check`
- `DJANGO_SECRET_KEY=dev DJANGO_SETTINGS_MODULE=noesis.settings python manage.py test core.tests.test_general.SeedInitialDataTests -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6890e9f3ebcc832b8a638751080db8dc