### PR TITLE
feat: erweitere anlagenspezifische Loggingstruktur

### DIFF
--- a/core/anlage3_parser.py
+++ b/core/anlage3_parser.py
@@ -7,7 +7,8 @@ from docx import Document
 
 from .models import BVProjectFile, Anlage3ParserRule
 
-logger = logging.getLogger("anlage3_debug")
+logger = logging.getLogger("anlage3_detail")
+result_logger = logging.getLogger("anlage3_result")
 
 
 _DEFAULT_ALIAS_MAP: Dict[str, list[str]] = {
@@ -72,4 +73,5 @@ def parse_anlage3(project_file: BVProjectFile) -> Dict[str, str]:
             handle_pair(before, after)
 
     logger.debug("Anlage3 Parser Ergebnis: %s", result)
+    result_logger.debug("Anlage3 Endergebnis: %s", result)
     return result

--- a/core/anlage4_parser.py
+++ b/core/anlage4_parser.py
@@ -11,7 +11,8 @@ from .models import BVProjectFile, Anlage4Config, Anlage4ParserConfig
 _DEFAULT_REGEX_PATTERNS = [r"Zweck: (.+)"]
 
 
-logger = logging.getLogger("anlage4_debug")
+logger = logging.getLogger("anlage4_detail")
+result_logger = logging.getLogger("anlage4_result")
 
 
 def _normalize(text: str) -> str:
@@ -121,6 +122,7 @@ def parse_anlage4(
         project_file.pk,
         len(items),
     )
+    result_logger.debug("Anlage4 Endergebnis: %s", items)
     return items
 
 
@@ -317,4 +319,5 @@ def parse_anlage4_dual(
         project_file.pk,
         len(results),
     )
+    result_logger.debug("Anlage4 Dual-Ergebnis: %s", results)
     return results

--- a/core/docx_utils.py
+++ b/core/docx_utils.py
@@ -28,8 +28,8 @@ def extract_text(path: Path) -> str:
     """Extrahiert den gesamten Text einer DOCX-Datei."""
     doc = Document(str(path))
     text = "\n".join(p.text for p in doc.paragraphs)
-    debug_logger = logging.getLogger("anlage2_debug")
-    debug_logger.debug("Rohtext aus %s: %r", path, text)
+    detail_logger = logging.getLogger("anlage2_detail")
+    detail_logger.debug("Rohtext aus %s: %r", path, text)
     return text
 
 
@@ -227,9 +227,9 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
     ``note``.
     """
     logger = logging.getLogger(__name__)
-    debug_logger = logging.getLogger("anlage2_debug")
+    detail_logger = logging.getLogger("anlage2_detail")
     logger.debug(f"Starte parse_anlage2_table mit Pfad: {path}")
-    debug_logger.info("parse_anlage2_table gestartet: %s", path)
+    detail_logger.info("parse_anlage2_table gestartet: %s", path)
 
     try:
         doc = Document(str(path))
@@ -248,7 +248,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
     skipped = 0
     if not doc.tables:
         logger.debug("Keine Tabellen im Dokument gefunden")
-        debug_logger.debug("Keine Tabellen im Dokument gefunden")
+        detail_logger.debug("Keine Tabellen im Dokument gefunden")
     for table_idx, table in enumerate(doc.tables):
         headers_raw = [cell.text for cell in table.rows[0].cells]
         headers = [
@@ -304,13 +304,13 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
 
             if main_col_text and "Wenn die Funktion technisch" not in main_col_text:
                 current_main_function_name = main_col_text
-                debug_logger.debug(
+                detail_logger.debug(
                     "Hauptfunktion erkannt: %s", current_main_function_name
                 )
                 row_data = {"funktion": current_main_function_name}
             elif sub_col_text and current_main_function_name:
                 full_name = f"{current_main_function_name}: {sub_col_text}"
-                debug_logger.debug("Unterfrage erkannt: %s", full_name)
+                detail_logger.debug("Unterfrage erkannt: %s", full_name)
                 row_data = {"funktion": full_name}
                 is_sub = True
 
@@ -328,7 +328,7 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
                         continue
                     row_data[col_name] = _parse_cell_value(row.cells[idx].text)
 
-            debug_logger.debug("Verarbeite Zeile %s: %s", row_idx, row_data)
+            detail_logger.debug("Verarbeite Zeile %s: %s", row_idx, row_data)
             found.append(row_data["funktion"])
             logger.debug(
                 "Zeile %s: Funktion '%s' Daten %s",
@@ -345,10 +345,10 @@ def parse_anlage2_table(path: Path) -> list[dict[str, object]]:
 
     logger.debug(f"Endgültige Ergebnisse: {results}")
     if found:
-        debug_logger.info("Gefundene Funktionen: %s", ", ".join(found))
+        detail_logger.info("Gefundene Funktionen: %s", ", ".join(found))
     if skipped:
-        debug_logger.info("Übersprungene Zeilen: %s", skipped)
-    debug_logger.info("parse_anlage2_table beendet: %s", path)
+        detail_logger.info("Übersprungene Zeilen: %s", skipped)
+    detail_logger.info("parse_anlage2_table beendet: %s", path)
     return results
 
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -35,7 +35,7 @@ from .models import (
     Anlage3Metadata,
 )
 
-parse_exact_logger = logging.getLogger("parse_exact_anlage2_log")
+detail_logger = logging.getLogger("anlage2_detail")
 
 
 class ActionsJSONWidget(forms.Widget):
@@ -1101,7 +1101,7 @@ class AntwortErkennungsRegelForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        parse_exact_logger.debug(
+        detail_logger.debug(
             "Init RegelForm PK=%s actions_json=%r",
             getattr(self.instance, "pk", None),
             self.initial.get("actions_json"),
@@ -1109,7 +1109,7 @@ class AntwortErkennungsRegelForm(forms.ModelForm):
 
     def save(self, commit: bool = True) -> AntwortErkennungsRegel:
         self.instance.actions_json = self.cleaned_data.get("actions_json")
-        parse_exact_logger.debug(
+        detail_logger.debug(
             "Speichere Regel PK=%s actions_json=%r",
             getattr(self.instance, "pk", None),
             self.instance.actions_json,

--- a/core/parser_manager.py
+++ b/core/parser_manager.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Type
 from .models import BVProjectFile, Anlage2Config
 from .parsers import AbstractParser, TableParser, ExactParser
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("anlage2_detail")
 
 
 class ParserManager:
@@ -32,6 +32,7 @@ class ParserManager:
         cfg = Anlage2Config.get_instance()
         mode = project_file.parser_mode or cfg.parser_mode
         order = project_file.parser_order or cfg.parser_order or ["exact"]
+        logger.debug("Parser-Modus: %s Reihenfolge: %s", mode, order)
 
         if mode == "table_only":
             return self._run_single("table", project_file)
@@ -49,13 +50,16 @@ class ParserManager:
             if parser is None:
                 logger.warning("Unbekannter Parser: %s", name)
                 continue
+            logger.debug("Starte Parser: %s", name)
             try:
                 result = parser.parse(project_file)
             except Exception as exc:  # pragma: no cover - Fehlkonfiguration
                 logger.error("Parser '%s' Fehler: %s", name, exc)
                 result = []
             if result:
+                logger.debug("Parser '%s' lieferte %s Einträge", name, len(result))
                 return result
+        logger.debug("Keine Parser lieferten Ergebnisse")
         return []
 
     def _run_single(self, name: str, project_file: BVProjectFile) -> list[dict[str, object]]:

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -755,7 +755,7 @@ class Anlage4ParserTests(NoesisTestCase):
             upload=upload,
             anlage4_config=cfg,
         )
-        with self.assertLogs("anlage4_debug", level="DEBUG") as cm:
+        with self.assertLogs("anlage4_detail", level="DEBUG") as cm:
             parse_anlage4(pf)
         self.assertIn("table detected - 1 items", cm.output[0])
 
@@ -779,7 +779,7 @@ class Anlage4ParserTests(NoesisTestCase):
             text_content="Zweck: A",
             anlage4_config=cfg,
         )
-        with self.assertLogs("anlage4_debug", level="DEBUG") as cm:
+        with self.assertLogs("anlage4_detail", level="DEBUG") as cm:
             parse_anlage4(pf)
         self.assertIn("free text found - 1 items", "".join(cm.output))
 
@@ -1040,7 +1040,7 @@ class Anlage4ParserTests(NoesisTestCase):
             upload=SimpleUploadedFile("x.txt", b""),
             text_content="",
         )
-        with self.assertLogs("anlage4_debug", level="WARNING") as cm:
+        with self.assertLogs("anlage4_detail", level="WARNING") as cm:
             items = parse_anlage4_dual(pf)
         self.assertEqual(items, [])
         self.assertIn("Keine Anlage4ParserConfig vorhanden", "".join(cm.output))

--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -18,8 +18,8 @@ from .models import (
 from .parsers import AbstractParser
 
 logger = logging.getLogger(__name__)
-debug_logger = logging.getLogger("anlage2_debug")
-result_logger = logging.getLogger("anlage2_ergebnis")
+detail_logger = logging.getLogger("anlage2_detail")
+result_logger = logging.getLogger("anlage2_result")
 
 # Standard-Schwelle für Fuzzy-Vergleiche
 FUZZY_THRESHOLD = 80
@@ -103,7 +103,7 @@ def parse_format_b(text: str) -> List[dict[str, object]]:
     Eine vorausgehende Nummerierung wie ``1.`` wird ignoriert.
     """
 
-    debug_logger.info("parse_format_b gestartet")
+    detail_logger.info("parse_format_b gestartet")
     rules = FormatBParserRule.objects.all()
     if rules:
         mapping = {r.key.lower(): r.target_field for r in rules}
@@ -138,7 +138,7 @@ def parse_format_b(text: str) -> List[dict[str, object]]:
             }
         results.append(entry)
 
