### PR TITLE
fix: repair toggle functionality for review table

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -114,10 +114,6 @@
 
 
 
-.hidden-row {
-    display: none;
-}
-
 /* Tab-Navigation in Anlage 2 */
 .tab-btn {
     padding: 0.5rem 1rem;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -52,11 +52,6 @@
     display: none;
 }
 
-/* Neue Klasse für ein- und ausblendbare Zeilen */
-.hidden-row {
-    display: none;
-}
-
 /* Zeilen, die durch den Filter versteckt werden */
 .filter-hidden {
     display: none;

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -1,5 +1,5 @@
 {% load recording_extras %}
-<tr class="{% if row.sub %}subquestion-row hidden-row subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}opacity-40{% endif %}"
+<tr class="{% if row.sub %}subquestion-row hidden subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}opacity-40{% endif %}"
     data-relevant="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'true,false,unknown' }}"
     data-parsed-status="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'True,False,None' }}"
     data-parsed-notes="{{ row.doc_result|raw_item:'technisch_vorhanden'|get_item:'note' }}"

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -48,7 +48,7 @@
         </thead>
         <tbody id="anlage2-table-body">
         {% for row in rows %}
-            <tr class="{% if row.sub %}subquestion-row hidden-row subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}opacity-40{% endif %}"
+            <tr class="{% if row.sub %}subquestion-row hidden subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}opacity-40{% endif %}"
                 data-relevant="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'true,false,unknown' }}"
                 data-parsed-status="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'True,False,None' }}"
                 data-parsed-notes="{{ row.doc_result|raw_item:'technisch_vorhanden'|get_item:'note' }}"
@@ -172,21 +172,21 @@ function initAnlage2Review() {
             const target = btn.dataset.targetClass;
             if (!target) return;
             const rows = document.querySelectorAll('.' + target);
-            const collapsed = Array.from(rows).every(r => r.classList.contains('hidden-row'));
-            rows.forEach(r => r.classList.toggle('hidden-row'));
+            const collapsed = Array.from(rows).every(r => r.classList.contains('hidden'));
+            rows.forEach(r => r.classList.toggle('hidden'));
             btn.textContent = collapsed ? '-' : '+';
         });
     });
 
     if (expandAllBtn) {
         expandAllBtn.addEventListener('click', () => {
-            document.querySelectorAll('.subquestion-row').forEach(r => r.classList.remove('hidden-row'));
+            document.querySelectorAll('.subquestion-row').forEach(r => r.classList.remove('hidden'));
             individualToggleButtons.forEach(b => b.textContent = '-');
         });
     }
     if (collapseAllBtn) {
         collapseAllBtn.addEventListener('click', () => {
-            document.querySelectorAll('.subquestion-row').forEach(r => r.classList.add('hidden-row'));
+            document.querySelectorAll('.subquestion-row').forEach(r => r.classList.add('hidden'));
             individualToggleButtons.forEach(b => b.textContent = '+');
         });
     }
@@ -202,7 +202,7 @@ function initAnlage2Review() {
  
 function toggleSubRows(funcId, enabled) {
     document.querySelectorAll(`.subquestions-for-${funcId}`).forEach(r => {
-        r.classList.toggle('hidden-row', !enabled);
+        r.classList.toggle('hidden', !enabled);
         r.querySelectorAll('button, input, textarea').forEach(el => {
             el.disabled = !enabled;
         });


### PR DESCRIPTION
## Summary
- use Tailwind's `hidden` utility to toggle Anlage-2 subquestion rows
- drop legacy `.hidden-row` CSS definitions

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_689ae865e884832b90075dbc3062cb2d