### PR TITLE
Fix parser-first priority for specific Anlage 2 review fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ der Parser erneut ausgeführt, um aktualisierte Dateien einzulesen. Mit
 Wird im Projekt der Prompt geändert, setzt dies den KI‑Check zurück und führt
 ihn beim nächsten Speichern erneut aus.
 
+In der Review-Ansicht der Anlage 2 folgt die Anzeige der Werte einer spaltenspezifischen Priorität. Für „Einsatz bei Telefónica“ und „Zur LV-Kontrolle“ gilt die Reihenfolge Manuell > Parser – KI-Einschätzungen werden hier ignoriert. Für „Technisch vorhanden“ und „KI-Beteiligung“ bleibt es bei Manuell > KI > Parser.
+
 
 Erkennungsphrasen für den Textparser können nun zeilenweise eingegeben werden;
 jede Zeile wird als eigene Phrase gespeichert.

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -106,6 +106,7 @@ from ..views import (
     get_user_tiles,
     _has_manual_gap,
     _build_supervision_groups,
+    _resolve_value,
 )
 from ..reporting import generate_gap_analysis, generate_management_summary
 from unittest.mock import patch, ANY, Mock, call
@@ -4961,3 +4962,22 @@ class ManualGapDetectionTests(TestCase):
         self.assertTrue(_has_manual_gap(doc_data, manual_data))
         manual_data2 = {"einsatz_bei_telefonica": False}
         self.assertFalse(_has_manual_gap(doc_data, manual_data2))
+
+
+class ResolveValueLogicTests(TestCase):
+    """Tests für die Feldpriorisierung in ``_resolve_value``."""
+
+    def test_doc_overrides_ai_for_special_fields(self) -> None:
+        """Bei Spezialfeldern hat Parser-Vorrang vor KI."""
+        val, src = _resolve_value(
+            None, False, True, "einsatz_bei_telefonica", False, True
+        )
+        self.assertTrue(val)
+        self.assertEqual(src, "Dokumenten-Analyse")
+
+    def test_ai_still_used_for_regular_fields(self) -> None:
+        """Bei normalen Feldern dominiert der KI-Wert."""
+        val, _ = _resolve_value(
+            None, False, True, "technisch_vorhanden", False, True
+        )
+        self.assertFalse(val)

--- a/core/views.py
+++ b/core/views.py
@@ -242,6 +242,10 @@ FIELD_RENAME = {
     "einsatz_telefonica": "einsatz_bei_telefonica",
 }
 
+# Felder ohne KI-Unterstützung: Werte stammen ausschließlich aus
+# Dokumentenparser oder manueller Eingabe.
+NO_AI_FIELDS = {"einsatz_bei_telefonica", "zur_lv_kontrolle"}
+
 
 def _deep_update(base: dict, extra: dict) -> dict:
     """Aktualisiert ``base`` rekursiv mit ``extra``."""
@@ -495,6 +499,12 @@ def _resolve_value(
 
     # Quelle richtet sich ausschließlich nach dem Dokument
     src = "Dokumenten-Analyse" if doc_exists or doc_val is not None else "N/A"
+
+    # Für bestimmte Felder wird kein KI-Wert berücksichtigt
+    if field in NO_AI_FIELDS:
+        if doc_val is not None:
+            return doc_val, src
+        return False, src
 
     # Vorauswahl der Checkbox kann durch KI bestimmt werden
     if ai_val is not None:

--- a/docs/anlage2_workflow_final.md
+++ b/docs/anlage2_workflow_final.md
@@ -11,7 +11,7 @@ Diese Datei beschreibt die konsolidierten Anforderungen für den Prüfprozess de
 
 ## Kernlogik 2: UI-Verhalten in der Review-Ansicht
 
-- **Anzeigepriorität**: Sichtbarer Status in der Zelle folgt der Reihenfolge Manuell > KI > Parser.
+- **Anzeigepriorität**: Standardmäßig gilt Manuell > KI > Parser. Für die Spalten „Einsatz bei Telefónica“ und „Zur LV-Kontrolle“ wird der KI-Wert ignoriert, hier lautet die Reihenfolge Manuell > Parser.
 - **Tooltip**: Zeigt immer Werte aus allen drei Quellen (Dokument, KI-Check, Manuell). Die Zeile "Manuell" wird hervorgehoben, sobald dort ein Wert vorhanden ist.
 
 ## Kernlogik 3: Interaktion & Reset-Funktion als "Toggle"


### PR DESCRIPTION
## Summary
- ignore KI results for `einsatz_bei_telefonica` and `zur_lv_kontrolle` in review logic
- document column-specific priority in docs and README
- cover behaviour with new tests

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ResolveValueLogicTests --verbosity=2`
- `pre-commit run --files core/views.py docs/anlage2_workflow_final.md README.md core/tests/test_general.py`

------
https://chatgpt.com/codex/tasks/task_e_68998d1cd868832bbae0ad2db6a1bcdc