### PR TITLE
Fix UTF-8 encoding for LLM log handlers

### DIFF
--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -231,12 +231,14 @@ LOGGING = {
             "class": "logging.FileHandler",
             "filename": BASE_DIR / "debug.log",
             "formatter": "verbose",
+            "encoding": "utf-8",
         },
         "llm_file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
             "filename": BASE_DIR / "llm-debug.log",
             "formatter": "llm_formatter",
+            "encoding": "utf-8",
         },
         "anlage1_detail_file": {
             "level": "DEBUG",


### PR DESCRIPTION
## Summary
- ensure file and llm FileHandlers write UTF-8 to avoid encoding errors
- confirm remaining LLM log handlers already use UTF-8 encoding

## Testing
- `DJANGO_SECRET_KEY=dummy python manage.py makemigrations --check`
- `pre-commit run --files noesis/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_6895ac442c74832bb11f9f74440bb8ee