### PR TITLE
fix: show function justification in supervision

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -819,7 +819,8 @@ def _build_supervision_row(
         "doc_val": doc_val,
         "doc_snippet": parser_entry.begruendung if parser_entry else "",
         "ai_val": ai_val,
-        "ai_reason": ai_entry.ki_beteiligt_begruendung if ai_entry else "",
+        # Nutze die allgemeine KI-Begründung der Funktion
+        "ai_reason": ai_entry.begruendung if ai_entry else "",
         "final_val": final_val,
         "notes": result.supervisor_notes or "",
         "has_discrepancy": has_discrepancy,


### PR DESCRIPTION
## Summary
- show KI function justification instead of KI involvement in supervision view
- cover supervision justification with a dedicated unit test

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.SupervisionGapTests.test_ai_reason_uses_function_begruendung -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6895976763d8832ba0969c8f12ce3ad5