### PR TITLE
fix: priorisiere Dokumentwert in Anlage2 Review

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -4890,3 +4890,43 @@ class ManualGapDetectionTests(TestCase):
         self.assertTrue(_has_manual_gap(doc_data, manual_data))
         manual_data2 = {"einsatz_bei_telefonica": False}
         self.assertFalse(_has_manual_gap(doc_data, manual_data2))
+
+
+class DocumentValuePriorityTests(TestCase):
+    """Sicherstellung der Priorisierung von Dokumentwerten ohne manuelle Angaben."""
+
+    def test_doc_value_used_when_no_manual(self) -> None:
+        """Der Dokumentwert wird angezeigt, wenn kein manueller Wert gesetzt ist."""
+        create_statuses()
+        with TemporaryDirectory() as tmpdir, override_settings(MEDIA_ROOT=tmpdir):
+            projekt = BVProject.objects.create(title="P")
+            pf = BVProjectFile.objects.create(
+                project=projekt,
+                anlage_nr=2,
+                upload=SimpleUploadedFile("a.txt", b"x"),
+                text_content="d",
+            )
+            func = Anlage2Function.objects.create(name="F1")
+            meta = AnlagenFunktionsMetadaten.objects.create(
+                anlage_datei=pf, funktion=func
+            )
+            FunktionsErgebnis.objects.create(
+                anlage_datei=pf,
+                funktion=func,
+                quelle="parser",
+                einsatz_bei_telefonica=True,
+            )
+            form = Anlage2ReviewForm(initial={})
+            row = _build_row_data(
+                func.name,
+                func.name,
+                func.id,
+                f"func{func.id}_",
+                form,
+                answers={},
+                ki_map={},
+                beteilig_map={},
+                manual_lookup={},
+                result_map={func.name: meta},
+            )
+            self.assertTrue(row["initial"]["einsatz_bei_telefonica"])

--- a/core/views.py
+++ b/core/views.py
@@ -652,6 +652,15 @@ def _build_row_data(
     disp = _get_display_data(
         lookup_key, answers, {lookup_key: ai_data}, manual_lookup
     )
+    # Für Felder ohne KI-Prüfung soll der Dokumentenwert Priorität haben,
+    # sofern kein manueller Wert gesetzt wurde. Dies betrifft die Spalten
+    # "einsatz_bei_telefonica" und "zur_lv_kontrolle".
+    for field in ("einsatz_bei_telefonica", "zur_lv_kontrolle"):
+        if manual_lookup.get(lookup_key, {}).get(field) is None:
+            doc_val = doc_data.get(field)
+            if doc_val is not None:
+                disp["values"][field] = doc_val
+                disp["sources"][field] = "Dokumenten-Analyse"
     fields_def = get_anlage2_fields()
     form_fields_map: dict[str, dict] = {}
     rev_origin = {}


### PR DESCRIPTION
## Summary
- nutze Dokumentwert für Felder ohne KI-Prüfung in Anlage 2 Review
- teste Priorisierung des Dokumentwerts bei fehlender manueller Angabe

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ManualGapDetectionTests core.tests.test_general.DocumentValuePriorityTests -v 2`
- `pre-commit run --files core/views.py core/tests/test_general.py`


------
https://chatgpt.com/codex/tasks/task_e_6893b59f59b4832b85d291a67b9b9d16