-    debug_logger.info("parse_format_b beendet: %s Einträge", len(results))
+    detail_logger.info("parse_format_b beendet: %s Einträge", len(results))
 
     return results
 
@@ -168,13 +168,13 @@ def apply_tokens(
     threshold: int = FUZZY_THRESHOLD,
 ) -> None:
     """Wendet Token-Regeln auf einen Textabschnitt an."""
-    debug_logger.debug("Prüfe Tokens in '%s'", text_part)
+    detail_logger.debug("Prüfe Tokens in '%s'", text_part)
     for field, items in token_map.items():
         if field in entry:
             continue
         for phrase, value in sorted(items, key=lambda t: len(t[0]), reverse=True):
             if fuzzy_match(phrase, text_part, threshold):
-                debug_logger.debug(
+                detail_logger.debug(
                     "Token '%s' gefunden, setze %s=%s",
                     phrase,
                     field,
@@ -191,11 +191,11 @@ def apply_rules(
     threshold: int = FUZZY_THRESHOLD,
 ) -> None:
     """Wendet Antwortregeln auf einen Textabschnitt an."""
-    debug_logger.debug("Prüfe Regeln in '%s'", text_part)
+    detail_logger.debug("Prüfe Regeln in '%s'", text_part)
     found_rules: Dict[str, tuple[bool, int, str]] = {}
     for rule in rules:
         match = fuzzy_match(rule.erkennungs_phrase, text_part, threshold)
-        debug_logger.debug(
+        detail_logger.debug(
             "Regelvergleich '%s' (Prio %s) -> %s in '%s'",
             rule.erkennungs_phrase,
             rule.prioritaet,
@@ -220,7 +220,7 @@ def apply_rules(
                         rule.prioritaet,
                         rule.erkennungs_phrase,
                     )
-                    debug_logger.debug(
+                    detail_logger.debug(
                         "Regel '%s' (%s) setzt %s=%s",
                         rule.regel_name,
                         rule.erkennungs_phrase,
@@ -278,7 +278,7 @@ def _alias_regex(alias: str) -> str:
 def parse_anlage2_text(text: str) -> List[dict[str, object]]:
     """Parst die Freitextvariante der Anlage 2."""
 
-    debug_logger.info("parse_anlage2_text gestartet")
+    detail_logger.info("parse_anlage2_text gestartet")
 
     text = _clean_text(text)
     lines = _split_lines(text)
@@ -334,7 +334,7 @@ def parse_anlage2_text(text: str) -> List[dict[str, object]]:
 
         text_part = line
         if found_key:
-            debug_logger.debug(
+            detail_logger.debug(
                 "Analysiere Funktion '%s' mit Text: %s",
                 found_key,
                 text_part,
@@ -359,7 +359,7 @@ def parse_anlage2_text(text: str) -> List[dict[str, object]]:
 
         if current_key:
             entry = results[current_key]
-            debug_logger.debug(
+            detail_logger.debug(
                 "Analysiere Funktion '%s' mit Text: %s",
                 current_key,
                 line,

--- a/core/views.py
+++ b/core/views.py
@@ -163,13 +163,12 @@ from django.conf import settings
 from .templatetags.recording_extras import markdownify
 
 logger = logging.getLogger(__name__)
-debug_logger = logging.getLogger("anlage2_debug")
-admin_a2_logger = logging.getLogger("anlage2_admin_debug")
-anlage2_logger = logging.getLogger("anlage2_debug")
-ergebnis_logger = logging.getLogger("anlage2_ergebnis")
-anlage4_logger = logging.getLogger("anlage4_debug")
+detail_logger = logging.getLogger("anlage2_detail")
+admin_a2_logger = logging.getLogger("anlage2_detail")
+anlage2_logger = logging.getLogger("anlage2_detail")
+ergebnis_logger = logging.getLogger("anlage2_result")
+anlage4_logger = logging.getLogger("anlage4_detail")
 workflow_logger = logging.getLogger("workflow_debug")
-parse_exact_logger = logging.getLogger("parse_exact_anlage2_log")
 
 
 _WHISPER_MODEL = None
@@ -401,7 +400,7 @@ def _analysis_to_initial(anlage: BVProjectFile) -> dict:
         for fid, data in analysis_data.items():
             initial["functions"].setdefault(fid, data)
 
-    debug_logger.debug("Ergebnis initial: %r", initial)
+    detail_logger.debug("Ergebnis initial: %r", initial)
     return initial
 
 
@@ -2393,7 +2392,7 @@ def anlage2_config(request):
     rules_qs = AntwortErkennungsRegel.objects.all().order_by("prioritaet")
     raw_actions = {r.pk: r.actions_json for r in rules_qs}
     for r in rules_qs:
-        parse_exact_logger.debug("Lade Regel %s actions_json=%r", r.pk, r.actions_json)
+        detail_logger.debug("Lade Regel %s actions_json=%r", r.pk, r.actions_json)
     a4_parser_cfg = (
         Anlage4ParserConfig.objects.first() or Anlage4ParserConfig.objects.create()
     )
@@ -2537,7 +2536,7 @@ def anlage2_config(request):
     cfg_form = cfg_form if "cfg_form" in locals() else Anlage2ConfigForm(instance=cfg)
     rule_formset = RuleFormSet(queryset=rules_qs, prefix="rules")
     for f in rule_formset:
-        parse_exact_logger.debug(
+        detail_logger.debug(
             "Formset Rule PK=%s initial actions_json=%r",
             f.instance.pk,
             f.initial.get("actions_json"),
@@ -2548,7 +2547,7 @@ def anlage2_config(request):
         else RuleFormSetFB(queryset=rules_qs, prefix="rules_fb")
     )
     for f in rule_formset_fb:
-        parse_exact_logger.debug(
+        detail_logger.debug(
             "Formset FB Rule PK=%s initial actions_json=%r",
             f.instance.pk,
             f.initial.get("actions_json"),
@@ -3976,14 +3975,14 @@ def projekt_file_edit_json(request, pk):
             lookup_key = func.name
             func_status = analysis_lookup.get(lookup_key, {}).get("technisch_vorhanden")
             if func.name == "Anwesenheitsüberwachung":
-                debug_logger.info(
+                detail_logger.info(
                     "--- Starte detaillierte Prüfung für Funktion: '%s' ---",
                     func.name,
                 )
                 if func_status is True:
-                    debug_logger.info("-> Status: Als 'Technisch verfügbar' erkannt.")
+                    detail_logger.info("-> Status: Als 'Technisch verfügbar' erkannt.")
                 elif func_status is False:
-                    debug_logger.info(
+                    detail_logger.info(
                         "-> Status: Als 'Technisch NICHT verfügbar' erkannt."
                     )
                 note = None
@@ -3991,15 +3990,15 @@ def projekt_file_edit_json(request, pk):
                 if isinstance(tv_entry, dict):
                     note = tv_entry.get("note") or tv_entry.get("text")
                 if note:
-                    debug_logger.info("-> Entscheidungsgrundlage im Text: '%s'", note)
+                    detail_logger.info("-> Entscheidungsgrundlage im Text: '%s'", note)
             else:
-                debug_logger.info(
+                detail_logger.info(
                     "--- Starte Prüfung für Funktion: '%s' ---", func.name
                 )
                 if answers.get(lookup_key):
-                    debug_logger.info("-> Ergebnis: Im Dokument gefunden.")
+                    detail_logger.info("-> Ergebnis: Im Dokument gefunden.")
                 else:
-                    debug_logger.info("-> Ergebnis: Nicht im Dokument gefunden.")
+                    detail_logger.info("-> Ergebnis: Nicht im Dokument gefunden.")
             rows.append(
                 _build_row_data(
                     func.name,
@@ -4019,13 +4018,13 @@ def projekt_file_edit_json(request, pk):
                 if not (
                     func.name == "Anwesenheitsüberwachung" and func_status is not True
                 ):
-                    debug_logger.info(
+                    detail_logger.info(
                         "--- Starte Prüfung für Unterfrage: '%s' ---", sub.frage_text
                     )
                     if answers.get(lookup_key):
-                        debug_logger.info("-> Ergebnis: Im Dokument gefunden.")
+                        detail_logger.info("-> Ergebnis: Im Dokument gefunden.")
                     else:
-                        debug_logger.info("-> Ergebnis: Nicht im Dokument gefunden.")
+                        detail_logger.info("-> Ergebnis: Nicht im Dokument gefunden.")
                 rows.append(
                     _build_row_data(
                         sub.frage_text,

--- a/noesis/logging_filters.py
+++ b/noesis/logging_filters.py
@@ -1,27 +1,17 @@
-"""Hilfsfilter für Logging-Konfiguration."""
+"""Hilfsfilter für anlagenspezifisches Logging."""
+
+from __future__ import annotations
 
 import logging
 
 
-class Anlage2DBWriteFilter(logging.Filter):
-    """Filtert SQL-Schreiboperationen für Anlage 2."""
+class AnlageFilter(logging.Filter):
+    """Filtert Logeinträge anhand der Anlagenummer."""
 
-    TARGET_TABLES = (
-        "core_anlagenfunktionsmetadaten",
-        "core_funktionsergebnis",
-    )
+    def __init__(self, anlage: str) -> None:
+        super().__init__()
+        self.anlage = str(anlage)
 
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Gibt nur Schreiboperationen auf Anlage 2-Tabellen frei."""
-
-        sql: str = getattr(record, "sql", "")
-        if not sql:
-            return record.name.startswith("core.llm_tasks")
-        upper_sql = sql.upper()
-        if not (
-            upper_sql.startswith("INSERT")
-            or upper_sql.startswith("UPDATE")
-            or upper_sql.startswith("DELETE")
-        ):
-            return False
-        return any(table in upper_sql for table in self.TARGET_TABLES)
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - Django-Style
+        """Lässt nur Einträge für die konfigurierte Anlage passieren."""
+        return getattr(record, "anlage", "") == self.anlage

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -214,9 +214,11 @@ LOGGING = {
         },
     },
     "filters": {
-        "anlage2_db_writes": {
-            "()": "noesis.logging_filters.Anlage2DBWriteFilter",
-        },
+        "anlage1": {"()": "noesis.logging_filters.AnlageFilter", "anlage": "1"},
+        "anlage2": {"()": "noesis.logging_filters.AnlageFilter", "anlage": "2"},
+        "anlage3": {"()": "noesis.logging_filters.AnlageFilter", "anlage": "3"},
+        "anlage4": {"()": "noesis.logging_filters.AnlageFilter", "anlage": "4"},
+        "anlage5": {"()": "noesis.logging_filters.AnlageFilter", "anlage": "5"},
     },
     "handlers": {
         "console": {
@@ -236,17 +238,39 @@ LOGGING = {
             "filename": BASE_DIR / "llm-debug.log",
             "formatter": "llm_formatter",
         },
-        "anlage1_file": {
+        "anlage1_detail_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": BASE_DIR / "anlage1-debug.log",
+            "filename": BASE_DIR / "anlage1-detail.log",
             "formatter": "verbose",
             "encoding": "utf-8",
         },
-        "anlage2_file": {
+        "anlage1_result_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": BASE_DIR / "anlage2-debug.log",
+            "filename": BASE_DIR / "anlage-1.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+        },
+        "postgres_anlage1_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "postgres-anlage1.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+            "filters": ["anlage1"],
+        },
+        "anlage2_detail_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "anlage2-detail.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+        },
+        "anlage2_result_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "anlage-2.log",
             "formatter": "verbose",
             "encoding": "utf-8",
         },
@@ -256,49 +280,73 @@ LOGGING = {
             "filename": BASE_DIR / "postgres-anlage2.log",
             "formatter": "verbose",
             "encoding": "utf-8",
-            "filters": ["anlage2_db_writes"],
+            "filters": ["anlage2"],
         },
-        "anlage2_ergebnis_file": {
+        "anlage3_detail_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": BASE_DIR / "anlage2-ergebnis.log",
+            "filename": BASE_DIR / "anlage3-detail.log",
             "formatter": "verbose",
             "encoding": "utf-8",
         },
-        "anlage3_file": {
+        "anlage3_result_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": BASE_DIR / "anlage3-debug.log",
+            "filename": BASE_DIR / "anlage-3.log",
             "formatter": "verbose",
             "encoding": "utf-8",
         },
-        "anlage4_file": {
+        "postgres_anlage3_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": BASE_DIR / "anlage4-debug.log",
+            "filename": BASE_DIR / "postgres-anlage3.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+            "filters": ["anlage3"],
+        },
+        "anlage4_detail_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "anlage4-detail.log",
             "formatter": "verbose",
             "encoding": "utf-8",
         },
-        "anlage5_file": {
+        "anlage4_result_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": BASE_DIR / "anlage5-debug.log",
+            "filename": BASE_DIR / "anlage-4.log",
             "formatter": "verbose",
             "encoding": "utf-8",
         },
-        "anlage2_admin_file": {
+        "postgres_anlage4_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": BASE_DIR / "debug-admin_anlage2_funktionen.log",
+            "filename": BASE_DIR / "postgres-anlage4.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+            "filters": ["anlage4"],
+        },
+        "anlage5_detail_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "anlage5-detail.log",
             "formatter": "verbose",
             "encoding": "utf-8",
         },
-        "parse_exact_anlage2_file": {
+        "anlage5_result_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": BASE_DIR / "parse_exact_anlage2.log",
+            "filename": BASE_DIR / "anlage-5.log",
             "formatter": "verbose",
             "encoding": "utf-8",
+        },
+        "postgres_anlage5_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": BASE_DIR / "postgres-anlage5.log",
+            "formatter": "verbose",
+            "encoding": "utf-8",
+            "filters": ["anlage5"],
         },
         "workflow_file": {
             "level": "DEBUG",
@@ -326,11 +374,6 @@ LOGGING = {
             "level": "INFO",  # Django selbst loggt nicht alles auf DEBUG standardmäßig, INFO ist oft ausreichend
             "propagate": False,
         },
-        "django.db.backends": {
-            "handlers": ["postgres_anlage2_file"],
-            "level": "DEBUG",
-            "propagate": False,
-        },
         "llm_debugger": {
             "handlers": ["llm_file"],
             "level": "DEBUG",
@@ -341,43 +384,64 @@ LOGGING = {
             "level": "DEBUG",  # Hier setzt du den Loglevel für DEINE App auf DEBUG
             "propagate": False,
         },
-        "anlage1_debug": {
-            "handlers": ["anlage1_file"],
+        "anlage1_detail": {
+            "handlers": ["anlage1_detail_file"],
             "level": "DEBUG",
             "propagate": False,
         },
-        "anlage2_debug": {
-            "handlers": ["anlage2_file"],
+        "anlage1_result": {
+            "handlers": ["anlage1_result_file"],
             "level": "DEBUG",
             "propagate": False,
         },
-        "anlage2_ergebnis": {
-            "handlers": ["anlage2_ergebnis_file"],
+        "anlage2_detail": {
+            "handlers": ["anlage2_detail_file"],
             "level": "DEBUG",
             "propagate": False,
         },
-        "anlage3_debug": {
-            "handlers": ["anlage3_file"],
+        "anlage2_result": {
+            "handlers": ["anlage2_result_file"],
             "level": "DEBUG",
             "propagate": False,
         },
-        "anlage4_debug": {
-            "handlers": ["anlage4_file"],
+        "anlage3_detail": {
+            "handlers": ["anlage3_detail_file"],
             "level": "DEBUG",
             "propagate": False,
         },
-        "anlage5_debug": {
-            "handlers": ["anlage5_file"],
+        "anlage3_result": {
+            "handlers": ["anlage3_result_file"],
             "level": "DEBUG",
             "propagate": False,
         },
-        "anlage2_admin_debug": {
-            "handlers": ["anlage2_admin_file"],
+        "anlage4_detail": {
+            "handlers": ["anlage4_detail_file"],
             "level": "DEBUG",
             "propagate": False,
         },
-        "parse_exact_anlage2_log": {
-            "handlers": ["parse_exact_anlage2_file"],
+        "anlage4_result": {
+            "handlers": ["anlage4_result_file"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
+        "anlage5_detail": {
+            "handlers": ["anlage5_detail_file"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
+        "anlage5_result": {
+            "handlers": ["anlage5_result_file"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
+        "postgres": {
+            "handlers": [
+                "postgres_anlage1_file",
+                "postgres_anlage2_file",
+                "postgres_anlage3_file",
+                "postgres_anlage4_file",
+                "postgres_anlage5_file",
+            ],
             "level": "DEBUG",
             "propagate": False,
         },
@@ -392,7 +456,7 @@ LOGGING = {
             "propagate": False,
         },
         "core.llm_tasks": {
-            "handlers": ["console", "file", "postgres_anlage2_file"],
+            "handlers": ["console", "file"],
             "level": "DEBUG",
             "propagate": False,
         },


### PR DESCRIPTION
## Zusammenfassung
- Neue Logging-Filter und -Handler je Anlage konfiguriert
- Detaillierte Parser-Protokollierung und Ergebnis-Logging erweitert
- Anlagenspezifische DB-Logs umgesetzt und veraltete Logs entfernt

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_parsing.py::` *(fehlt wegen IndentationError in test_general.py)*

------
https://chatgpt.com/codex/tasks/task_e_6891a7488eb4832ba19b111afd36b42a