### PR TITLE
feat: centralize tailwind design system

### DIFF
--- a/templates/admin_anlage4_config.html
+++ b/templates/admin_anlage4_config.html
@@ -22,16 +22,16 @@
             <div id="ges-aliases-container">
                 {% for val in form.instance.gesellschaft_aliases %}
                 <div class="flex mb-2">
-                    <input type="text" name="gesellschaft_aliases" value="{{ val }}" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="gesellschaft_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="gesellschaft_aliases" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="gesellschaft_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
-            <button type="button" id="add-ges-alias" class="btn btn-sm btn-secondary mt-1">+ Alias hinzufügen</button>
+            <button type="button" id="add-ges-alias" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
         </div>
         <div>
             <label>{{ form.fachbereiche_phrase.label }}</label>
@@ -43,48 +43,48 @@
             <div id="fb-aliases-container">
                 {% for val in form.instance.fachbereich_aliases %}
                 <div class="flex mb-2">
-                    <input type="text" name="fachbereich_aliases" value="{{ val }}" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="fachbereich_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="fachbereich_aliases" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="fachbereich_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
-            <button type="button" id="add-fb-alias" class="btn btn-sm btn-secondary mt-1">+ Alias hinzufügen</button>
+            <button type="button" id="add-fb-alias" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
         </div>
         <div>
             <label>{{ form.name_aliases.label }}</label>
             <div id="name-aliases-container">
                 {% for val in form.instance.name_aliases %}
                 <div class="flex mb-2">
-                    <input type="text" name="name_aliases" value="{{ val }}" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="name_aliases" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
-            <button type="button" id="add-name-alias" class="btn btn-sm btn-secondary mt-1">+ Alias hinzufügen</button>
+            <button type="button" id="add-name-alias" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
         </div>
         <div class="mb-3">
             <label class="form-label">Negative Patterns (jeweils ein Regex pro Feld):</label>
             <div id="negative-inputs-container">
                 {% for pat in form.instance.negative_patterns %}
                 <div class="flex mb-2">
-                    <input type="text" name="negative_patterns" value="{{ pat }}" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="negative_patterns" value="{{ pat }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="negative_patterns" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="negative_patterns" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
-            <button type="button" id="add-negative-btn" class="btn btn-sm btn-secondary mt-1">+</button>
+            <button type="button" id="add-negative-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+</button>
         </div>
     </section>
     <section class="border rounded p-4 space-y-4">
@@ -94,16 +94,16 @@
             <div id="column-inputs-container">
                 {% for col in form.instance.table_columns %}
                 <div class="flex mb-2">
-                    <input type="text" name="table_columns" value="{{ col }}" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="table_columns" value="{{ col }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="table_columns" class="form-control flex-grow">
-                    <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                    <input type="text" name="table_columns" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
-            <button type="button" id="add-column-btn" class="btn btn-sm btn-secondary mt-1">+ Spalte hinzufügen</button>
+            <button type="button" id="add-column-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Spalte hinzufügen</button>
         </div>
     </section>
     <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
@@ -125,11 +125,11 @@
                 const input = document.createElement('input');
                 input.type = 'text';
                 input.name = name;
-                input.className = 'form-control flex-grow';
+                input.className = 'mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow';
                 const del = document.createElement('button');
                 del.type = 'button';
                 del.textContent = 'x';
-                del.className = 'btn btn-sm btn-secondary ml-2 remove-btn';
+                del.className = 'px-2 py-1 bg-gray-200 rounded ml-2 remove-btn';
                 del.addEventListener('click', () => wrap.remove());
                 wrap.appendChild(input);
                 wrap.appendChild(del);

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -1,21 +1,17 @@
 {% extends 'base.html' %}
 {% load static %}
-{% block extra_head %}
-    <link rel="stylesheet" href="{% static 'css/admin.css' %}">
-{% endblock %}
 
 {% block content %}
 <div class="max-w-screen-2xl mx-auto">
-<div class="admin-container">
-    <section class="admin-content">
+    <section class="p-4">
         <div class="flex flex-col md:flex-row gap-6">
-            <aside class="admin-sidebar">
+            <aside class="w-full md:w-64 bg-gray-50 p-4 border-r border-gray-200">
         <h2 class="text-xl font-bold mb-4">Admin-Navigation</h2>
