### PR TITLE
fix: guard supervision groups without main function

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -881,7 +881,7 @@ def _build_supervision_groups(pf: BVProjectFile) -> list[dict]:
             {
                 "function": func,
                 "subrows": subrows,
-                "show_subs": bool(present),
+                "show_subs": bool(present) or not func,
             }
         )
     return groups

--- a/templates/partials/supervision_group.html
+++ b/templates/partials/supervision_group.html
@@ -1,9 +1,11 @@
-<details class="border rounded" {% if group.function.has_discrepancy %}open{% endif %}>
-  <summary class="p-2 cursor-pointer {% if group.function.has_discrepancy %}bg-red-100{% else %}bg-gray-100{% endif %}">
-    {{ group.function.name }}
+<details class="border rounded" {% if group.function and group.function.has_discrepancy %}open{% endif %}>
+  <summary class="p-2 cursor-pointer {% if group.function and group.function.has_discrepancy %}bg-red-100{% else %}bg-gray-100{% endif %}">
+    {% if group.function %}{{ group.function.name }}{% else %}{{ group.name }}{% endif %}
     {% if group.subrows %}<span class="ms-2">+</span>{% endif %}
   </summary>
-  {% include 'partials/supervision_row_content.html' with row=group.function standard_notes=standard_notes %}
+  {% if group.function %}
+    {% include 'partials/supervision_row_content.html' with row=group.function standard_notes=standard_notes %}
+  {% endif %}
   {% if group.show_subs and group.subrows %}
   <div class="ms-4 space-y-4 mt-2">
     {% for sub in group.subrows %}


### PR DESCRIPTION
## Summary
- Avoid rendering supervision main row forms when no function is present
- Ensure sub-rows appear for groups without a main function

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'selenium', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b449a4bd4832bab153dbbd6acbf48