### PR TITLE
Farbkodierung für KI-Beteiligung in Anlage 2

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -315,17 +315,19 @@ function updateRowAppearance(row) {
         if (displayVal === true) icon.classList.add('status-badge','status-ja');
         else if (displayVal === false) icon.classList.add('status-badge','status-nein');
         else icon.classList.add('status-badge','status-unbekannt');
-        let cls = 'status-unbekannt';
-        if (hasManual) {
-            cls = manualVal === docVal ? 'status-ok' : 'status-manuell-abweichung';
-        } else if (docVal !== undefined && aiVal !== undefined) {
-            cls = docVal === aiVal ? 'status-ok' : 'status-konflikt';
+        if (f !== 'ki_beteiligung') {
+            let cls = 'status-unbekannt';
+            if (hasManual) {
+                cls = manualVal === docVal ? 'status-ok' : 'status-manuell-abweichung';
+            } else if (docVal !== undefined && aiVal !== undefined) {
+                cls = docVal === aiVal ? 'status-ok' : 'status-konflikt';
+            }
+            const finalVal = hasManual ? manualVal : (docVal !== undefined ? docVal : aiVal);
+            if ((f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') && techEffective === false && finalVal === false) {
+                cls = 'status-ok';
+            }
+            icon.classList.add(cls);
         }
-        const finalVal = hasManual ? manualVal : (docVal !== undefined ? docVal : aiVal);
-        if ((f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') && techEffective === false && finalVal === false) {
-            cls = 'status-ok';
-        }
-        icon.classList.add(cls);
         updatePopoverContent(icon);
         if (calcNeedsReview(manualVal, docVal, aiVal, hasManual, f)) {
             needsReviewRow = true;


### PR DESCRIPTION
## Zusammenfassung
- KI-Beteiligungsstatus in Anlage 2 nun farblich hervorgehoben
- Grün für vorhandene KI-Beteiligung, Grau für jeden anderen Zustand

## Testing
- `python manage.py makemigrations --check`
- `node static/js/tests/anlage2_review_utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689379c457e8832b8834f1f2839cfb18