### PR TITLE
feat: reuse AI review results for new document versions

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -97,19 +97,23 @@
                 {% endfor %}
                 {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}
                 <td class="border px-2 text-center action-column">
+                    {% if allow_ai_check %}
                     <button type="button" class="btn btn-sm btn-light review-cycle-btn"
                         data-state="robot" title="KI-Prüfung starten"
                         data-project-file-id="{{ anlage.pk }}"
                         data-function-id="{{ row.func_id }}"
                         data-justification-url="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
                         {% if row.sub %}data-subquestion-id="{{ row.sub_id }}"{% endif %}>🤖</button>
+                    {% endif %}
                 </td>
             </tr>
         {% endfor %}
         </tbody>
     </table>
     <div class="mb-2">
+        {% if allow_ai_check %}
         <button type="button" id="btn-verify-all" data-project-id="{{ anlage.project.pk }}" class="bg-green-600 text-white px-2 py-1 rounded">Alle Funktionen prüfen 🤖</button>
+        {% endif %}
         <a href="{% url 'projekt_file_parse_anlage2' anlage.pk %}" class="bg-blue-600 text-white px-2 py-1 rounded ml-4">Parser-Analyse starten</a>
     </div>
     </div>


### PR DESCRIPTION
## Summary
- copy KI review results and metadata from previous document versions
- block manual KI verification if any version already has results
- test reuse of KI results and verify manual verification remains disabled

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_versioned_results.py -q --ds=noesis.settings`


------
https://chatgpt.com/codex/tasks/task_e_6894783b8ac0832b9079360fb36d691e