### PR TITLE
feat: add KI involvement info link

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -325,3 +325,9 @@ input[type="submit"]:hover {
     list-style-type: decimal;
 }
 
+/* Info-Symbol neben dem KI-Beteiligungsstatus */
+.info-icon {
+    margin-left: 0.25rem;
+    text-decoration: none;
+}
+

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -21,6 +21,9 @@
         <i class="fas fa-file-alt"></i>
         {% endif %}
     </span>
+    {% if field_name == 'ki_beteiligung' and row.ki_beteiligt_begruendung %}
+    <a href="{% url 'ki_involvement_detail_edit' anlage.pk row.verif_key %}" class="info-icon" title="Begründung ansehen/bearbeiten">ℹ️</a>
+    {% endif %}
     {% else %}
     <span>-</span>
     {% endif %}

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -37,38 +37,7 @@
     </td>
     {% for field in fields %}
     {% with f=row.form_fields|get_item:field %}
-        {% if field == 'ki_beteiligung' %}
-        <td class="border px-2 text-center">
-            {% if row.result_id %}
-            <button class="tri-state-icon" data-field-name="{{ field }}" data-is-manual="{{ row.manual_flags|get_item:field|yesno:'true,false' }}" hx-post="{% url 'hx_update_review_cell' result_id=row.result_id field_name=field %}{% if row.sub_id %}?sub_id={{ row.sub_id }}{% endif %}" hx-target="closest tr" hx-swap="outerHTML">
-                {% if row.initial|get_item:field == True %}
-                ✓ Vorhanden
-                {% elif row.initial|get_item:field == False %}
-                ✗ Nicht vorhanden
-                {% else %}
-                ? Ungeprüft
-                {% endif %}
-            </button>
-            <span class="source-icon" title="{{ f.source }}">
-                {% if f.source == 'Manuell' %}
-                <i class="fas fa-user"></i>
-                {% elif f.source == 'KI-Check' %}
-                <i class="fas fa-robot"></i>
-                {% else %}
-                <i class="fas fa-file-alt"></i>
-                {% endif %}
-            </span>
-            {% if row.ki_beteiligt_begruendung %}
-            <span class="ms-1" data-popover-content="{{ row.ki_beteiligt_begruendung|escape }}">ℹ️</span>
-            {% endif %}
-            {% else %}
-            <span>-</span>
-            {% endif %}
-            {{ f.widget }}
-        </td>
-        {% else %}
-        {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
-        {% endif %}
+    {% include 'partials/review_cell.html' with row=row field_name=field state=row.initial|get_item:field source=f.source is_manual=row.manual_flags|get_item:field widget=f.widget %}
     {% endwith %}
     {% endfor %}
     {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}


### PR DESCRIPTION
## Summary
- show info symbol for KI involvement status linking to detail view
- streamline row partial to reuse cell partial for all fields
- style info icon for consistent spacing

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68936d1982e0832ba22feb0381eb028e