### PR TITLE
fix: drop check_anlage3 prompt

### DIFF
--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -268,7 +268,6 @@ def create_initial_data(apps) -> None:
                 "Prüfe anhand des folgenden Textes, ob die genannte Funktion vorhanden ist. Gib ein JSON mit den Schlüsseln \"technisch_verfuegbar\", \"einsatz_telefonica\", \"zur_lv_kontrolle\" und \"ki_beteiligung\" zurück.\n\n",
                 True,
             ),
-            ("check_anlage3", "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n", True),
             ("check_anlage4", "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n", True),
             ("check_anlage5", "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n", True),
             ("classify_system", "Bitte klassifiziere das folgende Softwaresystem. Gib ein JSON mit den Schlüsseln 'kategorie' und 'begruendung' zurück.\n\n", True),

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -315,9 +315,6 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
                 "zurück.\n\n"
             )
         },
-        "check_anlage3": {
-            "text": "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n"
-        },
         "check_anlage4": {
             "text": "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n"
         },


### PR DESCRIPTION
## Summary
- remove `check_anlage3` prompt from initial seed data
- drop related test configuration

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.SeedInitialDataTests.test_answer_rules_seeded core.tests.test_general.PromptTests.test_check_anlage3_vision_prompt_text -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6890f1cc82c4832ba58cd85e5fbc986d