### PR TITLE
feat: trenne technische Verfügbarkeit und KI-Beteiligung

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -800,27 +800,52 @@ def _build_supervision_row(
         .first()
     )
 
-    doc_val = parser_entry.technisch_verfuegbar if parser_entry else None
-    ai_val = ai_entry.technisch_verfuegbar if ai_entry else None
-    final_val = manual_entry.technisch_verfuegbar if manual_entry else None
+    tech_doc = parser_entry.technisch_verfuegbar if parser_entry else None
+    tech_ai = ai_entry.technisch_verfuegbar if ai_entry else None
+    tech_final = manual_entry.technisch_verfuegbar if manual_entry else None
+    ki_doc = parser_entry.ki_beteiligung if parser_entry else None
+    ki_ai = ai_entry.ki_beteiligung if ai_entry else None
+    ki_final = manual_entry.ki_beteiligung if manual_entry else None
 
-    if result.is_negotiable_manual_override:
-        has_discrepancy = False
-    elif manual_entry is not None:
-        has_discrepancy = doc_val is not None and final_val != doc_val
-    else:
-        has_discrepancy = (
-            doc_val is not None and ai_val is not None and doc_val != ai_val
-        )
+    fields: dict[str, dict] = {
+        "technisch_vorhanden": {
+            "label": "Technisch vorhanden",
+            "doc_val": tech_doc,
+            "doc_reason": parser_entry.begruendung if parser_entry else "",
+            "ai_val": tech_ai,
+            "ai_reason": ai_entry.begruendung if ai_entry else "",
+            "final_val": tech_final,
+        },
+        "ki_beteiligung": {
+            "label": "KI-Beteiligung",
+            "doc_val": ki_doc,
+            "doc_reason": parser_entry.ki_beteiligt_begruendung if parser_entry else "",
+            "ai_val": ki_ai,
+            "ai_reason": ai_entry.ki_beteiligt_begruendung if ai_entry else "",
+            "final_val": ki_final,
+        },
+    }
+
+    for f in fields.values():
+        if result.is_negotiable_manual_override:
+            f["has_discrepancy"] = False
+        elif manual_entry is not None:
+            f["has_discrepancy"] = (
+                f["doc_val"] is not None and f["final_val"] != f["doc_val"]
+            )
+        else:
+            f["has_discrepancy"] = (
+                f["doc_val"] is not None
+                and f["ai_val"] is not None
+                and f["doc_val"] != f["ai_val"]
+            )
+
+    has_discrepancy = any(f["has_discrepancy"] for f in fields.values())
 
     return {
         "result_id": result.id,
         "name": result.get_lookup_key(),
-        "doc_val": doc_val,
-        "doc_snippet": parser_entry.begruendung if parser_entry else "",
-        "ai_val": ai_val,
-        "ai_reason": ai_entry.ki_beteiligt_begruendung if ai_entry else "",
-        "final_val": final_val,
+        "fields": fields,
         "notes": result.supervisor_notes or "",
         "has_discrepancy": has_discrepancy,
     }
@@ -863,9 +888,13 @@ def _build_supervision_groups(pf: BVProjectFile) -> list[dict]:
             continue
         if not subrows and func and not func["has_discrepancy"]:
             continue
-        present = func["final_val"] if func else None
-        if present is None and func:
-            present = func["doc_val"] if func["doc_val"] is not None else func["ai_val"]
+        present = None
+        if func:
+            tv_field = func["fields"].get("technisch_vorhanden", {})
+            present = tv_field.get("final_val")
+            if present is None:
+                doc = tv_field.get("doc_val")
+                present = doc if doc is not None else tv_field.get("ai_val")
         groups.append(
             {
                 "function": func,
@@ -4436,6 +4465,7 @@ def hx_supervision_confirm(request, result_id: int):
             subquestion=result.subquestion,
             quelle="manuell",
             technisch_verfuegbar=ai_entry.technisch_verfuegbar,
+            ki_beteiligung=ai_entry.ki_beteiligung,
         )
 
     if result.subquestion is None:

--- a/templates/partials/supervision_row_content.html
+++ b/templates/partials/supervision_row_content.html
@@ -1,22 +1,27 @@
 <div class="p-2 space-y-4">
-  <div class="border rounded bg-gray-50 p-2 space-y-1">
-    <h3 class="font-semibold">Parser</h3>
-    <p>{{ row.doc_val|yesno:"Vorhanden,Nicht vorhanden,?" }}</p>
-    {% if row.doc_snippet %}
-      <pre class="whitespace-pre-wrap bg-gray-100 p-2 rounded">{{ row.doc_snippet }}</pre>
-    {% endif %}
+  {% for f in row.fields.values %}
+  <div class="border rounded bg-white p-2 space-y-2">
+    <h3 class="font-semibold">{{ f.label }}</h3>
+    <div class="border rounded bg-gray-50 p-2 space-y-1">
+      <h4 class="font-semibold">Parser</h4>
+      <p>{{ f.doc_val|yesno:"Vorhanden,Nicht vorhanden,?" }}</p>
+      {% if f.doc_reason %}
+      <pre class="whitespace-pre-wrap bg-gray-100 p-2 rounded">{{ f.doc_reason }}</pre>
+      {% endif %}
+    </div>
+    <div class="border rounded bg-blue-50 p-2 space-y-1">
+      <h4 class="font-semibold">KI</h4>
+      <p>{{ f.ai_val|yesno:"Vorhanden,Nicht vorhanden,?" }}</p>
+      {% if f.ai_reason %}
+      <p class="whitespace-pre-wrap bg-gray-100 p-2 rounded">{{ f.ai_reason }}</p>
+      {% endif %}
+    </div>
+    <div class="border rounded bg-gray-50 p-2 space-y-1">
+      <h4 class="font-semibold">Manuell</h4>
+      <p>{{ f.final_val|yesno:"Vorhanden,Nicht vorhanden,?" }}</p>
+    </div>
   </div>
-  <div class="border rounded bg-blue-50 p-2 space-y-1">
-    <h3 class="font-semibold">KI</h3>
-    <p>{{ row.ai_val|yesno:"Vorhanden,Nicht vorhanden,?" }}</p>
-    {% if row.ai_reason %}
-      <p class="whitespace-pre-wrap bg-gray-100 p-2 rounded">{{ row.ai_reason }}</p>
-    {% endif %}
-  </div>
-  <div class="border rounded bg-gray-50 p-2 space-y-1">
-    <h3 class="font-semibold">Manuell</h3>
-    <p>{{ row.final_val|yesno:"Vorhanden,Nicht vorhanden,?" }}</p>
-  </div>
+  {% endfor %}
   <div class="border rounded bg-white p-2 space-y-2">
     <form hx-post="{% url 'hx_supervision_confirm' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="inline">
       <button class="bg-green-600 text-white px-2 py-1 rounded" type="submit">GAP bestätigen</button>


### PR DESCRIPTION
## Summary
- separiere technische Verfügbarkeit und KI-Beteiligung in der Supervisionsansicht
- speichere KI-Beteiligung beim Bestätigen eines GAPs

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_general.py::SupervisionGapTests::test_manually_negotiable_function_excluded_from_supervision -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_6894ea696c64832b99c188443b3108e3