### PR TITLE
fix: remove tab-btn class and use data attributes

### DIFF
--- a/static/js/anlagen_dropzone.js
+++ b/static/js/anlagen_dropzone.js
@@ -10,7 +10,7 @@ function initDropzone() {
     const colspan = parseInt(zone.dataset.colspan || '6', 10);
 
     function setActiveTab(nr) {
-        document.querySelectorAll('.anlage-tab-btn').forEach(btn => {
+        document.querySelectorAll('.anlage-tab').forEach(btn => {
             if (btn.dataset.nr === String(nr)) {
                 btn.classList.add('border-blue-600', 'text-blue-600');
                 btn.classList.remove('border-transparent', 'text-gray-600');

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -13,11 +13,11 @@
     <input type="hidden" name="active_tab" id="active_tab" value="{{ active_tab }}">
     <input type="hidden" name="phrase_key" id="phrase_key" value="">
     <nav class="border-b border-gray-200 space-x-2 mb-4">
-        <button type="button" data-tab-btn data-tab="table" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Tabellen-Parser</button>
-        <button type="button" data-tab-btn data-tab="general" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Allgemein</button>
-        <button type="button" data-tab-btn data-tab="rules" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Parser-Antwortregeln</button>
-        <button type="button" data-tab-btn data-tab="rules2" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Regeln Fallback</button>
-        <button type="button" data-tab-btn data-tab="a4" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Anlage 4 Parser</button>
+        <button type="button" data-tab="table" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Tabellen-Parser</button>
+        <button type="button" data-tab="general" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Allgemein</button>
+        <button type="button" data-tab="rules" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Parser-Antwortregeln</button>
+        <button type="button" data-tab="rules2" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Regeln Fallback</button>
+        <button type="button" data-tab="a4" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Anlage 4 Parser</button>
     </nav>
     <div id="tab-table" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Tabellen-Parser: Spaltenüberschriften (Alias)</h2>
@@ -132,7 +132,7 @@ function showTab(tab){
     const el=document.getElementById('tab-'+tab);
     if(el){el.style.display='';}
     document.getElementById('active_tab').value=tab;
-    document.querySelectorAll('[data-tab-btn]').forEach(btn=>{
+    document.querySelectorAll('[data-tab]').forEach(btn=>{
         if(btn.dataset.tab===tab){
             btn.classList.remove('bg-gray-200','text-gray-600','border-b-0');
             btn.classList.add('bg-white','text-blue-600','font-semibold','border-b-transparent');
@@ -142,7 +142,7 @@ function showTab(tab){
         }
     });
 }
-document.querySelectorAll('[data-tab-btn]').forEach(btn=>{
+document.querySelectorAll('[data-tab]').forEach(btn=>{
     btn.addEventListener('click',()=>showTab(btn.dataset.tab));
 });
 showTab('{{ active_tab }}');

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -9,7 +9,7 @@
 </div>
 <div class="mb-4 space-x-2">
     {% for key, label, items in grouped %}
-        <button data-tab-btn data-tab="{{ key }}" class="px-3 py-1 bg-blue-600 text-white rounded">{{ label }}</button>
+        <button data-tab="{{ key }}" class="px-3 py-1 bg-blue-600 text-white rounded">{{ label }}</button>
     {% endfor %}
 </div>
 
@@ -103,7 +103,7 @@
 {% endfor %}
 
 <script>
-document.querySelectorAll('[data-tab-btn]').forEach(btn => {
+document.querySelectorAll('[data-tab]').forEach(btn => {
     btn.addEventListener('click', () => {
         document.querySelectorAll('.tab-content').forEach(sec => sec.classList.add('hidden'));
         document.getElementById('tab-' + btn.dataset.tab).classList.remove('hidden');

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -47,7 +47,7 @@
 <h2 class="text-xl font-semibold mb-4">Anlagen</h2>
 <nav class="flex space-x-2 mb-4" id="anlage-tabs-nav">
   {% for nr in anlage_numbers %}
-  <button class="anlage-tab-btn px-3 py-1 border-b-2 {% if forloop.first %}border-primary text-primary{% else %}border-transparent text-gray-600{% endif %}"
+  <button class="anlage-tab px-3 py-1 border-b-2 {% if forloop.first %}border-primary text-primary{% else %}border-transparent text-gray-600{% endif %}"
           hx-get="{% url 'hx_project_anlage_tab' projekt.pk nr %}"
           hx-target="#anlage-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-nr="{{ nr }}">
@@ -62,11 +62,11 @@
 <div class="bg-white rounded-lg shadow p-4">
 <h2 class="text-xl font-semibold mb-4">Initial-Prüfung der Software-Komponenten</h2>
 <nav class="flex space-x-2 mb-4">
-  <button class="software-tab-btn px-3 py-1 border-b-2 border-primary text-primary"
+  <button class="software-tab px-3 py-1 border-b-2 border-primary text-primary"
           hx-get="{% url 'hx_project_software_tab' projekt.pk 'tech' %}"
           hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-tab="tech">Technische Prüfung</button>
-  <button class="software-tab-btn px-3 py-1 border-b-2 border-transparent text-gray-600"
+  <button class="software-tab px-3 py-1 border-b-2 border-transparent text-gray-600"
           hx-get="{% url 'hx_project_software_tab' projekt.pk 'gutachten' %}"
           hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-tab="gutachten">Gutachten</button>
@@ -237,16 +237,16 @@ document.addEventListener('htmx:afterSwap',function(){
 
 document.addEventListener('htmx:beforeRequest',function(e){
   const t=e.target;
-  if(t.classList.contains('anlage-tab-btn')){
-    document.querySelectorAll('.anlage-tab-btn').forEach(b=>{
+  if(t.classList.contains('anlage-tab')){
+    document.querySelectorAll('.anlage-tab').forEach(b=>{
       b.classList.remove('border-primary','text-primary');
       b.classList.add('border-transparent','text-gray-600');
     });
     t.classList.remove('border-transparent','text-gray-600');
     t.classList.add('border-primary','text-primary');
   }
-  if(t.classList.contains('software-tab-btn')){
-    document.querySelectorAll('.software-tab-btn').forEach(b=>{
+  if(t.classList.contains('software-tab')){
+    document.querySelectorAll('.software-tab').forEach(b=>{
       b.classList.remove('border-primary','text-primary');
       b.classList.add('border-transparent','text-gray-600');
     });


### PR DESCRIPTION
## Summary
- replace legacy tab-btn usage in admin templates with Tailwind classes and data attributes
- drop remaining tab-btn selectors in project detail and dropzone script

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_689b3b0cb42c832b8c7f995caa30ba23