### PR TITLE
fix: improve manual gap detection

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -4687,3 +4687,18 @@ class ManualGapDetectionTests(TestCase):
         doc_data: dict = {}
         manual_data = {"technisch_vorhanden": True}
         self.assertTrue(_has_manual_gap(doc_data, manual_data))
+
+    def test_no_gap_when_manual_missing(self) -> None:
+        """Kein GAP, wenn manuelle Daten fehlen."""
+        doc_data = {"technisch_vorhanden": True}
+        manual_data = {"technisch_vorhanden": None}
+        self.assertFalse(_has_manual_gap(doc_data, manual_data))
+
+    def test_gap_with_additional_manual_field(self) -> None:
+        """Erkennt eine Lücke bei zusätzlichen manuellen Feldern."""
+        doc_data = {"technisch_vorhanden": True}
+        manual_data = {
+            "technisch_vorhanden": True,
+            "neues_feld": False,
+        }
+        self.assertTrue(_has_manual_gap(doc_data, manual_data))

--- a/core/views.py
+++ b/core/views.py
@@ -542,14 +542,14 @@ def _get_display_data(
 
 
 def _has_manual_gap(doc_data: dict, manual_data: dict) -> bool:
-    """Prüft, ob ein manueller Wert von den Dokumentdaten abweicht."""
+    """Ermittelt, ob manuelle Angaben von den Dokumentdaten abweichen."""
 
-    for field, _ in get_anlage2_fields():
-        man_val = manual_data.get(field)
+    for field, man_val in manual_data.items():
         if man_val is not None:
-            man_val = _extract_bool(man_val)
-            doc_val = _extract_bool(doc_data.get(field))
-            if doc_val is None or man_val != doc_val:
+            man_bool = _extract_bool(man_val)
+            doc_val = doc_data.get(field)
+            doc_bool = _extract_bool(doc_val) if doc_val is not None else None
+            if doc_bool is None or man_bool != doc_bool:
                 return True
     return False
 


### PR DESCRIPTION
## Summary
- refine `_has_manual_gap` to compare manual against document values directly
- expand tests for manual gap detection

## Testing
- `pre-commit run --files core/views.py core/tests/test_general.py`
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ManualGapDetectionTests --verbosity=2`


------
https://chatgpt.com/codex/tasks/task_e_68925075875c832b859eb3d2d91119ef