### PR TITLE
Fix incorrect status display for Telefónica usage fields

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -104,6 +104,7 @@ from ..views import (
     get_user_tiles,
     _has_manual_gap,
     _build_supervision_groups,
+    _resolve_value,
 )
 from ..reporting import generate_gap_analysis, generate_management_summary
 from unittest.mock import patch, ANY, Mock, call
@@ -4890,3 +4891,32 @@ class ManualGapDetectionTests(TestCase):
         self.assertTrue(_has_manual_gap(doc_data, manual_data))
         manual_data2 = {"einsatz_bei_telefonica": False}
         self.assertFalse(_has_manual_gap(doc_data, manual_data2))
+
+
+class ResolveValuePriorityTests(TestCase):
+    """Prüft die Vorrangregel der Dokumentwerte bei Spezialfeldern."""
+
+    def test_doc_priority_for_einsatzweise(self) -> None:
+        """Dokumentenwert setzt sich gegen KI-Wert durch."""
+        val, src = _resolve_value(
+            manual_val=None,
+            ai_val=False,
+            doc_val=True,
+            field="einsatz_bei_telefonica",
+            manual_exists=False,
+            doc_exists=True,
+        )
+        self.assertTrue(val)
+        self.assertEqual(src, "Dokumenten-Analyse")
+
+    def test_doc_priority_for_lv_kontrolle(self) -> None:
+        """Dokumentenwert hat Vorrang bei Leistungs- oder Verhaltenskontrolle."""
+        val, _src = _resolve_value(
+            manual_val=None,
+            ai_val=False,
+            doc_val=True,
+            field="zur_lv_kontrolle",
+            manual_exists=False,
+            doc_exists=True,
+        )
+        self.assertTrue(val)

--- a/core/views.py
+++ b/core/views.py
@@ -496,12 +496,18 @@ def _resolve_value(
     # Quelle richtet sich ausschließlich nach dem Dokument
     src = "Dokumenten-Analyse" if doc_exists or doc_val is not None else "N/A"
 
-    # Vorauswahl der Checkbox kann durch KI bestimmt werden
-    if ai_val is not None:
-        return ai_val, src
-
-    if doc_val is not None:
-        return doc_val, src
+    # Spezielle Felder ohne KI-Prüfung orientieren sich am Dokument
+    if field in ["einsatz_bei_telefonica", "zur_lv_kontrolle"]:
+        if doc_val is not None:
+            return doc_val, src
+        if ai_val is not None:
+            return ai_val, src
+    else:
+        # Vorauswahl der Checkbox kann durch KI bestimmt werden
+        if ai_val is not None:
+            return ai_val, src
+        if doc_val is not None:
+            return doc_val, src
 
     # Null-Werte werden als "nicht vorhanden" interpretiert
     return False, src


### PR DESCRIPTION
## Summary
- ensure `_resolve_value` prefers document data over AI suggestions for Telefónica usage fields
- add tests for document-first logic

## Testing
- `pre-commit run --files core/views.py core/tests/test_general.py`
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ResolveValuePriorityTests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6893b59f59b4832b85d291a67b9b9d16