### PR TITLE
feat: highlight negotiable cells

### DIFF
--- a/templates/partials/negotiable_cell.html
+++ b/templates/partials/negotiable_cell.html
@@ -1,11 +1,11 @@
 {% if row.result_id %}
-<td class="border px-2 text-center negotiable-cell"
+<td class="border px-2 text-center negotiable-cell {% if is_negotiable %}bg-green-100 text-green-800{% else %}bg-red-100 text-red-800{% endif %}{% if override is not none %} border-yellow-400{% endif %}"
     hx-post="{% url 'hx_toggle_negotiable' result_id=row.result_id %}"
     hx-target="closest td" hx-swap="outerHTML">
     {% if is_negotiable %}
-    <span class="text-green-600">✅</span>
+    <span>✅</span>
     {% else %}
-    <span class="text-red-600">❌</span>
+    <span>❌</span>
     {% endif %}
     {% if override is not none %}
     <span class="ms-1" title="Manueller Override">👤</span>


### PR DESCRIPTION
## Summary
- color cell background and text based on negotiable status
- show yellow border when value overridden

## Testing
- `pre-commit run --files templates/partials/negotiable_cell.html`
- `DJANGO_SECRET_KEY=dummy python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6899e5db39d0832baef8d9dd3e1c83df