-        <nav class="admin-nav space-y-4 text-sm">
+        <nav class="space-y-4 text-sm">
             <div>
                 <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">Projekt-Konfiguration</h3>
-                <a href="{% url 'admin_projects' %}" class="nav-link">Projekt-Liste</a><br>
-                <a href="{% url 'admin_project_statuses' %}" class="nav-link">Projekt-Status</a><br>
+                <a href="{% url 'admin_projects' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Projekt-Liste</a><br>
+                <a href="{% url 'admin_project_statuses' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Projekt-Status</a><br>
             </div>
             <div>
                 <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">Anlagen-Konfiguration</h3>
@@ -26,7 +22,7 @@
                         <i class="fas fa-chevron-down accordion-icon ml-2 {% if current in 'admin_anlage1' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'admin_anlage1' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'admin_anlage1' %}" class="nav-link {% if current == 'admin_anlage1' %}active-nav-link{% endif %}">Fragen</a>
+                        <a href="{% url 'admin_anlage1' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'admin_anlage1' %}bg-primary text-white{% else %}text-primary{% endif %}">Fragen</a>
                     </div>
                 </div>
                 <div>
@@ -35,8 +31,8 @@
                         <i class="fas fa-chevron-down accordion-icon ml-2 {% if current in 'anlage2_function_list anlage2_config' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'anlage2_function_list anlage2_config' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'anlage2_function_list' %}" class="nav-link {% if current == 'anlage2_function_list' %}active-nav-link{% endif %}">Funktionen</a>
-                        <a href="{% url 'anlage2_config' %}" class="nav-link {% if current == 'anlage2_config' %}active-nav-link{% endif %}">Globale Phrasen</a>
+                        <a href="{% url 'anlage2_function_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage2_function_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Funktionen</a>
+                        <a href="{% url 'anlage2_config' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage2_config' %}bg-primary text-white{% else %}text-primary{% endif %}">Globale Phrasen</a>
                     </div>
                 </div>
                 <div>
@@ -45,7 +41,7 @@
                         <i class="fas fa-chevron-down accordion-icon ml-2 {% if current in 'anlage3_rule_list' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'anlage3_rule_list' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'anlage3_rule_list' %}" class="nav-link {% if current == 'anlage3_rule_list' %}active-nav-link{% endif %}">Parser Regeln</a>
+                        <a href="{% url 'anlage3_rule_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage3_rule_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Parser Regeln</a>
                     </div>
                 </div>
                 <div>
@@ -54,7 +50,7 @@
                         <i class="fas fa-chevron-down accordion-icon ml-2 {% if current in 'anlage4_config' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'anlage4_config' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'anlage4_config' %}" class="nav-link {% if current == 'anlage4_config' %}active-nav-link{% endif %}">Konfiguration</a>
+                        <a href="{% url 'anlage4_config' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage4_config' %}bg-primary text-white{% else %}text-primary{% endif %}">Konfiguration</a>
                     </div>
                 </div>
                 <div>
@@ -63,23 +59,23 @@
                         <i class="fas fa-chevron-down accordion-icon ml-2 {% if current in 'parser_rule_list zweckkategoriea_list supervisionnote_list' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'parser_rule_list zweckkategoriea_list supervisionnote_list' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'parser_rule_list' %}" class="nav-link {% if current == 'parser_rule_list' %}active-nav-link{% endif %}">Exakter Parser Regeln</a>
-                        <a href="{% url 'zweckkategoriea_list' %}" class="nav-link {% if current == 'zweckkategoriea_list' %}active-nav-link{% endif %}">Zwecke verwalten</a>
-                        <a href="{% url 'supervisionnote_list' %}" class="nav-link {% if current == 'supervisionnote_list' %}active-nav-link{% endif %}">Supervision-Notizen</a>
+                        <a href="{% url 'parser_rule_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'parser_rule_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Exakter Parser Regeln</a>
+                        <a href="{% url 'zweckkategoriea_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'zweckkategoriea_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Zwecke verwalten</a>
+                        <a href="{% url 'supervisionnote_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'supervisionnote_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Supervision-Notizen</a>
                     </div>
                 </div>
                 {% endwith %}
             </div>
             <div>
                 <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">KI-Konfiguration</h3>
