### PR TITLE
fix: include rule name in apply_rules tuple

### DIFF
--- a/core/text_parser.py
+++ b/core/text_parser.py
@@ -163,7 +163,7 @@ def apply_rules(
                         bool(val),
                         rule.prioritaet,
                         rule.erkennungs_phrase,
-
+                        rule.regel_name,
                     )
                     detail_logger.debug(
                         "  -> Regel '%s' gefunden. Setzt '%s' auf '%s'.",


### PR DESCRIPTION
## Summary
- ensure `apply_rules` stores `regel_name` for later logging

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'selenium', AttributeError in llm_tasks.parse_anlage2_text, IntegrityError UNIQUE constraint failed on core_anlage2function.name, KeyError 'technisch_verfuegbar', AssertionError 'Login' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689352c1f7c8832bbc6ce7b44f6342d4