### PR TITLE
fix: remove popover-manual style

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -39,9 +39,6 @@
     background-color: #ffc107;
     color: black;
 }
-.popover-manual {
-    font-weight: bold;
-}
 .status-unbekannt {
     background-color: #6c757d;
     color: white;

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -265,7 +265,7 @@ function updatePopoverContent(icon) {
         else manualVal = manualEntry;
     }
     const manualHtml = hasManual ?
-        `<span class="popover-manual">Manuell: ${manualVal}</span>` :
+        `<span class="font-bold">Manuell: ${manualVal}</span>` :
         'Manuell: -';
     const html = `Dokument: ${docVal}${docNote ? ' ('+docNote+')' : ''}<br>` +
                  `KI-Check: ${aiDisplay}${aiNote ? ' ('+aiNote+')' : ''}<br>` +


### PR DESCRIPTION
## Summary
- replace manual popover span with bold class
- remove obsolete popover-manual CSS rule and ensure no popover.css references

## Testing
- `DJANGO_SECRET_KEY=tmp python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_689b39e572e4832bae693d947853d26d