-                <a href="{% url 'admin_llm_roles' %}" class="nav-link">LLM-Rollen</a><br>
-                <a href="{% url 'admin_prompts' %}" class="nav-link">Prompts</a><br>
-                <a href="{% url 'admin_models' %}" class="nav-link">LLM-Modelle</a><br>
+                <a href="{% url 'admin_llm_roles' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">LLM-Rollen</a><br>
+                <a href="{% url 'admin_prompts' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Prompts</a><br>
+                <a href="{% url 'admin_models' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">LLM-Modelle</a><br>
             </div>
             <div>
                 <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">Systemverwaltung</h3>
-                <a href="{% url 'admin_user_list' %}" class="nav-link">Benutzer verwalten</a><br>
-                <a href="{% url 'admin:auth_group_changelist' %}" class="nav-link">Gruppen</a><br>
+                <a href="{% url 'admin_user_list' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Benutzer verwalten</a><br>
+                <a href="{% url 'admin:auth_group_changelist' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Gruppen</a><br>
             </div>
         </nav>
             </aside>
@@ -88,7 +84,6 @@
             </div>
         </div>
     </section>
-</div>
 </div>
 {% endblock %}
 {% block extra_js %}

--- a/templates/admin_projects.html
+++ b/templates/admin_projects.html
@@ -10,22 +10,17 @@
             <tr class="border-b text-left">
                 <th class="py-2">
                     Titel
-                    <input type="text" name="q" placeholder="Suchen..." value="{{ search_query }}" class="form-control form-control-sm mt-1">
+                    {% include 'partials/_form_input.html' with name='q' placeholder='Suchen...' value=search_query classes='mt-1' %}
                 </th>
                 <th class="py-2">Beschreibung</th>
 
                 <th class="py-2">
                     Software-Typen
-                    <input type="text" name="software" placeholder="Suchen..." value="{{ software_filter }}" class="form-control form-control-sm mt-1">
+                    {% include 'partials/_form_input.html' with name='software' placeholder='Suchen...' value=software_filter classes='mt-1' %}
                 </th>
                 <th class="py-2">
                     Status
-                    <select name="status" class="form-select form-select-sm mt-1">
-                        <option value="">Alle</option>
-                        {% for s in status_choices %}
-                            <option value="{{ s.key }}" {% if s.key == status_filter %}selected{% endif %}>{{ s.name }}</option>
-                        {% endfor %}
-                    </select>
+                    {% include 'partials/_form_select.html' with name='status' options=status_choices value=status_filter classes='mt-1' include_blank='Alle' %}
                 </th>
                 <th class="py-2">LLM geprüft</th>
 
@@ -43,9 +38,10 @@
     {% csrf_token %}
     {% if projects %}
     <div class="mt-4 space-x-2">
