### PR TITLE
Fix null parser handling in Anlage 2 review

### DIFF
--- a/static/js/anlage2_review_utils.js
+++ b/static/js/anlage2_review_utils.js
@@ -1,11 +1,16 @@
 function calcNeedsReview(manualVal, docVal, aiVal, hasManual) {
+    const docMissing = docVal === undefined || docVal === null;
+    const aiMissing = aiVal === undefined || aiVal === null;
     if (hasManual) {
-        return docVal === undefined || manualVal !== docVal;
+        if (docMissing) {
+            return false;
+        }
+        return manualVal !== docVal;
     }
-    if (docVal === undefined) {
+    if (docMissing) {
         return true;
     }
-    if (aiVal === undefined) {
+    if (aiMissing) {
         return false;
     }
     return docVal !== aiVal;

--- a/static/js/tests/anlage2_review_utils.test.js
+++ b/static/js/tests/anlage2_review_utils.test.js
@@ -11,8 +11,12 @@ test('manual equals doc does not trigger review', () => {
     assert.strictEqual(calcNeedsReview(true, true, false, true), false);
 });
 
-test('missing doc triggers review even with manual', () => {
-    assert.strictEqual(calcNeedsReview(true, undefined, false, true), true);
+test('manual with undefined doc does not trigger review', () => {
+    assert.strictEqual(calcNeedsReview(true, undefined, false, true), false);
+});
+
+test('manual with null doc does not trigger review', () => {
+    assert.strictEqual(calcNeedsReview(true, null, false, true), false);
 });
 
 test('no manual and doc differs from ai triggers review', () => {
@@ -21,4 +25,8 @@ test('no manual and doc differs from ai triggers review', () => {
 
 test('no manual and doc equals ai does not trigger review', () => {
     assert.strictEqual(calcNeedsReview(undefined, true, true, false), false);
+});
+
+test('no manual and null doc triggers review', () => {
+    assert.strictEqual(calcNeedsReview(undefined, null, false, false), true);
 });

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -306,18 +306,28 @@ function updateRowAppearance(row) {
         if (docVal && typeof docVal === 'object' && 'value' in docVal) docVal = docVal.value;
         let aiVal = ai[aiKey];
         if (aiVal && typeof aiVal === 'object' && 'value' in aiVal) aiVal = aiVal.value;
+        let docValDisplay = docVal;
+        let aiValDisplay = aiVal;
+        if (f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') {
+            docValDisplay = (docVal === undefined || docVal === null) ? false : docVal;
+            aiValDisplay = (aiVal === undefined || aiVal === null) ? false : aiVal;
+        }
         icon.classList.remove('status-badge','status-ja','status-nein','status-unbekannt','status-ok','status-konflikt','status-manuell-abweichung');
-        const displayVal = hasManual ? manualVal : (docVal !== undefined ? docVal : aiVal);
-        if (displayVal === true) icon.classList.add('status-badge','status-ja');
-        else if (displayVal === false) icon.classList.add('status-badge','status-nein');
-        else icon.classList.add('status-badge','status-unbekannt');
+        let displayVal = hasManual ? manualVal : (docValDisplay !== undefined ? docValDisplay : aiValDisplay);
+        if (f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') {
+            icon.classList.add('status-badge', docValDisplay ? 'status-ja' : 'status-nein');
+        } else {
+            if (displayVal === true) icon.classList.add('status-badge','status-ja');
+            else if (displayVal === false) icon.classList.add('status-badge','status-nein');
+            else icon.classList.add('status-badge','status-unbekannt');
+        }
         let cls = 'status-unbekannt';
         if (hasManual) {
             cls = manualVal === docVal ? 'status-ok' : 'status-manuell-abweichung';
         } else if (docVal !== undefined && aiVal !== undefined) {
             cls = docVal === aiVal ? 'status-ok' : 'status-konflikt';
         }
-        const finalVal = hasManual ? manualVal : (docVal !== undefined ? docVal : aiVal);
+        const finalVal = displayVal;
         if ((f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') && techEffective === false && finalVal === false) {
             cls = 'status-ok';
         }


### PR DESCRIPTION
## Summary
- treat missing parser values as `false` in Anlage 2 review and color by parser result
- avoid GAP notifications when manual entries have no parser value
- add tests covering manual overrides and `null` parser values

## Testing
- `python manage.py makemigrations --check`
- `node --test static/js/tests/anlage2_review_utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689339517344832b8b2b72b99bb3740d