### PR TITLE
Remove leftover check_anlage4 usage

### DIFF
--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -269,7 +269,6 @@ def create_initial_data(apps) -> None:
                 True,
             ),
             ("check_anlage3", "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n", True),
-            ("check_anlage4", "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n", True),
             ("check_anlage5", "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n", True),
             ("classify_system", "Bitte klassifiziere das folgende Softwaresystem. Gib ein JSON mit den Schlüsseln 'kategorie' und 'begruendung' zurück.\n\n", True),
             ("generate_gutachten", "Erstelle ein technisches Gutachten basierend auf deinem Wissen:\n\n", True),

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -318,9 +318,6 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
         "check_anlage3": {
             "text": "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n"
         },
-        "check_anlage4": {
-            "text": "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n"
-        },
         "check_anlage5": {
             "text": "Prüfe die folgende Anlage auf Vollständigkeit. Gib ein JSON mit 'ok' und 'hinweis' zurück:\n\n"
         },


### PR DESCRIPTION
## Summary
- drop obsolete check_anlage4 prompt from initial data seeding
- clean up check_anlage4 test section

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general --verbosity 2` *(fails: FieldError and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6890f1ce4200832bafbc5bc9f7fa8437