-        <button type="button" id="import-btn" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</button>
-        <button type="submit" id="export-btn" formaction="{% url 'admin_project_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded" disabled>Exportieren</button>
-        <button type="submit" name="delete_selected" class="px-4 py-2 bg-red-600 text-white rounded" onclick="return confirm('Einträge wirklich löschen?');">Markierte löschen</button>
+        {% include 'partials/_button.html' with type='button' id='import-btn' label='Importieren' color_classes='bg-green-600 text-white hover:bg-green-700' %}
+        {% url 'admin_project_export' as export_url %}
+        {% include 'partials/_button.html' with type='submit' id='export-btn' formaction=export_url label='Exportieren' disabled=True %}
+        {% include 'partials/_button.html' with type='submit' name='delete_selected' label='Markierte löschen' color_classes='bg-red-600 text-white hover:bg-red-700' onclick="return confirm('Einträge wirklich löschen?');" %}
     </div>
     {% endif %}
 </form>

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -15,18 +15,18 @@
         <div id="alias-container">
             {% for val in aliases %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" value="{{ val }}" class="form-control flex-grow">
-                <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
             {% endfor %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" class="form-control flex-grow">
-                <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
         </div>
-        <button type="button" id="add-alias-btn" class="btn btn-sm btn-secondary mt-1">+ Alias hinzufügen</button>
+        <button type="button" id="add-alias-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded mt-4">Speichern</button>
+    {% include 'partials/_button.html' with type='submit' label='Speichern' classes='mt-4' %}
 </form>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
@@ -42,11 +42,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const input = document.createElement('input');
         input.type = 'text';
         input.name = 'name_aliases';
-        input.className = 'form-control flex-grow';
+        input.className = 'mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow';
         const del = document.createElement('button');
         del.type = 'button';
         del.textContent = 'x';
-        del.className = 'btn btn-sm btn-secondary ml-2 remove-btn';
+        del.className = 'px-2 py-1 bg-gray-200 rounded ml-2 remove-btn';
         del.addEventListener('click', () => wrap.remove());
         wrap.appendChild(input);
         wrap.appendChild(del);
@@ -71,7 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <tr class="border-b text-sm">
             <td class="py-1">{{ q.frage_text|truncatechars:80 }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'anlage2_subquestion_edit' q.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
+                  <a href="{% url 'anlage2_subquestion_edit' q.id %}" class="px-2 py-1 bg-primary text-white rounded">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form action="{% url 'anlage2_subquestion_delete' q.id %}" method="post" class="inline">

--- a/templates/anlage2/subquestion_form.html
+++ b/templates/anlage2/subquestion_form.html
@@ -15,16 +15,16 @@
         <div id="alias-container">
             {% for val in aliases %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" value="{{ val }}" class="form-control flex-grow">
-                <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
             {% endfor %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" class="form-control flex-grow">
-                <button type="button" class="btn btn-sm btn-secondary ml-2 remove-btn">x</button>
+                <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
         </div>
-        <button type="button" id="add-alias-btn" class="btn btn-sm btn-secondary mt-1">+ Alias hinzufügen</button>
+        <button type="button" id="add-alias-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
     </div>
     <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -40,11 +40,11 @@
             const input = document.createElement('input');
             input.type = 'text';
             input.name = 'name_aliases';
-            input.className = 'form-control flex-grow';
+            input.className = 'mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow';
             const del = document.createElement('button');
             del.type = 'button';
             del.textContent = 'x';
-            del.className = 'btn btn-sm btn-secondary ml-2 remove-btn';
+            del.className = 'px-2 py-1 bg-gray-200 rounded ml-2 remove-btn';
             del.addEventListener('click', () => wrap.remove());
             wrap.appendChild(input);
             wrap.appendChild(del);
@@ -53,6 +53,6 @@
         });
     });
     </script>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    {% include 'partials/_button.html' with type='submit' label='Speichern' %}
 </form>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,10 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Noesis Assistant{% endblock %}</title>
-    <!-- Tailwind CSS via CDN -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="{% static 'css/dist/styles.css' %}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-mK8e1zgS60F7uO3cu6UytzszbmWzxubUANe0yoyS9MhUlCT3ocOITkkpFmS6r30YIOCwRvDDDeZz7eGRIDcNQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="{% static 'css/style.css' %}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script>
@@ -21,7 +19,7 @@
     {% block extra_head %}{% endblock %}
 </head>
 <body class="flex flex-col min-h-screen bg-white text-gray-900">
-    <header class="bg-gradient-to-r from-blue-600 to-blue-800 text-white">
+    <header class="bg-primary text-white">
         <div class="container mx-auto flex items-center justify-between p-4">
             <div class="text-xl font-semibold">
                 <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="Noesis Logo" class="h-8 inline"></a>
@@ -40,7 +38,7 @@
 
                     <form action="{% url 'logout' %}" method="post" class="inline">
                         {% csrf_token %}
-                        <button type="submit" class="bg-transparent border-0 p-0 m-0 text-white hover:underline">Abmelden</button>
+                        {% include 'partials/_button.html' with type='submit' label='Abmelden' classes='bg-transparent hover:underline px-0 py-0' %}
                     </form>
 
                 {% else %}
@@ -54,7 +52,7 @@
         {% if messages %}
         <div class="mb-4 space-y-2">
             {% for message in messages %}
-            <div class="p-2 rounded bg-blue-100 text-blue-800 {{ message.tags }}">
+            <div class="p-2 rounded bg-primary-light text-primary-dark {{ message.tags }}">
                 {{ message }}
             </div>
             {% endfor %}
@@ -66,7 +64,6 @@
     <footer class="bg-gray-100 text-center py-4">
         <p>&copy; 2024 Noesis Assistant</p>
     </footer>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{% static 'js/utils.js' %}"></script>
     <script src="{% static 'js/file_upload.js' %}"></script>
     <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>

--- a/templates/partials/_button.html
+++ b/templates/partials/_button.html
@@ -1,0 +1,6 @@
+{% if href %}
+<a href="{{ href }}" {% if id %}id="{{ id }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} class="inline-flex items-center px-4 py-2 rounded {{ color_classes|default:'bg-primary text-white hover:bg-primary-dark' }} {{ classes|default:'' }}">{{ label }}</a>
+{% else %}
+<button type="{{ type|default:'button' }}" {% if id %}id="{{ id }}"{% endif %} {% if name %}name="{{ name }}"{% endif %} {% if formaction %}formaction="{{ formaction }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {% if disabled %}disabled{% endif %} class="inline-flex items-center px-4 py-2 rounded {{ color_classes|default:'bg-primary text-white hover:bg-primary-dark' }} {{ classes|default:'' }}">{{ label }}</button>
+{% endif %}
+

--- a/templates/partials/_card.html
+++ b/templates/partials/_card.html
@@ -1,0 +1,5 @@
+<div class="bg-white rounded-lg shadow p-4 {{ classes|default:'' }}">
+  {% if title %}<h2 class="text-xl font-semibold mb-4">{{ title }}</h2>{% endif %}
+  {{ content }}
+</div>
+

--- a/templates/partials/_form_input.html
+++ b/templates/partials/_form_input.html
@@ -1,0 +1,8 @@
+<input type="{{ type|default:'text' }}"
+       name="{{ name }}"
+       id="{{ id|default:name }}"
+       value="{{ value|default:'' }}"
+       class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary {{ classes|default:'' }}"
+       {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
+       {% if required %}required{% endif %}>
+

--- a/templates/partials/_form_select.html
+++ b/templates/partials/_form_select.html
@@ -1,0 +1,12 @@
+<select name="{{ name }}"
+        id="{{ id|default:name }}"
+        class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary {{ classes|default:'' }}"
+        {% if multiple %}multiple{% endif %}>
+  {% if include_blank %}<option value="">{{ include_blank }}</option>{% endif %}
+  {% for option in options %}
+    {% with val=option.value|default:option.key lbl=option.label|default:option.name %}
+    <option value="{{ val }}" {% if val == value %}selected{% endif %}>{{ lbl }}</option>
+    {% endwith %}
+  {% endfor %}
+</select>
+

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -5,7 +5,8 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">{{ projekt.title }}
 {% if is_admin %}
-<a href="{% url 'admin_projects' %}" class="bg-red-600 text-white px-4 py-2 rounded ml-2">Admin</a>
+{% url 'admin_projects' as admin_url %}
+{% include 'partials/_button.html' with href=admin_url label='Admin' color_classes='bg-red-600 text-white hover:bg-red-700' classes='ml-2' %}
 {% endif %}
 </h1>
 <div class="lg:flex lg:space-x-4">
@@ -21,26 +22,23 @@
         ✎
     </a>
 </p>
-<form method="post" action="{% url 'projekt_status_update' projekt.pk %}" class="mb-4">
+<form method="post" action="{% url 'projekt_status_update' projekt.pk %}" class="mb-4 flex items-center space-x-2">
     {% csrf_token %}
     <label for="status" class="font-semibold">Status:</label>
-    <select id="status" name="status" class="border rounded p-2">
-    {% for s in status_choices %}
-        <option value="{{ s.key }}" {% if projekt.status and projekt.status.key == s.key %}selected{% endif %}>{{ s.name }}</option>
-    {% endfor %}
-    </select>
-    <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded ml-2">Aktualisieren</button>
+    {% include 'partials/_form_select.html' with name='status' id='status' options=status_choices value=projekt.status.key classes='' %}
+    {% include 'partials/_button.html' with type='submit' label='Aktualisieren' classes='' %}
 </form>
 <p class="mb-4">
-    <a href="{% url 'projekt_gap_analysis' projekt.pk %}" class="text-blue-700 underline">Gap-Analyse herunterladen</a>
+    <a href="{% url 'projekt_gap_analysis' projekt.pk %}" class="text-primary underline">Gap-Analyse herunterladen</a>
     |
-    <a href="{% url 'projekt_management_summary' projekt.pk %}" class="text-blue-700 underline">Management Summary herunterladen</a>
+    <a href="{% url 'projekt_management_summary' projekt.pk %}" class="text-primary underline">Management Summary herunterladen</a>
 </p>
 <p class="mb-4">
     {% if can_gap_report %}
-    <a href="{% url 'gap_report_view' projekt.pk %}" class="bg-blue-600 text-white px-4 py-2 rounded">GAP-Bericht f\u00fcr Fachbereich erstellen</a>
+    {% url 'gap_report_view' projekt.pk as gap_url %}
+    {% include 'partials/_button.html' with href=gap_url label='GAP-Bericht f\u00fcr Fachbereich erstellen' %}
     {% else %}
-    <button class="bg-gray-300 text-gray-500 px-4 py-2 rounded" disabled>GAP-Bericht f\u00fcr Fachbereich erstellen</button>
+    {% include 'partials/_button.html' with label='GAP-Bericht f\u00fcr Fachbereich erstellen' color_classes='bg-gray-300 text-gray-500' disabled=True %}
     {% endif %}
 </p>
 </div>
@@ -49,7 +47,7 @@
 <h2 class="text-xl font-semibold mb-4">Anlagen</h2>
 <nav class="flex space-x-2 mb-4" id="anlage-tabs-nav">
   {% for nr in anlage_numbers %}
-  <button class="anlage-tab-btn px-3 py-1 border-b-2 {% if forloop.first %}border-blue-600 text-blue-600{% else %}border-transparent text-gray-600{% endif %}"
+  <button class="anlage-tab-btn px-3 py-1 border-b-2 {% if forloop.first %}border-primary text-primary{% else %}border-transparent text-gray-600{% endif %}"
           hx-get="{% url 'hx_project_anlage_tab' projekt.pk nr %}"
           hx-target="#anlage-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-nr="{{ nr }}">
@@ -64,7 +62,7 @@
 <div class="bg-white rounded-lg shadow p-4">
 <h2 class="text-xl font-semibold mb-4">Initial-Prüfung der Software-Komponenten</h2>
 <nav class="flex space-x-2 mb-4">
-  <button class="software-tab-btn px-3 py-1 border-b-2 border-blue-600 text-blue-600"
+  <button class="software-tab-btn px-3 py-1 border-b-2 border-primary text-primary"
           hx-get="{% url 'hx_project_software_tab' projekt.pk 'tech' %}"
           hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-tab="tech">Technische Prüfung</button>
@@ -107,15 +105,15 @@ function renderLLM(data){
    <textarea id="edit" class="border rounded w-full p-2 mb-2">${data.llm_initial_output||''}</textarea>
    <input id="context" type="text" placeholder="Weiterer Kontext" class="border rounded w-full p-2 mb-2 hidden">
    <div class="space-x-2">
-     <button id="edit-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Antwort bearbeiten & erneut prüfen</button>
-     <button id="ctx-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Zusätzlichen Kontext & erneut prüfen</button>
+     <button id="edit-btn" class="bg-primary text-white px-4 py-2 rounded">Antwort bearbeiten & erneut prüfen</button>
+     <button id="ctx-btn" class="bg-primary text-white px-4 py-2 rounded">Zusätzlichen Kontext & erneut prüfen</button>
    </div>`;
  }else if(data.ist_llm_geprueft && data.llm_validated){
   sec.innerHTML=`<button id="toggle" class="bg-green-600 text-white px-4 py-2 rounded mb-2">Antwort ein-/ausblenden</button>
   <div id="output" class="prose max-w-none bg-gray-100 p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
  }
  if(data.llm_initial_output){
-   sec.innerHTML += `<button id="recheck" class="bg-blue-600 text-white px-4 py-2 rounded mt-2">Erneut prüfen</button>`;
+  sec.innerHTML += `<button id="recheck" class="bg-primary text-white px-4 py-2 rounded mt-2">Erneut prüfen</button>`;
  }
  attachHandlers();
 }
@@ -241,19 +239,19 @@ document.addEventListener('htmx:beforeRequest',function(e){
   const t=e.target;
   if(t.classList.contains('anlage-tab-btn')){
     document.querySelectorAll('.anlage-tab-btn').forEach(b=>{
-      b.classList.remove('border-blue-600','text-blue-600');
+      b.classList.remove('border-primary','text-primary');
       b.classList.add('border-transparent','text-gray-600');
     });
     t.classList.remove('border-transparent','text-gray-600');
-    t.classList.add('border-blue-600','text-blue-600');
+    t.classList.add('border-primary','text-primary');
   }
   if(t.classList.contains('software-tab-btn')){
     document.querySelectorAll('.software-tab-btn').forEach(b=>{
-      b.classList.remove('border-blue-600','text-blue-600');
+      b.classList.remove('border-primary','text-primary');
       b.classList.add('border-transparent','text-gray-600');
     });
     t.classList.remove('border-transparent','text-gray-600');
-    t.classList.add('border-blue-600','text-blue-600');
+    t.classList.add('border-primary','text-primary');
   }
 });
 </script>

--- a/templates/projekt_list.html
+++ b/templates/projekt_list.html
@@ -2,9 +2,11 @@
 {% block title %}Projektverwaltung{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Projektverwaltung</h1>
-<a href="{% url 'projekt_create' %}" class="bg-blue-600 text-white px-4 py-2 rounded">Neues Projekt</a>
+{% url 'projekt_create' as create_url %}
+{% include 'partials/_button.html' with href=create_url label='Neues Projekt' %}
 {% if is_admin %}
-<a href="{% url 'admin_projects' %}" class="bg-red-600 text-white px-4 py-2 rounded ml-2">Admin</a>
+{% url 'admin_projects' as admin_url %}
+{% include 'partials/_button.html' with href=admin_url label='Admin' color_classes='bg-red-600 text-white hover:bg-red-700' classes='ml-2' %}
 {% endif %}
 <form method="get" action="{% url 'projekt_list' %}">
 <table class="min-w-full mt-4">
@@ -12,22 +14,17 @@
         <tr class="text-left border-b">
             <th class="py-2">
                 Titel
-                <input type="text" name="q" placeholder="Suchen..." value="{{ search_query }}" class="form-control form-control-sm mt-1">
+                {% include 'partials/_form_input.html' with name='q' placeholder='Suchen...' value=search_query classes='mt-1' %}
             </th>
             <th class="py-2">Beschreibung</th>
 
             <th class="py-2">
                 Software-Typen
-                <input type="text" name="software" placeholder="Suchen..." value="{{ software_filter }}" class="form-control form-control-sm mt-1">
+                {% include 'partials/_form_input.html' with name='software' placeholder='Suchen...' value=software_filter classes='mt-1' %}
             </th>
             <th class="py-2">
                 Status
-                <select name="status" class="form-select form-select-sm mt-1">
-                    <option value="">Alle</option>
-                    {% for s in status_choices %}
-                        <option value="{{ s.key }}" {% if s.key == status_filter %}selected{% endif %}>{{ s.name }}</option>
-                    {% endfor %}
-                </select>
+                {% include 'partials/_form_select.html' with name='status' options=status_choices value=status_filter classes='mt-1' include_blank='Alle' %}
             </th>
 
 

--- a/theme/static_src/package.json
+++ b/theme/static_src/package.json
@@ -13,8 +13,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.11",
-
     "cross-env": "^7.0.3",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -7,7 +7,39 @@ module.exports = {
     "../../**/*.py",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#2563eb',
+          light: '#3b82f6',
+          dark: '#1e40af',
+        },
+        gray: {
+          50: '#f9fafb',
+          100: '#f3f4f6',
+          200: '#e5e7eb',
+          300: '#d1d5db',
+          400: '#9ca3af',
+          500: '#6b7280',
+          600: '#4b5563',
+          700: '#374151',
+          800: '#1f2937',
+          900: '#111827',
+        },
+      },
+      fontSize: {
+        xs: ['0.75rem', { lineHeight: '1rem' }],
+        sm: ['0.875rem', { lineHeight: '1.25rem' }],
+        base: ['1rem', { lineHeight: '1.5rem' }],
+        lg: ['1.125rem', { lineHeight: '1.75rem' }],
+        xl: ['1.25rem', { lineHeight: '1.75rem' }],
+        '2xl': ['1.5rem', { lineHeight: '2rem' }],
+        '3xl': ['1.875rem', { lineHeight: '2.25rem' }],
+        '4xl': ['2.25rem', { lineHeight: '2.5rem' }],
+      },
+    },
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/forms'),
+  ],
 }


### PR DESCRIPTION
## Summary
- define Tailwind color palette and typography scale with forms plugin
- add reusable button, input, select and card partials
- refactor core templates to use design system and Tailwind form styles

## Testing
- `npm run build`
- `DJANGO_SECRET_KEY=dummy python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6899c7aef148832b950b8f3ac6cdef5c