### PR TITLE
fix: improve disabled button contrast

### DIFF
--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -38,7 +38,7 @@
     {% url 'gap_report_view' projekt.pk as gap_url %}
     {% include 'partials/_button.html' with href=gap_url label='GAP-Bericht f\u00fcr Fachbereich erstellen' %}
     {% else %}
-    {% include 'partials/_button.html' with label='GAP-Bericht f\u00fcr Fachbereich erstellen' color_classes='bg-gray-300 text-gray-500' disabled=True %}
+    {% include 'partials/_button.html' with label='GAP-Bericht f\u00fcr Fachbereich erstellen' color_classes='bg-gray-300 text-gray-700' disabled=True %}
     {% endif %}
 </p>
 </div>


### PR DESCRIPTION
## Summary
- adjust disabled GAP report button contrast in project detail to bg-gray-300 text-gray-700

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_689ba1e58f98832bad4148dc632c8c7d