### PR TITLE
refactor: use form partials in project templates

### DIFF
--- a/templates/edit_project_context.html
+++ b/templates/edit_project_context.html
@@ -6,6 +6,6 @@
     {% csrf_token %}
     {{ form.project_prompt.label_tag }}
     {{ form.project_prompt }}
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/gap_notes_form.html
+++ b/templates/gap_notes_form.html
@@ -5,9 +5,11 @@
 <p>Diese Notizen werden automatisch erstellt und können hier nicht mehr bearbeitet werden.</p>
 <div class="space-x-2 mt-4">
     {% if project_file %}
-    <a href="{% url 'projekt_file_edit_json' project_file.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück</a>
+    {% url 'projekt_file_edit_json' project_file.pk as back_url %}
+    {% include 'partials/_button.html' with href=back_url label='Zurück' color_classes='bg-gray-300 text-black' classes='px-4 py-2 rounded' %}
     {% else %}
-    <a href="{% url 'projekt_detail' result.project.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück</a>
+    {% url 'projekt_detail' result.project.pk as back_url %}
+    {% include 'partials/_button.html' with href=back_url label='Zurück' color_classes='bg-gray-300 text-black' classes='px-4 py-2 rounded' %}
     {% endif %}
 </div>
 {% endblock %}

--- a/templates/partials/_button.html
+++ b/templates/partials/_button.html
@@ -1,6 +1,6 @@
 {% if href %}
-<a href="{{ href }}" {% if id %}id="{{ id }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} class="inline-flex items-center px-4 py-2 rounded {{ color_classes|default:'bg-primary text-white hover:bg-primary-dark' }} {{ classes|default:'' }}">{{ label }}</a>
+<a href="{{ href }}" {% if id %}id="{{ id }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-4 py-2 rounded {{ color_classes|default:'bg-primary text-white hover:bg-primary-dark' }} {{ classes|default:'' }}">{{ label }}</a>
 {% else %}
-<button type="{{ type|default:'button' }}" {% if id %}id="{{ id }}"{% endif %} {% if name %}name="{{ name }}"{% endif %} {% if formaction %}formaction="{{ formaction }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {% if disabled %}disabled{% endif %} class="inline-flex items-center px-4 py-2 rounded {{ color_classes|default:'bg-primary text-white hover:bg-primary-dark' }} {{ classes|default:'' }}">{{ label }}</button>
+<button type="{{ type|default:'button' }}" {% if id %}id="{{ id }}"{% endif %} {% if name %}name="{{ name }}"{% endif %} {% if formaction %}formaction="{{ formaction }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {% if disabled %}disabled{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-4 py-2 rounded {{ color_classes|default:'bg-primary text-white hover:bg-primary-dark' }} {{ classes|default:'' }}">{{ label }}</button>
 {% endif %}
 

--- a/templates/partials/_form_input.html
+++ b/templates/partials/_form_input.html
@@ -2,7 +2,8 @@
        name="{{ name }}"
        id="{{ id|default:name }}"
        value="{{ value|default:'' }}"
