### PR TITLE
feat: add reusable button variants

### DIFF
--- a/core/templatetags/ui_extras.py
+++ b/core/templatetags/ui_extras.py
@@ -1,0 +1,19 @@
+from django import template
+
+register = template.Library()
+
+BTN_VARIANTS = {
+    "primary": "bg-primary text-white hover:bg-primary-dark",
+    "secondary": "bg-gray-300 text-black hover:bg-gray-400",
+    "success": "bg-green-600 text-white hover:bg-green-700",
+    "danger": "bg-red-600 text-white hover:bg-red-700",
+    "danger-light": "bg-red-100 hover:bg-red-200 text-red-700",
+    "purple": "bg-purple-600 text-white hover:bg-purple-700",
+    "muted": "bg-gray-200 hover:bg-gray-300 text-gray-800",
+    "disabled": "bg-gray-300 text-gray-500 cursor-not-allowed",
+}
+
+@register.simple_tag
+def btn_classes(variant: str = "primary") -> str:
+    """Gibt die Tailwind-Klassen f\u00fcr die Button-Variante zur\u00fcck."""
+    return BTN_VARIANTS.get(variant, BTN_VARIANTS["primary"])

--- a/templates/admin_projects.html
+++ b/templates/admin_projects.html
@@ -38,10 +38,10 @@
     {% csrf_token %}
     {% if projects %}
     <div class="mt-4 space-x-2">
-        {% include 'partials/_button.html' with type='button' id='import-btn' label='Importieren' color_classes='bg-green-600 text-white hover:bg-green-700' %}
+        {% include 'partials/_button.html' with type='button' id='import-btn' label='Importieren' variant='success' %}
         {% url 'admin_project_export' as export_url %}
-        {% include 'partials/_button.html' with type='submit' id='export-btn' formaction=export_url label='Exportieren' disabled=True %}
-        {% include 'partials/_button.html' with type='submit' name='delete_selected' label='Markierte löschen' color_classes='bg-red-600 text-white hover:bg-red-700' onclick="return confirm('Einträge wirklich löschen?');" %}
+        {% include 'partials/_button.html' with type='submit' id='export-btn' formaction=export_url label='Exportieren' variant='primary' disabled=True %}
+        {% include 'partials/_button.html' with type='submit' name='delete_selected' label='Markierte löschen' variant='danger' onclick="return confirm('Einträge wirklich löschen?');" %}
     </div>
     {% endif %}
 </form>

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -26,7 +26,7 @@
         </div>
         <button type="button" id="add-alias-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
     </div>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' classes='mt-4' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='mt-4' %}
 </form>
 <script>
 document.addEventListener('DOMContentLoaded', () => {

--- a/templates/anlage2/subquestion_form.html
+++ b/templates/anlage2/subquestion_form.html
@@ -53,6 +53,6 @@
         });
     });
     </script>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' %}
 </form>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
 
                     <form action="{% url 'logout' %}" method="post" class="inline">
                         {% csrf_token %}
-                        {% include 'partials/_button.html' with type='submit' label='Abmelden' classes='bg-transparent hover:underline px-0 py-0' %}
+                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='primary' classes='bg-transparent hover:underline px-0 py-0' %}
                     </form>
 
                 {% else %}

--- a/templates/edit_project_context.html
+++ b/templates/edit_project_context.html
@@ -6,6 +6,6 @@
     {% csrf_token %}
     {{ form.project_prompt.label_tag }}
     {{ form.project_prompt }}
-    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/gap_notes_form.html
+++ b/templates/gap_notes_form.html
@@ -6,10 +6,10 @@
 <div class="space-x-2 mt-4">
     {% if project_file %}
     {% url 'projekt_file_edit_json' project_file.pk as back_url %}
-    {% include 'partials/_button.html' with href=back_url label='Zurück' color_classes='bg-gray-300 text-black' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with href=back_url label='Zurück' variant='secondary' classes='px-4 py-2 rounded' %}
     {% else %}
     {% url 'projekt_detail' result.project.pk as back_url %}
