### PR TITLE
feat: erweitere Versionsvergleich für Anlage 1

### DIFF
--- a/core/tests/__init__.py
+++ b/core/tests/__init__.py
@@ -3,3 +3,4 @@ from .test_forms import *
 from .test_parsing import *
 from .test_general import *
 from .test_gap_notes import *
+from .test_compare_versions import *

--- a/core/tests/test_compare_versions.py
+++ b/core/tests/test_compare_versions.py
@@ -1,0 +1,41 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from .test_general import NoesisTestCase, create_project
+from ..models import BVProjectFile
+
+
+class CompareVersionsAnlage1Tests(NoesisTestCase):
+    """Tests für den Versionsvergleich von Anlage 1."""
+
+    def setUp(self):
+        self.client.login(username=self.superuser.username, password="pass")
+        self.project = create_project(["A"], beschreibung="x")
+        self.parent = BVProjectFile.objects.create(
+            project=self.project,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("alt.txt", b"data"),
+            question_review={"1": {"hinweis": "H", "vorschlag": "V"}},
+        )
+        self.current = BVProjectFile.objects.create(
+            project=self.project,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("neu.txt", b"data"),
+            parent=self.parent,
+        )
+
+    def test_add_gap_copies_notes(self):
+        url = reverse("compare_versions", args=[self.current.pk])
+        resp = self.client.post(url, {"action": "add_gap", "question": "1"})
+        self.assertEqual(resp.status_code, 204)
+        self.current.refresh_from_db()
+        self.assertEqual(
+            self.current.question_review["1"], {"hinweis": "H", "vorschlag": "V"}
+        )
+
+    def test_negotiable_sets_ok(self):
+        url = reverse("compare_versions", args=[self.current.pk])
+        resp = self.client.post(url, {"action": "negotiable", "question": "1"})
+        self.assertEqual(resp.status_code, 204)
+        self.current.refresh_from_db()
+        self.assertTrue(self.current.question_review["1"]["ok"])

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -26,41 +26,78 @@
     <pre class="whitespace-pre-wrap border p-2 bg-gray-100">{{ parent.manual_analysis_json|default:parent.analysis_json|tojson }}</pre>
   </div>
   {% endif %}
-</div>
-{% if parent_gaps %}
-<h2 class="text-xl font-semibold mt-6">Offene Gaps aus Version {{ parent.version }}</h2>
-<table class="table-auto w-full border mt-2">
-  <thead>
-    <tr>
-      <th class="border px-2">Funktion</th>
-      <th class="border px-2">Gap-Notizen</th>
-      <th class="border px-2">Aktion</th>
-    </tr>
-  </thead>
-  <tbody>
-  {% for gap in parent_gaps %}
-    <tr id="gap-row-{{ gap.id }}">
-      <td class="border px-2">{{ gap.get_lookup_key }}</td>
-      <td class="border px-2">
-        {% if gap.gap_notiz %}<p>{{ gap.gap_notiz|linebreaksbr }}</p>{% endif %}
-        {% if gap.gap_summary %}<p class="mt-1">{{ gap.gap_summary|linebreaksbr }}</p>{% endif %}
-      </td>
-      <td class="border px-2 space-x-2 whitespace-nowrap">
-        <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline">
-          <input type="hidden" name="result_id" value="{{ gap.id }}">
-          <input type="hidden" name="action" value="carry">
-          <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Übernehmen</button>
-        </form>
-        <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline ms-2">
-          <input type="hidden" name="result_id" value="{{ gap.id }}">
-          <input type="hidden" name="action" value="fix">
-          <button type="submit" class="bg-green-600 text-white px-2 py-1 rounded">Behoben</button>
-        </form>
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
+{% if file.anlage_nr == 1 %}
+  {% if gap_questions %}
+  <h2 class="text-xl font-semibold mt-6">Offene Fragen aus Version {{ parent.version }}</h2>
+  <table class="table-auto w-full border mt-2">
+    <thead>
+      <tr>
+        <th class="border px-2">Frage</th>
+        <th class="border px-2">Gap-Notizen</th>
+        <th class="border px-2">Aktion</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for q in gap_questions %}
+      <tr id="gap-row-{{ q.num }}">
+        <td class="border px-2">{{ q.num }}</td>
+        <td class="border px-2">
+          {% if q.parent.hinweis %}<p>{{ q.parent.hinweis|linebreaksbr }}</p>{% endif %}
+          {% if q.parent.vorschlag %}<p class="mt-1">{{ q.parent.vorschlag|linebreaksbr }}</p>{% endif %}
+        </td>
+        <td class="border px-2 space-x-2 whitespace-nowrap">
+          <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ q.num }}" hx-swap="delete" class="inline">
+            <input type="hidden" name="question" value="{{ q.num }}">
+            <input type="hidden" name="action" value="add_gap">
+            <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Übernehmen</button>
+          </form>
+          <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ q.num }}" hx-swap="delete" class="inline ms-2">
+            <input type="hidden" name="question" value="{{ q.num }}">
+            <input type="hidden" name="action" value="negotiable">
+            <button type="submit" class="bg-green-600 text-white px-2 py-1 rounded">Verhandlungsfähig</button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+{% else %}
+  {% if parent_gaps %}
+  <h2 class="text-xl font-semibold mt-6">Offene Gaps aus Version {{ parent.version }}</h2>
+  <table class="table-auto w-full border mt-2">
+    <thead>
+      <tr>
+        <th class="border px-2">Funktion</th>
+        <th class="border px-2">Gap-Notizen</th>
+        <th class="border px-2">Aktion</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for gap in parent_gaps %}
+      <tr id="gap-row-{{ gap.id }}">
+        <td class="border px-2">{{ gap.get_lookup_key }}</td>
+        <td class="border px-2">
+          {% if gap.gap_notiz %}<p>{{ gap.gap_notiz|linebreaksbr }}</p>{% endif %}
+          {% if gap.gap_summary %}<p class="mt-1">{{ gap.gap_summary|linebreaksbr }}</p>{% endif %}
+        </td>
+        <td class="border px-2 space-x-2 whitespace-nowrap">
+          <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline">
+            <input type="hidden" name="result_id" value="{{ gap.id }}">
+            <input type="hidden" name="action" value="carry">
+            <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Übernehmen</button>
+          </form>
+          <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline ms-2">
+            <input type="hidden" name="result_id" value="{{ gap.id }}">
+            <input type="hidden" name="action" value="fix">
+            <button type="submit" class="bg-green-600 text-white px-2 py-1 rounded">Behoben</button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
 {% endif %}
 <div class="mt-4">
   <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück zum Projekt</a>


### PR DESCRIPTION
## Summary
- handle Anlage-1 versions separately by merging question reviews and exposing gap and all question contexts
- allow marking questions as negotiable or carrying gaps forward in version comparison view
- render gap questions in comparison template and test new behaviour

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_compare_versions -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6893993b8580832b9ea69c4b7d54eb0e