### PR TITLE
fix: manuell verhandlungsfähige Funktionen erzeugen kein GAP

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -103,6 +103,7 @@ from ..views import (
     extract_anlage_nr,
     get_user_tiles,
     _has_manual_gap,
+    _build_supervision_groups,
 )
 from ..reporting import generate_gap_analysis, generate_management_summary
 from unittest.mock import patch, ANY, Mock, call
@@ -4456,6 +4457,56 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
             "subquestion",
             sub.pk,
         )
+
+
+class SupervisionGapTests(NoesisTestCase):
+    def test_manually_negotiable_function_excluded_from_supervision(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        pf = BVProjectFile.objects.create(
+            project=projekt,
+            anlage_nr=2,
+            upload=SimpleUploadedFile("f.txt", b"x"),
+        )
+        func = Anlage2Function.objects.create(name="Login")
+        AnlagenFunktionsMetadaten.objects.create(
+            anlage_datei=pf,
+            funktion=func,
+            is_negotiable_manual_override=True,
+        )
+        FunktionsErgebnis.objects.create(
+            anlage_datei=pf,
+            funktion=func,
+            quelle="parser",
+            technisch_verfuegbar=True,
+        )
+        FunktionsErgebnis.objects.create(
+            anlage_datei=pf,
+            funktion=func,
+            quelle="ki",
+            technisch_verfuegbar=False,
+        )
+        sub = Anlage2SubQuestion.objects.create(funktion=func, frage_text="S?")
+        AnlagenFunktionsMetadaten.objects.create(
+            anlage_datei=pf,
+            funktion=func,
+            subquestion=sub,
+        )
+        FunktionsErgebnis.objects.create(
+            anlage_datei=pf,
+            funktion=func,
+            subquestion=sub,
+            quelle="parser",
+            technisch_verfuegbar=True,
+        )
+        FunktionsErgebnis.objects.create(
+            anlage_datei=pf,
+            funktion=func,
+            subquestion=sub,
+            quelle="ki",
+            technisch_verfuegbar=False,
+        )
+        groups = _build_supervision_groups(pf)
+        self.assertEqual(groups, [])
 
 
 class Anlage2ResetTests(NoesisTestCase):

--- a/core/views.py
+++ b/core/views.py
@@ -804,7 +804,9 @@ def _build_supervision_row(
     ai_val = ai_entry.technisch_verfuegbar if ai_entry else None
     final_val = manual_entry.technisch_verfuegbar if manual_entry else None
 
-    if manual_entry is not None:
+    if result.is_negotiable_manual_override:
+        has_discrepancy = False
+    elif manual_entry is not None:
         has_discrepancy = doc_val is not None and final_val != doc_val
     else:
         has_discrepancy = (
@@ -834,7 +836,13 @@ def _build_supervision_groups(pf: BVProjectFile) -> list[dict]:
     )
 
     grouped: dict[int, dict] = {}
+    skipped_funcs: set[int] = set()
     for r in results:
+        if r.subquestion_id is None and r.is_negotiable_manual_override:
+            skipped_funcs.add(r.funktion_id)
+            continue
+        if r.funktion_id in skipped_funcs:
+            continue
         row_data = _build_supervision_row(r, pf)
         if not row_data["has_discrepancy"]:
             continue


### PR DESCRIPTION
## Summary
- berücksichtige manuelle Verhandlungsfähigkeit in der Supervision-Ansicht
- füge Test hinzu, der ausgehandelte Funktionen von GAP-Erkennung ausschließt

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.SupervisionGapTests.test_manually_negotiable_function_excluded_from_supervision -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6893762fab50832b918a8424f4e89537