### PR TITLE
feat: enqueue file analysis via django-q

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -51,5 +51,5 @@ def auto_start_analysis(sender, instance: BVProjectFile, created: bool, **kwargs
     if not created:
         return
 
-    start_analysis_for_file(instance)
+    start_analysis_for_file(instance.pk)
 

--- a/core/views.py
+++ b/core/views.py
@@ -5175,15 +5175,15 @@ def hx_project_file_upload(request, pk: int):
 
 @login_required
 @require_POST
-def trigger_file_analysis(request, pk: int):
+def trigger_file_analysis(request, pk: int) -> JsonResponse:
     """L\u00f6st die Analyse f\u00fcr eine bestehende Datei erneut aus."""
     file_obj = get_object_or_404(BVProjectFile, pk=pk)
 
     if not _user_can_edit_project(request.user, file_obj.project):
         return HttpResponseForbidden("Nicht berechtigt")
 
-    start_analysis_for_file(file_obj)
-    return redirect("projekt_detail", pk=file_obj.project.pk)
+    task_id = start_analysis_for_file(file_obj.pk)
+    return JsonResponse({"task_id": task_id})
 
 
 @login_required


### PR DESCRIPTION
## Summary
- adjust `start_analysis_for_file` to accept an ID and always queue analysis tasks asynchronously
- expose `trigger_file_analysis` as AJAX endpoint returning task id
- update signals and tests to use file IDs and verify async enqueuing

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_trigger_file_analysis_starts_tasks core.tests.test_general.BVProjectFileTests.test_start_analysis_for_file_enqueues_tasks -v 2`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'selenium'; plus various test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894ac862a24832b923c311dd05a89a1