### PR TITLE
fix: berücksichtige Verifizierungsstatus beim Analyse-Button

### DIFF
--- a/templates/partials/anlage_status.html
+++ b/templates/partials/anlage_status.html
@@ -11,12 +11,12 @@
 {% endif %}
 
 <div id="anlage-edit-{{ anlage.pk }}" hx-swap="outerHTML"
-    {% if anlage.processing_status == 'PROCESSING' or anlage.processing_status == 'PENDING' %}
+    {% if anlage.processing_status == 'PROCESSING' or anlage.processing_status == 'PENDING' or anlage.is_verification_running %}
         hx-get="{% url 'hx_anlage_status' anlage.pk %}"
         hx-trigger="load, every 5s"
     {% endif %}>
 
-{% if anlage.processing_status == 'PROCESSING' %}
+{% if anlage.processing_status == 'PROCESSING' or anlage.is_verification_running %}
 <span class="table-action-btn table-action-secondary disabled-btn"><span class="spinner"></span> Analyse läuft...</span>
 {% elif anlage.processing_status == 'COMPLETE' %}
 <a href="{{ edit_url }}" class="table-action-btn table-action-primary">Analyse bearbeiten</a>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -13,7 +13,7 @@
     Zur neuen Supervisions-Ansicht wechseln
   </a>
 </p>
-{% if anlage.processing_status == 'PROCESSING' %}
+{% if anlage.processing_status == 'PROCESSING' or anlage.is_verification_running %}
 <div id="anlage-edit-{{ anlage.pk }}" class="p-4 text-center"
      hx-get="{% url 'hx_anlage_status' anlage.pk %}"
      hx-trigger="load, every 5s" hx-swap="outerHTML">


### PR DESCRIPTION
## Summary
- poll and disable action buttons while verification runs
- block Anlage 2 review until all verification tasks finish

## Testing
- `pre-commit run --files templates/partials/anlage_status.html templates/projekt_file_anlage2_review.html`
- `python manage.py makemigrations --check`
- Manually uploaded Anlage 2, started analysis, and verified the button stayed disabled until verification completed

------
https://chatgpt.com/codex/tasks/task_e_68920bf2e914832bb3a04574b270ae73