### PR TITLE
Integrate django-tailwind for production-ready frontend builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ debug.log
 node_modules/
 package-lock.json
 static/css/dist.css
+theme/static/css/dist/

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -43,6 +43,8 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+INTERNAL_IPS = ["127.0.0.1", "0.0.0.0"]
+
 
 # Application definition
 
@@ -55,7 +57,12 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "core",
     "django_q",
+    "tailwind",
+    "django_browser_reload",
+    "theme",
 ]
+
+TAILWIND_APP_NAME = "theme"
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -66,6 +73,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "core.middleware.LLMConfigNoticeMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_browser_reload.middleware.BrowserReloadMiddleware",
 ]
 
 ROOT_URLCONF = "noesis.urls"

--- a/noesis/urls.py
+++ b/noesis/urls.py
@@ -26,3 +26,4 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns += [path("__reload__/", include("django_browser_reload.urls"))]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,6 @@ fpdf
 thefuzz[speedup]
 thefuzz
 psycopg2-binary
+django-tailwind
+django-browser-reload
 

--- a/theme/apps.py
+++ b/theme/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class ThemeConfig(AppConfig):
+    name = 'theme'

--- a/theme/static_src/.gitignore
+++ b/theme/static_src/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/theme/static_src/package.json
+++ b/theme/static_src/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "theme",
+  "version": "4.2.0",
+  "description": "",
+  "scripts": {
+    "start": "npm run dev",
+    "build": "npm run build:clean && npm run build:tailwind",
+    "build:clean": "rimraf ../static/css/dist",
+    "build:tailwind": "cross-env NODE_ENV=production postcss ./src/styles.css -o ../static/css/dist/styles.css --minify",
+    "dev": "cross-env NODE_ENV=development postcss ./src/styles.css -o ../static/css/dist/styles.css --watch"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.11",
+
+    "cross-env": "^7.0.3",
+    "postcss": "^8.5.6",
+    "postcss-cli": "^11.0.1",
+    "postcss-nested": "^7.0.2",
+    "postcss-simple-vars": "^7.0.1",
+    "rimraf": "^6.0.1",
+    "tailwindcss": "^4.1.11"
+  }
+}

--- a/theme/static_src/postcss.config.js
+++ b/theme/static_src/postcss.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+    "postcss-simple-vars": {},
+    "postcss-nested": {}
+  },
+}

--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -1,0 +1,10 @@
+@import "tailwindcss";
+
+/**
+  * A catch-all path to Django template files, JavaScript, and Python files
+  * that contain Tailwind CSS classes and will be scanned by Tailwind to generate the final CSS file.
+  *
+  * If your final CSS file is not being updated after code changes, you may want to broaden or narrow
+  * the scope of this path.
+  */
+@source "../../../**/*.{html,py,js}";

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  content: [
+    "../templates/**/*.html",
+    "../../templates/**/*.html",
+    "../../core/templates/**/*.html",
+    "../../**/templates/**/*.html",
+    "../../**/*.py",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -1,0 +1,20 @@
+{% load static tailwind_tags %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Django Tailwind</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    {% tailwind_css %}
+</head>
+
+<body class="bg-gray-50 text-black font-serif leading-normal tracking-normal">
+
+<div class="container mx-auto">
+    <section class="flex items-center justify-center h-screen">
+        <h1 class="text-5xl">Django + Tailwind = ❤️</h1>
+    </section>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add django-tailwind and django-browser-reload dependencies
- register tailwind and new theme app with Tailwind settings
- initialize theme app with Tailwind config and base assets

## Testing
- `python manage.py makemigrations --check`
- `pre-commit run --files requirements.txt noesis/settings.py noesis/urls.py .gitignore theme/__init__.py theme/apps.py theme/static_src/.gitignore theme/static_src/package.json theme/static_src/postcss.config.js theme/static_src/src/styles.css theme/static_src/tailwind.config.js theme/templates/base.html`
- `DJANGO_SECRET_KEY=dummysecret timeout 5 python manage.py tailwind start`
- `python manage.py tailwind build`


------
https://chatgpt.com/codex/tasks/task_e_68999d88e4ec832b86ffcf59b23fd045