-    {% include 'partials/_button.html' with href=back_url label='Zurück' color_classes='bg-gray-300 text-black' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with href=back_url label='Zurück' variant='secondary' classes='px-4 py-2 rounded' %}
     {% endif %}
 </div>
 {% endblock %}

--- a/templates/partials/_button.html
+++ b/templates/partials/_button.html
@@ -1,6 +1,7 @@
+{% load ui_extras %}
 {% if href %}
-<a href="{{ href }}" {% if id %}id="{{ id }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-4 py-2 rounded {{ color_classes|default:'bg-primary text-white hover:bg-primary-dark' }} {{ classes|default:'' }}">{{ label }}</a>
+<a href="{{ href }}" {% if id %}id="{{ id }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-4 py-2 rounded {{ btn_classes(variant) }} {{ classes|default:'' }}">{{ label }}</a>
 {% else %}
-<button type="{{ type|default:'button' }}" {% if id %}id="{{ id }}"{% endif %} {% if name %}name="{{ name }}"{% endif %} {% if formaction %}formaction="{{ formaction }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {% if disabled %}disabled{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-4 py-2 rounded {{ color_classes|default:'bg-primary text-white hover:bg-primary-dark' }} {{ classes|default:'' }}">{{ label }}</button>
+<button type="{{ type|default:'button' }}" {% if id %}id="{{ id }}"{% endif %} {% if name %}name="{{ name }}"{% endif %} {% if formaction %}formaction="{{ formaction }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {% if disabled %}disabled{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-4 py-2 rounded {{ btn_classes(variant) }} {{ classes|default:'' }}">{{ label }}</button>
 {% endif %}
 

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -6,7 +6,7 @@
 <h1 class="text-2xl font-semibold mb-4">{{ projekt.title }}
 {% if is_admin %}
 {% url 'admin_projects' as admin_url %}
-{% include 'partials/_button.html' with href=admin_url label='Admin' color_classes='bg-red-600 text-white hover:bg-red-700' classes='ml-2' %}
+{% include 'partials/_button.html' with href=admin_url label='Admin' variant='danger' classes='ml-2' %}
 {% endif %}
 </h1>
 <div class="lg:flex lg:space-x-4">
@@ -26,7 +26,7 @@
     {% csrf_token %}
     <label for="status" class="font-semibold">Status:</label>
     {% include 'partials/_form_select.html' with name='status' id='status' options=status_choices value=projekt.status.key classes='' %}
-    {% include 'partials/_button.html' with type='submit' label='Aktualisieren' classes='' %}
+    {% include 'partials/_button.html' with type='submit' label='Aktualisieren' variant='primary' classes='' %}
 </form>
 <p class="mb-4">
     <a href="{% url 'projekt_gap_analysis' projekt.pk %}" class="text-primary underline">Gap-Analyse herunterladen</a>
@@ -36,9 +36,9 @@
 <p class="mb-4">
     {% if can_gap_report %}
     {% url 'gap_report_view' projekt.pk as gap_url %}
-    {% include 'partials/_button.html' with href=gap_url label='GAP-Bericht f\u00fcr Fachbereich erstellen' %}
+    {% include 'partials/_button.html' with href=gap_url label='GAP-Bericht f\u00fcr Fachbereich erstellen' variant='primary' %}
     {% else %}
-    {% include 'partials/_button.html' with label='GAP-Bericht f\u00fcr Fachbereich erstellen' color_classes='bg-gray-300 text-gray-500' disabled=True %}
+    {% include 'partials/_button.html' with label='GAP-Bericht f\u00fcr Fachbereich erstellen' variant='disabled' disabled=True %}
     {% endif %}
 </p>
 </div>

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -31,7 +31,7 @@
     </table>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <div class="space-x-2 mt-2">
