### PR TITLE
fix: sperre Analyse bearbeiten bis LLM fertig

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1472,10 +1472,12 @@ def run_conditional_anlage2_check(
                     result(sub_task_id, wait=-1)
 
         pf.verification_task_id = ""
-        pf.save(update_fields=["verification_task_id"])
+        pf.processing_status = BVProjectFile.COMPLETE
+        pf.save(update_fields=["verification_task_id", "processing_status"])
     except Exception:
         pf.verification_task_id = ""
-        pf.save(update_fields=["verification_task_id"])
+        pf.processing_status = BVProjectFile.FAILED
+        pf.save(update_fields=["verification_task_id", "processing_status"])
         raise
 
 


### PR DESCRIPTION
## Summary
- verhindere Zugriff auf Analyse bis LLM-Prüfungen der Anlage 2 abgeschlossen sind
- setze Verifizierungsstatus nach Abschluss oder Fehler
- erweitere Tests für Prüfstatus und Task-ID

## Testing
- `DJANGO_SECRET_KEY=test python manage.py makemigrations --check`
- `DJANGO_SECRET_KEY=test python manage.py test core.tests.test_general.BVProjectFileTests.test_check_functions_clears_task_id core.tests.test_general.ModelSelectionTests.test_functions_check_uses_model --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_689375135284832b801faf09c1fa1a19