-       class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary {{ classes|default:'' }}"
+       class="{{ base_classes|default:'mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary' }} {{ classes|default:'' }}"
        {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
-       {% if required %}required{% endif %}>
+       {% if required %}required{% endif %}
+       {% if checked %}checked{% endif %}>
 

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -31,7 +31,7 @@
     </table>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <div class="space-x-2 mt-2">
-        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+        {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
     </div>
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -8,9 +8,8 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen prüfen</h1>
 <p>
-  <a href="{% url 'anlage2_supervision' anlage.project.pk %}" class="bg-purple-600 text-white px-3 py-1 rounded">
-    Zur neuen Supervisions-Ansicht wechseln
-  </a>
+  {% url 'anlage2_supervision' anlage.project.pk as supervision_url %}
+  {% include 'partials/_button.html' with href=supervision_url label='Zur neuen Supervisions-Ansicht wechseln' color_classes='bg-purple-600 text-white' classes='px-3 py-1 rounded' %}
 </p>
 {% if anlage.processing_status == 'PROCESSING' or anlage.is_verification_running %}
 <div id="anlage-edit-{{ anlage.pk }}" class="p-4 text-center"
@@ -23,9 +22,9 @@
 <form method="post" class="space-y-4" data-anlage-id="{{ anlage.pk }}">
     {% csrf_token %}
     <div class="mb-3">
-        <button type="button" id="expand-all-subquestions" class="bg-gray-300 text-black px-2 py-1 rounded">Alle aufklappen</button>
-        <button type="button" id="collapse-all-subquestions" class="bg-gray-300 text-black px-2 py-1 rounded">Alle einklappen</button>
-        <button type="button" id="toggle-actions" class="bg-gray-300 text-black px-2 py-1 rounded ml-4">Aktionen einblenden</button>
+        {% include 'partials/_button.html' with type='button' id='expand-all-subquestions' label='Alle aufklappen' color_classes='bg-gray-300 text-black' classes='px-2 py-1 rounded' %}
+        {% include 'partials/_button.html' with type='button' id='collapse-all-subquestions' label='Alle einklappen' color_classes='bg-gray-300 text-black' classes='px-2 py-1 rounded' %}
+        {% include 'partials/_button.html' with type='button' id='toggle-actions' label='Aktionen einblenden' color_classes='bg-gray-300 text-black' classes='px-2 py-1 rounded ml-4' %}
     </div>
     <div class="overflow-x-auto">
     <table id="anlage2-review-table" class="table-auto w-full border">
@@ -112,7 +111,7 @@
     </table>
     <div class="mb-2">
         {% if allow_ai_check %}
-        <button type="button" id="btn-verify-all" data-project-id="{{ anlage.project.pk }}" class="bg-green-600 text-white px-2 py-1 rounded">Alle Funktionen prüfen 🤖</button>
+        {% include 'partials/_button.html' with type='button' id='btn-verify-all' label='Alle Funktionen prüfen 🤖' color_classes='bg-green-600 text-white' classes='px-2 py-1 rounded' attrs='data-project-id="'|add:anlage.project.pk|add:'"' %}
         {% endif %}
         <a href="{% url 'projekt_file_parse_anlage2' anlage.pk %}" class="bg-blue-600 text-white px-2 py-1 rounded ml-4">Parser-Analyse starten</a>
     </div>

--- a/templates/projekt_file_anlage3_review.html
+++ b/templates/projekt_file_anlage3_review.html
@@ -7,6 +7,6 @@
     {% csrf_token %}
     {{ form.as_p }}
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage4_review.html
+++ b/templates/projekt_file_anlage4_review.html
@@ -44,6 +44,6 @@
         </tbody>
     </table>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage5_review.html
+++ b/templates/projekt_file_anlage5_review.html
@@ -13,6 +13,6 @@
         {{ form.sonstige }}
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage6_review.html
+++ b/templates/projekt_file_anlage6_review.html
@@ -19,6 +19,6 @@
         {{ form.verhandlungsfaehig.errors }}
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_check_result.html
+++ b/templates/projekt_file_check_result.html
@@ -6,13 +6,13 @@
     <label class="font-semibold">LLM-Modell:</label>
     {% for key, data in categories.items %}
         <label class="ml-2">
-            <input type="radio" name="model_category" value="{{ key }}" {% if key == category %}checked{% endif %}>
+            {% include 'partials/_form_input.html' with type='radio' name='model_category' value=key checked=(key == category) base_classes='mr-1' %}
             {{ data.label }}
         </label>
     {% endfor %}
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded ml-2">Neu prüfen</button>
+    {% include 'partials/_button.html' with type='submit' label='Neu prüfen' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded ml-2' %}
     {% if anlage.anlage_nr == 2 %}
-    <button type="submit" name="llm" value="1" class="bg-purple-600 text-white px-4 py-2 rounded ml-2">LLM-Check</button>
+    {% include 'partials/_button.html' with type='submit' name='llm' value='1' label='LLM-Check' color_classes='bg-purple-600 text-white' classes='px-4 py-2 rounded ml-2' %}
     {% endif %}
 </form>
 <form method="post" class="space-y-4">
@@ -33,9 +33,10 @@
     </div>
     {% endif %}
     <div class="space-x-2">
-        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
-        <a href="{% url 'projekt_detail' anlage.project.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zur\u00fcck</a>
-        <button type="button" id="copy-email" class="bg-green-600 text-white px-4 py-2 rounded">E-Mail kopieren</button>
+        {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+        {% url 'projekt_detail' anlage.project.pk as detail_url %}
+        {% include 'partials/_button.html' with href=detail_url label='Zurück' color_classes='bg-gray-300 text-black' classes='px-4 py-2 rounded' %}
+        {% include 'partials/_button.html' with type='button' id='copy-email' label='E-Mail kopieren' color_classes='bg-green-600 text-white' classes='px-4 py-2 rounded' %}
     </div>
 </form>
 <script>

--- a/templates/projekt_file_form.html
+++ b/templates/projekt_file_form.html
@@ -41,7 +41,7 @@
     {{ form.verhandlungsfaehig }} {{ form.verhandlungsfaehig.label_tag }}
     {{ form.verhandlungsfaehig.errors }}
 </div>
-<button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded mt-4">Speichern</button>
+{% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded mt-4' %}
 </form>
 {% endblock %}
 

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -23,18 +23,18 @@
                 {% if software_list %}
                     {% for name in software_list %}
                     <div class="flex items-center space-x-2">
-                        <input type="text" name="software_typen" value="{{ name }}" class="flex-grow border rounded p-2">
-                        <button type="button" class="px-2 py-1 text-sm bg-red-100 hover:bg-red-200 text-red-700 rounded remove-software-btn">Entfernen</button>
+                        {% include 'partials/_form_input.html' with name='software_typen' value=name base_classes='flex-grow rounded-md border-gray-300 p-2 focus:border-primary focus:ring-primary' %}
+                        {% include 'partials/_button.html' with type='button' label='Entfernen' color_classes='bg-red-100 hover:bg-red-200 text-red-700' classes='px-2 py-1 text-sm rounded remove-software-btn' %}
                     </div>
                     {% endfor %}
                 {% else %}
                     <div class="flex items-center space-x-2">
-                        <input type="text" name="software_typen" class="flex-grow border rounded p-2">
-                        <button type="button" class="px-2 py-1 text-sm bg-red-100 hover:bg-red-200 text-red-700 rounded remove-software-btn">Entfernen</button>
+                        {% include 'partials/_form_input.html' with name='software_typen' base_classes='flex-grow rounded-md border-gray-300 p-2 focus:border-primary focus:ring-primary' %}
+                        {% include 'partials/_button.html' with type='button' label='Entfernen' color_classes='bg-red-100 hover:bg-red-200 text-red-700' classes='px-2 py-1 text-sm rounded remove-software-btn' %}
                     </div>
                 {% endif %}
             </div>
-            <button type="button" id="add-software-btn" class="mt-2 bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded">Software hinzufügen</button>
+            {% include 'partials/_button.html' with type='button' id='add-software-btn' label='Software hinzufügen' color_classes='bg-gray-200 hover:bg-gray-300 text-gray-800' classes='mt-2 px-3 py-1 rounded' %}
         </div>
         {% if 'status' in form.fields %}
         <div>
@@ -44,14 +44,14 @@
         </div>
         {% endif %}
         <div class="pt-4">
-            <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded shadow">Speichern</button>
+            {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 hover:bg-blue-700 text-white' classes='font-semibold px-6 py-2 rounded shadow' %}
         </div>
         {% if projekt %}
         <div class="mt-6">
             <label class="font-semibold">LLM-Modell:</label>
             {% for key, data in categories.items %}
                 <label class="ml-2">
-                    <input type="radio" name="model_category" value="{{ key }}" {% if key == category %}checked{% endif %}>
+                    {% include 'partials/_form_input.html' with type='radio' name='model_category' value=key checked=(key == category) base_classes='mr-1' %}
                     {{ data.label }}
                 </label>
             {% endfor %}
@@ -68,24 +68,20 @@ document.addEventListener('DOMContentLoaded', function() {
     const addSoftwareBtn = document.getElementById('add-software-btn');
     const container = document.getElementById('software-inputs-container');
 
+    const inputTemplate = `{% filter escapejs %}{% include 'partials/_form_input.html' with name='software_typen' base_classes='flex-grow rounded-md border-gray-300 p-2 focus:border-primary focus:ring-primary' %}{% endfilter %}`;
+    const removeBtnTemplate = `{% filter escapejs %}{% include 'partials/_button.html' with type='button' label='Entfernen' color_classes='bg-red-100 hover:bg-red-200 text-red-700' classes='px-2 py-1 text-sm rounded remove-software-btn' %}{% endfilter %}`;
+
     function addSoftwareField(value = '') {
         const wrapper = document.createElement('div');
         wrapper.className = 'flex items-center space-x-2';
-        const input = document.createElement('input');
-        input.type = 'text';
-        input.name = 'software_typen';
+        wrapper.innerHTML = inputTemplate + removeBtnTemplate;
+        const input = wrapper.querySelector('input[name="software_typen"]');
         input.value = value;
-        input.className = 'flex-grow border rounded p-2';
-        const removeBtn = document.createElement('button');
-        removeBtn.type = 'button';
-        removeBtn.className = 'px-2 py-1 text-sm bg-red-100 hover:bg-red-200 text-red-700 rounded remove-software-btn';
-        removeBtn.textContent = 'Entfernen';
+        const removeBtn = wrapper.querySelector('.remove-software-btn');
         removeBtn.addEventListener('click', function() {
             wrapper.remove();
             updateRemoveButtons();
         });
-        wrapper.appendChild(input);
-        wrapper.appendChild(removeBtn);
         container.appendChild(wrapper);
     }
 

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -9,12 +9,12 @@
         <label for="model_category" class="font-semibold">LLM-Modell:</label>
         {% for key, data in categories.items %}
             <label class="ml-2">
-                <input type="radio" name="model_category" value="{{ key }}" {% if key == category %}checked{% endif %}>
+                {% include 'partials/_form_input.html' with type='radio' name='model_category' value=key checked=(key == category) base_classes='mr-1' %}
                 {{ data.label }}
             </label>
         {% endfor %}
     </div>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">LLM starten</button>
+    {% include 'partials/_button.html' with type='submit' label='LLM starten' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
 </form>
 {% if projekt.gutachten_file %}
 <p class="mt-4">

--- a/templates/projekt_upload.html
+++ b/templates/projekt_upload.html
@@ -8,6 +8,6 @@
     {{ form.docx_file.label_tag }}<br>
     {{ form.docx_file }}
     {{ form.docx_file.errors }}
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
+    {% include 'partials/_button.html' with type='submit' label='Upload' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace manual inputs in project forms with partials
- unify buttons across project templates using `_button.html`
- allow form and button partials to accept extra attributes

## Testing
- `pre-commit run --files templates/partials/_form_input.html templates/partials/_button.html templates/projekt_form.html templates/projekt_gutachten_form.html templates/projekt_file_form.html templates/projekt_file_check_result.html templates/edit_project_context.html templates/projekt_upload.html templates/projekt_file_anlage1_review.html templates/projekt_file_anlage2_review.html templates/projekt_file_anlage3_review.html templates/projekt_file_anlage4_review.html templates/projekt_file_anlage5_review.html templates/projekt_file_anlage6_review.html templates/gap_notes_form.html` *(failed: command not found)*
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_689b3b0f0184832b8fafac0369aa8c02