-        {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+        {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
     </div>
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -10,7 +10,7 @@
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen prüfen</h1>
 <p>
   {% url 'anlage2_supervision' anlage.project.pk as supervision_url %}
-  {% include 'partials/_button.html' with href=supervision_url label='Zur neuen Supervisions-Ansicht wechseln' color_classes='bg-purple-600 text-white' classes='px-3 py-1 rounded' %}
+{% include 'partials/_button.html' with href=supervision_url label='Zur neuen Supervisions-Ansicht wechseln' variant='purple' classes='px-3 py-1 rounded' %}
 </p>
 {% if anlage.processing_status == 'PROCESSING' or anlage.is_verification_running %}
 <div id="anlage-edit-{{ anlage.pk }}" class="p-4 text-center"
@@ -23,9 +23,9 @@
 <form method="post" class="space-y-4" data-anlage-id="{{ anlage.pk }}">
     {% csrf_token %}
     <div class="mb-3">
-        {% include 'partials/_button.html' with type='button' id='expand-all-subquestions' label='Alle aufklappen' color_classes='bg-gray-300 text-black' classes='px-2 py-1 rounded' %}
-        {% include 'partials/_button.html' with type='button' id='collapse-all-subquestions' label='Alle einklappen' color_classes='bg-gray-300 text-black' classes='px-2 py-1 rounded' %}
-        {% include 'partials/_button.html' with type='button' id='toggle-actions' label='Aktionen einblenden' color_classes='bg-gray-300 text-black' classes='px-2 py-1 rounded ml-4' %}
+        {% include 'partials/_button.html' with type='button' id='expand-all-subquestions' label='Alle aufklappen' variant='secondary' classes='px-2 py-1 rounded' %}
+        {% include 'partials/_button.html' with type='button' id='collapse-all-subquestions' label='Alle einklappen' variant='secondary' classes='px-2 py-1 rounded' %}
+        {% include 'partials/_button.html' with type='button' id='toggle-actions' label='Aktionen einblenden' variant='secondary' classes='px-2 py-1 rounded ml-4' %}
     </div>
     <div class="overflow-x-auto">
     <table id="anlage2-review-table" class="table-auto w-full border">
@@ -112,7 +112,7 @@
     </table>
     <div class="mb-2">
         {% if allow_ai_check %}
-        {% include 'partials/_button.html' with type='button' id='btn-verify-all' label='Alle Funktionen prüfen 🤖' color_classes='bg-green-600 text-white' classes='px-2 py-1 rounded' attrs='data-project-id="'|add:anlage.project.pk|add:'"' %}
+        {% include 'partials/_button.html' with type='button' id='btn-verify-all' label='Alle Funktionen prüfen 🤖' variant='success' classes='px-2 py-1 rounded' attrs='data-project-id="'|add:anlage.project.pk|add:'"' %}
         {% endif %}
         <a href="{% url 'projekt_file_parse_anlage2' anlage.pk %}" class="bg-blue-600 text-white px-2 py-1 rounded ml-4">Parser-Analyse starten</a>
     </div>

--- a/templates/projekt_file_anlage3_review.html
+++ b/templates/projekt_file_anlage3_review.html
@@ -7,6 +7,6 @@
     {% csrf_token %}
     {{ form.as_p }}
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage4_review.html
+++ b/templates/projekt_file_anlage4_review.html
@@ -44,6 +44,6 @@
         </tbody>
     </table>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage5_review.html
+++ b/templates/projekt_file_anlage5_review.html
@@ -13,6 +13,6 @@
         {{ form.sonstige }}
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage6_review.html
+++ b/templates/projekt_file_anlage6_review.html
@@ -19,6 +19,6 @@
         {{ form.verhandlungsfaehig.errors }}
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_check_result.html
+++ b/templates/projekt_file_check_result.html
@@ -10,9 +10,9 @@
             {{ data.label }}
         </label>
     {% endfor %}
-    {% include 'partials/_button.html' with type='submit' label='Neu prüfen' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded ml-2' %}
+    {% include 'partials/_button.html' with type='submit' label='Neu prüfen' variant='primary' classes='px-4 py-2 rounded ml-2' %}
     {% if anlage.anlage_nr == 2 %}
-    {% include 'partials/_button.html' with type='submit' name='llm' value='1' label='LLM-Check' color_classes='bg-purple-600 text-white' classes='px-4 py-2 rounded ml-2' %}
+    {% include 'partials/_button.html' with type='submit' name='llm' value='1' label='LLM-Check' variant='purple' classes='px-4 py-2 rounded ml-2' %}
     {% endif %}
 </form>
 <form method="post" class="space-y-4">
@@ -33,10 +33,10 @@
     </div>
     {% endif %}
     <div class="space-x-2">
-        {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+        {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
         {% url 'projekt_detail' anlage.project.pk as detail_url %}
-        {% include 'partials/_button.html' with href=detail_url label='Zurück' color_classes='bg-gray-300 text-black' classes='px-4 py-2 rounded' %}
-        {% include 'partials/_button.html' with type='button' id='copy-email' label='E-Mail kopieren' color_classes='bg-green-600 text-white' classes='px-4 py-2 rounded' %}
+        {% include 'partials/_button.html' with href=detail_url label='Zurück' variant='secondary' classes='px-4 py-2 rounded' %}
+        {% include 'partials/_button.html' with type='button' id='copy-email' label='E-Mail kopieren' variant='success' classes='px-4 py-2 rounded' %}
     </div>
 </form>
 <script>

--- a/templates/projekt_file_form.html
+++ b/templates/projekt_file_form.html
@@ -41,7 +41,7 @@
     {{ form.verhandlungsfaehig }} {{ form.verhandlungsfaehig.label_tag }}
     {{ form.verhandlungsfaehig.errors }}
 </div>
-{% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded mt-4' %}
+{% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded mt-4' %}
 </form>
 {% endblock %}
 

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -24,17 +24,17 @@
                     {% for name in software_list %}
                     <div class="flex items-center space-x-2">
                         {% include 'partials/_form_input.html' with name='software_typen' value=name base_classes='flex-grow rounded-md border-gray-300 p-2 focus:border-primary focus:ring-primary' %}
-                        {% include 'partials/_button.html' with type='button' label='Entfernen' color_classes='bg-red-100 hover:bg-red-200 text-red-700' classes='px-2 py-1 text-sm rounded remove-software-btn' %}
+                        {% include 'partials/_button.html' with type='button' label='Entfernen' variant='danger-light' classes='px-2 py-1 text-sm rounded remove-software-btn' %}
                     </div>
                     {% endfor %}
                 {% else %}
                     <div class="flex items-center space-x-2">
                         {% include 'partials/_form_input.html' with name='software_typen' base_classes='flex-grow rounded-md border-gray-300 p-2 focus:border-primary focus:ring-primary' %}
-                        {% include 'partials/_button.html' with type='button' label='Entfernen' color_classes='bg-red-100 hover:bg-red-200 text-red-700' classes='px-2 py-1 text-sm rounded remove-software-btn' %}
+                        {% include 'partials/_button.html' with type='button' label='Entfernen' variant='danger-light' classes='px-2 py-1 text-sm rounded remove-software-btn' %}
                     </div>
                 {% endif %}
             </div>
-            {% include 'partials/_button.html' with type='button' id='add-software-btn' label='Software hinzufügen' color_classes='bg-gray-200 hover:bg-gray-300 text-gray-800' classes='mt-2 px-3 py-1 rounded' %}
+            {% include 'partials/_button.html' with type='button' id='add-software-btn' label='Software hinzufügen' variant='muted' classes='mt-2 px-3 py-1 rounded' %}
         </div>
         {% if 'status' in form.fields %}
         <div>
@@ -44,7 +44,7 @@
         </div>
         {% endif %}
         <div class="pt-4">
-            {% include 'partials/_button.html' with type='submit' label='Speichern' color_classes='bg-blue-600 hover:bg-blue-700 text-white' classes='font-semibold px-6 py-2 rounded shadow' %}
+            {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='font-semibold px-6 py-2 rounded shadow' %}
         </div>
         {% if projekt %}
         <div class="mt-6">
@@ -69,7 +69,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const container = document.getElementById('software-inputs-container');
 
     const inputTemplate = `{% filter escapejs %}{% include 'partials/_form_input.html' with name='software_typen' base_classes='flex-grow rounded-md border-gray-300 p-2 focus:border-primary focus:ring-primary' %}{% endfilter %}`;
-    const removeBtnTemplate = `{% filter escapejs %}{% include 'partials/_button.html' with type='button' label='Entfernen' color_classes='bg-red-100 hover:bg-red-200 text-red-700' classes='px-2 py-1 text-sm rounded remove-software-btn' %}{% endfilter %}`;
+    const removeBtnTemplate = `{% filter escapejs %}{% include 'partials/_button.html' with type='button' label='Entfernen' variant='danger-light' classes='px-2 py-1 text-sm rounded remove-software-btn' %}{% endfilter %}`;
 
     function addSoftwareField(value = '') {
         const wrapper = document.createElement('div');

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -14,7 +14,7 @@
             </label>
         {% endfor %}
     </div>
-    {% include 'partials/_button.html' with type='submit' label='LLM starten' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='LLM starten' variant='primary' classes='px-4 py-2 rounded' %}
 </form>
 {% if projekt.gutachten_file %}
 <p class="mt-4">

--- a/templates/projekt_list.html
+++ b/templates/projekt_list.html
@@ -3,10 +3,10 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Projektverwaltung</h1>
 {% url 'projekt_create' as create_url %}
-{% include 'partials/_button.html' with href=create_url label='Neues Projekt' %}
+{% include 'partials/_button.html' with href=create_url label='Neues Projekt' variant='primary' %}
 {% if is_admin %}
 {% url 'admin_projects' as admin_url %}
-{% include 'partials/_button.html' with href=admin_url label='Admin' color_classes='bg-red-600 text-white hover:bg-red-700' classes='ml-2' %}
+{% include 'partials/_button.html' with href=admin_url label='Admin' variant='danger' classes='ml-2' %}
 {% endif %}
 <form method="get" action="{% url 'projekt_list' %}">
 <table class="min-w-full mt-4">

--- a/templates/projekt_upload.html
+++ b/templates/projekt_upload.html
@@ -8,6 +8,6 @@
     {{ form.docx_file.label_tag }}<br>
     {{ form.docx_file }}
     {{ form.docx_file.errors }}
-    {% include 'partials/_button.html' with type='submit' label='Upload' color_classes='bg-blue-600 text-white' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Upload' variant='primary' classes='px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -1,4 +1,16 @@
+const btnVariants = {
+  primary: 'bg-primary text-white hover:bg-primary-dark',
+  secondary: 'bg-gray-300 text-black hover:bg-gray-400',
+  success: 'bg-green-600 text-white hover:bg-green-700',
+  danger: 'bg-red-600 text-white hover:bg-red-700',
+  'danger-light': 'bg-red-100 hover:bg-red-200 text-red-700',
+  purple: 'bg-purple-600 text-white hover:bg-purple-700',
+  muted: 'bg-gray-200 hover:bg-gray-300 text-gray-800',
+  disabled: 'bg-gray-300 text-gray-500 cursor-not-allowed',
+};
+
 module.exports = {
+  btnVariants,
   content: [
     "../templates/**/*.html",
     "../../templates/**/*.html",


### PR DESCRIPTION
## Summary
- add `btnVariants` map to Tailwind config
- expose `btn_classes` helper for variant-based button styling
- replace `color_classes` parameter with `variant` across templates

## Testing
- `DJANGO_SECRET_KEY=dummy python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_689ba1e45a78832bb1d22775ed863c77