### PR TITLE
fix: vereinfache GAP-Erkennung

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -101,6 +101,7 @@ from ..views import (
     _save_project_file,
     extract_anlage_nr,
     get_user_tiles,
+    _has_manual_gap,
 )
 from ..reporting import generate_gap_analysis, generate_management_summary
 from unittest.mock import patch, ANY, Mock, call
@@ -4664,3 +4665,25 @@ class GapReportTests(NoesisTestCase):
         self.pf2.refresh_from_db()
         self.assertEqual(self.pf1.gap_summary, "")
         self.assertEqual(self.pf2.gap_summary, "")
+
+
+class ManualGapDetectionTests(TestCase):
+    """Tests für die Funktion ``_has_manual_gap``."""
+
+    def test_detects_difference(self) -> None:
+        """Erkennt eine Abweichung zwischen Dokument und manuellem Wert."""
+        doc_data = {"technisch_vorhanden": True}
+        manual_data = {"technisch_vorhanden": False}
+        self.assertTrue(_has_manual_gap(doc_data, manual_data))
+
+    def test_no_gap_when_equal(self) -> None:
+        """Kein GAP, wenn Werte übereinstimmen."""
+        doc_data = {"technisch_vorhanden": True}
+        manual_data = {"technisch_vorhanden": True}
+        self.assertFalse(_has_manual_gap(doc_data, manual_data))
+
+    def test_gap_when_doc_missing(self) -> None:
+        """Erkennt eine Lücke, wenn Dokumentdaten fehlen."""
+        doc_data: dict = {}
+        manual_data = {"technisch_vorhanden": True}
+        self.assertTrue(_has_manual_gap(doc_data, manual_data))

--- a/core/views.py
+++ b/core/views.py
@@ -541,23 +541,16 @@ def _get_display_data(
     }
 
 
-def _has_manual_gap(doc_data: dict, ai_data: dict, manual_data: dict) -> bool:
-    """Prüft, ob ein manueller Wert einen neuen GAP erzeugt."""
+def _has_manual_gap(doc_data: dict, manual_data: dict) -> bool:
+    """Prüft, ob ein manueller Wert von den Dokumentdaten abweicht."""
 
     for field, _ in get_anlage2_fields():
-        doc_val = _extract_bool(doc_data.get(field))
-        ai_val = _extract_bool(ai_data.get(field))
         man_val = manual_data.get(field)
         if man_val is not None:
             man_val = _extract_bool(man_val)
-        if (
-            man_val is not None
-            and doc_val is not None
-            and ai_val is not None
-            and doc_val == ai_val
-            and man_val != doc_val
-        ):
-            return True
+            doc_val = _extract_bool(doc_data.get(field))
+            if doc_val is None or man_val != doc_val:
+                return True
     return False
 
 
@@ -698,7 +691,7 @@ def _build_row_data(
     auto_val = _calc_auto_negotiable(
         doc_data.get("technisch_vorhanden"), ai_data.get("technisch_vorhanden")
     )
-    manual_gap = _has_manual_gap(doc_data, ai_data, manual_data)
+    manual_gap = _has_manual_gap(doc_data, manual_data)
     if override_val is not None:
         is_negotiable = override_val
     else:
@@ -4856,7 +4849,7 @@ def hx_update_review_cell(request, result_id: int, field_name: str):
     auto_val = _calc_auto_negotiable(
         doc_data.get("technisch_vorhanden"), ai_data.get("technisch_vorhanden")
     )
-    manual_gap = _has_manual_gap(doc_data, ai_data, manual_data)
+    manual_gap = _has_manual_gap(doc_data, manual_data)
     if manual_gap:
         result.is_negotiable_manual_override = False
         result.is_negotiable = False


### PR DESCRIPTION
## Zusammenfassung
- entferne AI-Abhängigkeit aus `_has_manual_gap` und prüfe ausschließlich Differenzen zwischen Dokument- und manuellen Werten
- passe Aufrufer auf neue Signatur an und berücksichtige manuelle GAPs bei der Verhandlungslogik
- ergänze Tests zur Absicherung der manuellen GAP-Erkennung

## Testing
- `pre-commit run --files core/views.py core/tests/test_general.py`
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BuildRowDataTests core.tests.test_general.ManualGapDetectionTests`

------
https://chatgpt.com/codex/tasks/task_e_6892200caf88832b9c3da90cc4e25bbc