### PR TITLE
feat: erweitertes Logging im ParserManager

### DIFF
--- a/core/parser_manager.py
+++ b/core/parser_manager.py
@@ -57,9 +57,21 @@ class ParserManager:
                 logger.error("Parser '%s' Fehler: %s", name, exc)
                 result = []
             if result:
-                logger.debug("Parser '%s' lieferte %s Einträge", name, len(result))
+                logger.debug(
+                    "Parser '%s' lieferte %s Einträge", name, len(result)
+                )
+                logger.info(
+                    "Parser '%s' lieferte %s Einträge für Datei %s",
+                    name,
+                    len(result),
+                    project_file.upload.name,
+                )
                 return result
         logger.debug("Keine Parser lieferten Ergebnisse")
+        logger.warning(
+            "Kein Parser erzielte Treffer für Datei %s",
+            project_file.upload.name,
+        )
         return []
 
     def _run_single(self, name: str, project_file: BVProjectFile) -> list[dict[str, object]]:


### PR DESCRIPTION
## Summary
- logge Parser-Ergebnisse samt Dateiname
- warne, wenn kein Parser Treffer erzielt

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6891e311d244832ba1ed9927a8fde999