### PR TITLE
fix: graue verhandlungsfähige Zeilen

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -197,11 +197,6 @@ input[type="submit"]:hover {
     background-color: #fffae6;
 }
 
-/* Bereits verhandelte Zeilen deutlich ausgrauen */
-.negotiated-row {
-    opacity: 0.4;
-}
-
 /* Icon für Notiz-Bearbeitung */
 .gap-note-icon {
     cursor: pointer;

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -1,5 +1,5 @@
 {% load recording_extras %}
-<tr class="{% if row.sub %}subquestion-row hidden-row subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}negotiated-row{% endif %}"
+<tr class="{% if row.sub %}subquestion-row hidden-row subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}opacity-40{% endif %}"
     data-relevant="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'true,false,unknown' }}"
     data-parsed-status="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'True,False,None' }}"
     data-parsed-notes="{{ row.doc_result|raw_item:'technisch_vorhanden'|get_item:'note' }}"

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -48,7 +48,7 @@
         </thead>
         <tbody id="anlage2-table-body">
         {% for row in rows %}
-            <tr class="{% if row.sub %}subquestion-row hidden-row subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}negotiated-row{% endif %}"
+            <tr class="{% if row.sub %}subquestion-row hidden-row subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}opacity-40{% endif %}"
                 data-relevant="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'true,false,unknown' }}"
                 data-parsed-status="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'True,False,None' }}"
                 data-parsed-notes="{{ row.doc_result|raw_item:'technisch_vorhanden'|get_item:'note' }}"
@@ -370,7 +370,7 @@ function updateRowAppearance(row) {
         }
         row.dataset.negotiable = cellVal ? 'true' : 'false';
         updateNegotiableCell(negCell, cellVal, override);
-        row.classList.toggle('negotiated-row', cellVal);
+        row.classList.toggle('opacity-40', cellVal);
     }
     row.dataset.requiresReview = needsReviewRow ? 'true' : 'false';
     const indicator = row.querySelector('.text-danger.text-sm');


### PR DESCRIPTION
## Summary
- highlight already negotiated rows with Tailwind opacity styling
- drop unused CSS rule for negotiated rows

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_689ae5ea06d4832ba99acfbdbdfceda1