### PR TITLE
feat: erweitere Debug-Logs für Anlage 2

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -353,7 +353,11 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
     einer Funktion werden dabei zusammengeführt.
     """
 
-    anlage2_logger.debug("Starte run_anlage2_analysis für Datei %s", project_file.pk)
+    anlage2_logger.debug(
+        "Starte run_anlage2_analysis für Datei %s (%s)",
+        project_file.pk,
+        project_file.upload.name,
+    )
     workflow_logger.info(
         "[%s] - PARSER START - Beginne Dokumenten-Analyse.",
         project_file.project_id,
@@ -545,6 +549,11 @@ def worker_run_anlage2_analysis(file_id: int) -> list[dict[str, object]]:
         )
         return []
     pf = qs.first()
+    anlage2_logger.debug(
+        "Lade Datei %s (%s)",
+        pf.pk,
+        pf.upload.name,
+    )
     result = run_anlage2_analysis(pf)
     update_file_status(pf.pk, BVProjectFile.COMPLETE)
     anlage2_logger.info(

--- a/core/parser_manager.py
+++ b/core/parser_manager.py
@@ -28,7 +28,11 @@ class ParserManager:
 
     def parse_anlage2(self, project_file: BVProjectFile) -> list[dict[str, object]]:
         """Führt die Parser gemäß Konfiguration aus."""
-
+        logger.debug(
+            "Parse Datei %s (%s)",
+            project_file.pk,
+            project_file.upload.name,
+        )
         cfg = Anlage2Config.get_instance()
         mode = project_file.parser_mode or cfg.parser_mode
         order = project_file.parser_order or cfg.parser_order or ["exact"]


### PR DESCRIPTION
## Summary
- erweitere run_anlage2_analysis um detailliertere Debug-Ausgaben
- protokolliere geladenen Dateinamen im Worker
- logge Dateiinfos vor Parserwahl in parse_anlage2

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_6891e30f8b88832b849625b95973d7a5