### PR TITLE
feat: parser-gesteuerte Farblogik und GAP-Anpassung

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -4798,3 +4798,17 @@ class ManualGapDetectionTests(TestCase):
             "neues_feld": False,
         }
         self.assertTrue(_has_manual_gap(doc_data, manual_data))
+
+    def test_no_gap_when_parser_missing_special(self) -> None:
+        """Kein GAP bei Spezialfeldern ohne Parser-Wert."""
+        doc_data: dict = {}
+        manual_data = {"einsatz_bei_telefonica": True}
+        self.assertFalse(_has_manual_gap(doc_data, manual_data))
+
+    def test_gap_only_on_difference_special(self) -> None:
+        """GAP bei Spezialfeldern nur bei Abweichung."""
+        doc_data = {"einsatz_bei_telefonica": False}
+        manual_data = {"einsatz_bei_telefonica": True}
+        self.assertTrue(_has_manual_gap(doc_data, manual_data))
+        manual_data2 = {"einsatz_bei_telefonica": False}
+        self.assertFalse(_has_manual_gap(doc_data, manual_data2))

--- a/core/views.py
+++ b/core/views.py
@@ -550,8 +550,12 @@ def _has_manual_gap(doc_data: dict, manual_data: dict) -> bool:
             man_bool = _extract_bool(man_val)
             doc_val = doc_data.get(field)
             doc_bool = _extract_bool(doc_val) if doc_val is not None else None
-            if doc_bool is None or man_bool != doc_bool:
-                return True
+            if field in ["einsatz_bei_telefonica", "zur_lv_kontrolle"]:
+                if doc_bool is not None and man_bool != doc_bool:
+                    return True
+            else:
+                if doc_bool is None or man_bool != doc_bool:
+                    return True
     return False
 
 
@@ -711,15 +715,16 @@ def _build_row_data(
         doc_val = doc_data.get(field)
         ai_val = ai_data.get(field)
         manual_val = manual_lookup.get(lookup_key, {}).get(field)
-        if (
-            doc_val is not None
-            and ai_val is not None
-            and doc_val != ai_val
-            and manual_val is None
-        ):
-            has_gap = True
-            manual_review_required = True
-            break
+        if field not in ["einsatz_bei_telefonica", "zur_lv_kontrolle"]:
+            if (
+                doc_val is not None
+                and ai_val is not None
+                and doc_val != ai_val
+                and manual_val is None
+            ):
+                has_gap = True
+                manual_review_required = True
+                break
     return {
         "name": display_name,
         "doc_result": doc_data,

--- a/static/js/anlage2_review_utils.js
+++ b/static/js/anlage2_review_utils.js
@@ -1,4 +1,10 @@
-function calcNeedsReview(manualVal, docVal, aiVal, hasManual) {
+function calcNeedsReview(manualVal, docVal, aiVal, hasManual, field) {
+    if (field === 'einsatz_bei_telefonica' || field === 'zur_lv_kontrolle') {
+        if (hasManual) {
+            return docVal !== undefined && manualVal !== docVal;
+        }
+        return false;
+    }
     if (hasManual) {
         return docVal === undefined || manualVal !== docVal;
     }

--- a/static/js/tests/anlage2_review_utils.test.js
+++ b/static/js/tests/anlage2_review_utils.test.js
@@ -4,21 +4,33 @@ const { calcNeedsReview } = require('../anlage2_review_utils.js');
 const test = require('node:test');
 
 test('manual differs from doc triggers review', () => {
-    assert.strictEqual(calcNeedsReview(true, false, true, true), true);
+    assert.strictEqual(calcNeedsReview(true, false, true, true, 'technisch_vorhanden'), true);
 });
 
 test('manual equals doc does not trigger review', () => {
-    assert.strictEqual(calcNeedsReview(true, true, false, true), false);
+    assert.strictEqual(calcNeedsReview(true, true, false, true, 'technisch_vorhanden'), false);
 });
 
 test('missing doc triggers review even with manual', () => {
-    assert.strictEqual(calcNeedsReview(true, undefined, false, true), true);
+    assert.strictEqual(calcNeedsReview(true, undefined, false, true, 'technisch_vorhanden'), true);
 });
 
 test('no manual and doc differs from ai triggers review', () => {
-    assert.strictEqual(calcNeedsReview(undefined, true, false, false), true);
+    assert.strictEqual(calcNeedsReview(undefined, true, false, false, 'technisch_vorhanden'), true);
 });
 
 test('no manual and doc equals ai does not trigger review', () => {
-    assert.strictEqual(calcNeedsReview(undefined, true, true, false), false);
+    assert.strictEqual(calcNeedsReview(undefined, true, true, false, 'technisch_vorhanden'), false);
+});
+
+test('no review when parser missing for special field', () => {
+    assert.strictEqual(calcNeedsReview(true, undefined, false, true, 'einsatz_bei_telefonica'), false);
+});
+
+test('special field manual differs from parser triggers review', () => {
+    assert.strictEqual(calcNeedsReview(true, false, undefined, true, 'einsatz_bei_telefonica'), true);
+});
+
+test('special field without manual never needs review', () => {
+    assert.strictEqual(calcNeedsReview(undefined, true, false, false, 'einsatz_bei_telefonica'), false);
 });

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -306,6 +306,10 @@ function updateRowAppearance(row) {
         if (docVal && typeof docVal === 'object' && 'value' in docVal) docVal = docVal.value;
         let aiVal = ai[aiKey];
         if (aiVal && typeof aiVal === 'object' && 'value' in aiVal) aiVal = aiVal.value;
+        if (f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') {
+            if (docVal === null || docVal === undefined) docVal = false;
+            if (aiVal === null) aiVal = undefined;
+        }
         icon.classList.remove('status-badge','status-ja','status-nein','status-unbekannt','status-ok','status-konflikt','status-manuell-abweichung');
         const displayVal = hasManual ? manualVal : (docVal !== undefined ? docVal : aiVal);
         if (displayVal === true) icon.classList.add('status-badge','status-ja');
@@ -323,7 +327,7 @@ function updateRowAppearance(row) {
         }
         icon.classList.add(cls);
         updatePopoverContent(icon);
-        if (calcNeedsReview(manualVal, docVal, aiVal, hasManual)) {
+        if (calcNeedsReview(manualVal, docVal, aiVal, hasManual, f)) {
             needsReviewRow = true;
         }
     });


### PR DESCRIPTION
## Summary
- handle Spezialfelder "Einsatz bei Telefónica" und "Zur LV-Kontrolle" direkt nach Parser-Werten
- ignoriere KI-Lücken; GAP nur bei manueller Abweichung zum Parser
- erweitere Tests und Review-Ansicht für neue Logik

## Testing
- `node static/js/tests/anlage2_review_utils.test.js`
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ManualGapDetectionTests -v 2`
- `pre-commit run --files core/views.py core/tests/test_general.py static/js/anlage2_review_utils.js static/js/tests/anlage2_review_utils.test.js templates/projekt_file_anlage2_review.html`

------
https://chatgpt.com/codex/tasks/task_e_689364d3d838832ba8c2ee0d958411d2