### PR TITLE
fix: verwende initiale KI-Prüfung bei neuen Anlagen-Versionen

### DIFF
--- a/core/tests/test_versioned_results.py
+++ b/core/tests/test_versioned_results.py
@@ -6,12 +6,14 @@ from core.models import (
     BVProject,
     BVProjectFile,
     FunktionsErgebnis,
+    ProjectStatus,
 )
 from core.views import _verification_to_initial
 
 
 def test_funktions_ergebnisse_sind_versionsabhaengig(db):
     """Prüft, dass Ergebnisse pro Anlagen-Version getrennt gespeichert werden."""
+    ProjectStatus.objects.create(name="Offen", is_default=True)
     projekt = BVProject.objects.create(title="P")
     funktion = Anlage2Function.objects.create(name="Login")
     pf1 = BVProjectFile.objects.create(
@@ -31,14 +33,12 @@ def test_funktions_ergebnisse_sind_versionsabhaengig(db):
     AnlagenFunktionsMetadaten.objects.create(anlage_datei=pf2, funktion=funktion)
 
     FunktionsErgebnis.objects.create(
-        project=projekt,
         anlage_datei=pf1,
         funktion=funktion,
         quelle="ki",
         technisch_verfuegbar=True,
     )
     FunktionsErgebnis.objects.create(
-        project=projekt,
         anlage_datei=pf2,
         funktion=funktion,
         quelle="ki",
@@ -51,3 +51,29 @@ def test_funktions_ergebnisse_sind_versionsabhaengig(db):
     fid = str(funktion.id)
     assert data1["functions"][fid]["technisch_vorhanden"] is True
     assert data2["functions"][fid]["technisch_vorhanden"] is False
+
+
+def test_neue_version_nutzt_vorhandene_ki_ergebnisse(db):
+    """Bei vorhandenen Ergebnissen wird keine neue KI-Prüfung gestartet."""
+    ProjectStatus.objects.create(name="Offen", is_default=True)
+    projekt = BVProject.objects.create(title="P")
+    funktion = Anlage2Function.objects.create(name="Login")
+    pf1 = BVProjectFile.objects.create(
+        project=projekt,
+        anlage_nr=2,
+        upload=SimpleUploadedFile("a.txt", b"a"),
+        version=1,
+    )
+    FunktionsErgebnis.objects.create(
+        anlage_datei=pf1,
+        funktion=funktion,
+        quelle="ki",
+    )
+    pf2 = BVProjectFile.objects.create(
+        project=projekt,
+        anlage_nr=2,
+        upload=SimpleUploadedFile("b.txt", b"b"),
+        version=2,
+    )
+    tasks = pf2.get_analysis_tasks()
+    assert tasks == [("core.llm_tasks.worker_run_anlage2_analysis", pf2.pk)]


### PR DESCRIPTION
## Summary
- verhindere erneute KI-Prüfung für Anlage 2, wenn im Projekt bereits KI-Ergebnisse vorliegen
- teste, dass neue Versionen vorhandene KI-Ergebnisse nutzen und keinen zusätzlichen Check starten

## Testing
- `SKIP=gitleaks pre-commit run --files core/models.py core/tests/test_versioned_results.py`
- `DJANGO_SECRET_KEY=test python manage.py makemigrations --check`
- `DJANGO_SECRET_KEY=test pytest --ds=noesis.settings core/tests/test_versioned_results.py -q`
- `DJANGO_SECRET_KEY=test pytest --ds=noesis.settings core/tests/test_general.py::BVProjectFileTests::test_get_analysis_tasks_returns_project_id_for_conditional_check -q`


------
https://chatgpt.com/codex/tasks/task_e_68944634267c832bba6d6a041232358b