### PR TITLE
fix: entkopple farblogik der Einsatz- und LV-Spalten

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -306,11 +306,17 @@ function updateRowAppearance(row) {
         if (docVal && typeof docVal === 'object' && 'value' in docVal) docVal = docVal.value;
         let aiVal = ai[aiKey];
         if (aiVal && typeof aiVal === 'object' && 'value' in aiVal) aiVal = aiVal.value;
-        if (f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') {
-            if (docVal === null || docVal === undefined) docVal = false;
-            if (aiVal === null) aiVal = undefined;
-        }
         icon.classList.remove('status-badge','status-ja','status-nein','status-unbekannt','status-ok','status-konflikt','status-manuell-abweichung');
+        if (f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') {
+            // Farbgebung ausschließlich anhand des Dokumentenwertes
+            const displayVal = docVal === true;
+            icon.classList.add('status-badge', displayVal ? 'status-ja' : 'status-nein');
+            updatePopoverContent(icon);
+            if (calcNeedsReview(manualVal, docVal, aiVal, hasManual, f)) {
+                needsReviewRow = true;
+            }
+            return;
+        }
         const displayVal = hasManual ? manualVal : (docVal !== undefined ? docVal : aiVal);
         if (displayVal === true) icon.classList.add('status-badge','status-ja');
         else if (displayVal === false) icon.classList.add('status-badge','status-nein');
@@ -321,10 +327,6 @@ function updateRowAppearance(row) {
                 cls = manualVal === docVal ? 'status-ok' : 'status-manuell-abweichung';
             } else if (docVal !== undefined && aiVal !== undefined) {
                 cls = docVal === aiVal ? 'status-ok' : 'status-konflikt';
-            }
-            const finalVal = hasManual ? manualVal : (docVal !== undefined ? docVal : aiVal);
-            if ((f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') && techEffective === false && finalVal === false) {
-                cls = 'status-ok';
             }
             icon.classList.add(cls);
         }


### PR DESCRIPTION
## Summary
- entkopple Farbgebung der Spalten "Einsatz bei Telefónica" und "zur LV-Kontrolle" von der Spalte "Technisch verfügbar"
- Farbstatus orientiert sich jetzt ausschließlich am Dokumentenwert

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6893c09608b0832b97ff4d73d59b0260