### PR TITLE
feat: integrate custom popovers for Anlage2 review

### DIFF
--- a/static/js/popover.js
+++ b/static/js/popover.js
@@ -1,42 +1,37 @@
-(function(){
-    function removeAll(){
-        document.querySelectorAll('.custom-popover').forEach(el => el.remove());
-    }
-    function createPopover(content, target){
-        removeAll();
-        const pop = document.createElement('div');
-        pop.className = 'custom-popover absolute bg-white border border-gray-300 px-2 py-1 rounded shadow text-sm max-w-[250px] whitespace-normal z-[1000]';
-        pop.innerHTML = (content || '').replace(/\n/g, '<br>');
-        document.body.appendChild(pop);
-        const rect = target.getBoundingClientRect();
-        pop.style.left = rect.right + window.scrollX + 8 + 'px';
-        pop.style.top = rect.top + window.scrollY + 'px';
-        return pop;
-    }
-    function attach(el){
-        let instance = null;
-        el.addEventListener('mouseenter', () => {
-            const html = el.dataset.popoverContent;
-            if(html){
-                instance = createPopover(html, el);
-            }
-        });
-        el.addEventListener('mouseleave', () => {
-            if(instance){
-                instance.remove();
-                instance = null;
-            }
-        });
-    }
-    window.attachCustomPopover = attach;
-    window.removeCustomPopovers = removeAll;
-    window.initCustomPopovers = function(container=document){
-        container.querySelectorAll('[data-popover-content]').forEach(el => {
-            if(!el.dataset.popoverInit){
-                attach(el);
-                el.dataset.popoverInit = '1';
-            }
-        });
-    };
-    document.body.addEventListener('htmx:beforeSwap', removeAll);
+(function () {
+  function removeAll() {
+    document.querySelectorAll('.custom-popover').forEach(el => el.remove());
+  }
+  function createPopover(content, target) {
+    removeAll();
+    const pop = document.createElement('div');
+    pop.className = 'custom-popover absolute bg-white border border-gray-300 px-2 py-1 rounded shadow text-sm max-w-[250px] whitespace-normal z-[1000]';
+    pop.innerHTML = (content || '').replace(/\n/g, '<br>');
+    document.body.appendChild(pop);
+    const rect = target.getBoundingClientRect();
+    pop.style.left = rect.right + window.scrollX + 8 + 'px';
+    pop.style.top  = rect.top  + window.scrollY + 'px';
+    return pop;
+  }
+  function attach(el) {
+    let inst = null;
+    el.addEventListener('mouseenter', () => {
+      const html = el.dataset.popoverContent;
+      if (html) inst = createPopover(html, el);
+    });
+    el.addEventListener('mouseleave', () => {
+      if (inst) { inst.remove(); inst = null; }
+    });
+  }
+  window.attachCustomPopover = attach;
+  window.initCustomPopovers = function (root = document) {
+    root.querySelectorAll('[data-popover-content]').forEach(el => {
+      if (!el.dataset.popoverInit) {
+        attach(el);
+        el.dataset.popoverInit = '1';
+      }
+    });
+  };
+  document.body.addEventListener('htmx:beforeSwap', removeAll);
+  document.addEventListener('DOMContentLoaded', () => initCustomPopovers());
 })();

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -28,7 +28,7 @@
         {% endif %}
     </button>
     {% endwith %}
-    <span class="source-icon" title="{{ source }}">
+    <span class="source-icon" data-popover-content="{{ source }}">
         {% if source == 'Manuell' %}
         <i class="fas fa-user"></i>
         {% elif source == 'KI-Check' %}
@@ -38,7 +38,7 @@
         {% endif %}
     </span>
     {% if field_name == 'ki_beteiligung' and row.ki_beteiligt_begruendung %}
-    <a href="{% url 'ki_involvement_detail_edit' anlage.pk row.verif_key %}" class="info-icon" title="Begründung ansehen/bearbeiten">ℹ️</a>
+    <a href="{% url 'ki_involvement_detail_edit' anlage.pk row.verif_key %}" class="info-icon" data-popover-content="Begründung ansehen/bearbeiten">ℹ️</a>
     {% endif %}
     {% else %}
     <span>-</span>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% block extra_head %}
 {{ block.super }}
+<script src="{% static 'js/popover.js' %}"></script>
 {% endblock %}
 {% load recording_extras %}
 {% block title %}Anlage 2 Review{% endblock %}
@@ -78,7 +79,7 @@
                     {% endif %}
                     {% endif %}
                     {% if row.source_text and row.source_text != 'N/A' %}
-                    <span class="text-muted small source-indicator" title="{{ row.source_text }}">
+                    <span class="text-muted small source-indicator" data-popover-content="{{ row.source_text }}">
                         {% if row.source_text == 'Manuell' %}
                         <i class="fas fa-user"></i>
                         {% else %}
@@ -99,7 +100,7 @@
                     {% if allow_ai_check %}
                     <button type="button"
                         class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 rounded bg-gray-100 hover:bg-gray-200"
-                        data-state="robot" title="KI-Prüfung starten"
+                        data-state="robot" data-popover-content="KI-Prüfung starten"
                         data-project-file-id="{{ anlage.pk }}"
                         data-function-id="{{ row.func_id }}"
                         data-justification-url="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
@@ -461,9 +462,6 @@ function updateRowAppearance(row) {
     });
 
 
-    document.body.addEventListener('htmx:beforeSwap', () => {
-        if (window.removeCustomPopovers) removeCustomPopovers();
-    });
     document.body.addEventListener('htmx:afterSwap', e => {
         const r = e.target.closest("tr[data-parsed-status]");
         if (r) {
@@ -476,6 +474,7 @@ function updateRowAppearance(row) {
 
 document.addEventListener('DOMContentLoaded', function() {
     initAnlage2Review();
+    if (window.initCustomPopovers) initCustomPopovers();
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add standalone popover utility script
- enable popover tooltips in Anlage 2 review
- show popovers for source and info icons

## Testing
- `DJANGO_SECRET_KEY=foo python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_689b39dd16a8832ba45f4dbc98ab0330