### PR TITLE
Add contrast accessibility check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,10 @@ repos:
     rev: v8.27.2
     hooks:
       - id: gitleaks
+  - repo: local
+    hooks:
+      - id: contrast-check
+        name: Kontrastprüfung
+        entry: npm --prefix theme/static_src run contrast -- base.html
+        language: system
+        pass_filenames: false

--- a/docs/kontrastpruefung.md
+++ b/docs/kontrastpruefung.md
@@ -1,0 +1,18 @@
+# Kontrastprüfung für neue Komponenten
+
+Um sicherzustellen, dass neue oder geänderte Komponenten einen ausreichend hohen
+Farbkontrast besitzen, kann folgendes Vorgehen verwendet werden:
+
+1. Rendern des gewünschten Templates und Ausführen der automatischen Prüfung:
+
+   ```bash
+   npm --prefix theme/static_src run contrast -- <template>
+   ```
+
+   Ohne Angabe eines Templates wird `base.html` geprüft.
+
+2. Pa11y rendert das Template mit Hilfe der Django-Einstellungen und überprüft
+   den Inhalt mit dem Axe-Runner auf Barrierefreiheitsprobleme. Bei gefundenen
+   Fehlern beendet sich der Prozess mit einem Fehlercode.
+
+Behebe alle gemeldeten Probleme, bevor der Code committet wird.

--- a/pa11y.json
+++ b/pa11y.json
@@ -1,0 +1,8 @@
+{
+  "chromeLaunchConfig": {
+    "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+  },
+  "defaults": {
+    "timeout": 10000
+  }
+}

--- a/theme/static_src/package.json
+++ b/theme/static_src/package.json
@@ -7,7 +7,8 @@
     "build": "npm run build:clean && npm run build:tailwind",
     "build:clean": "rimraf ../static/css/dist",
     "build:tailwind": "cross-env NODE_ENV=production postcss ./src/styles.css -o ../static/css/dist/styles.css --minify",
-    "dev": "cross-env NODE_ENV=development postcss ./src/styles.css -o ../static/css/dist/styles.css --watch"
+    "dev": "cross-env NODE_ENV=development postcss ./src/styles.css -o ../static/css/dist/styles.css --watch",
+    "contrast": "python ../../tools/check_contrast.py"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +17,7 @@
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.11",
     "cross-env": "^7.0.3",
+    "pa11y": "^9.0.0",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",
     "postcss-nested": "^7.0.2",

--- a/tools/check_contrast.py
+++ b/tools/check_contrast.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Prüft Django-Templates auf ausreichenden Farbkontrast.
+
+Das Skript rendert das angegebene Template mit den Django-Einstellungen
+und führt anschließend Pa11y mit dem Axe-Runner aus, der mögliche
+Barrierefreiheitsprobleme – darunter auch den Farbkontrast – meldet.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import django
+from django.template.loader import render_to_string
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Template rendern und Kontrast prüfen")
+    parser.add_argument(
+        "template",
+        nargs="?",
+        default="base.html",
+        help="Pfad zum Django-Template, das geprüft werden soll",
+    )
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parent.parent
+    os.chdir(project_root)
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "noesis.settings")
+    os.environ.setdefault("DJANGO_SECRET_KEY", "dev-secret")
+    django.setup()
+
+    html = render_to_string(args.template)
+    with tempfile.NamedTemporaryFile("w", suffix=".html", delete=False) as tmp:
+        tmp.write(html)
+        tmp_path = tmp.name
+
+    try:
+        cmd = ["npx", "pa11y", "--runner", "axe", tmp_path]
+        result = subprocess.run(cmd, check=False)
+        return result.returncode
+    finally:
+        os.unlink(tmp_path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add pa11y to frontend dependencies and provide contrast check script
- integrate contrast check into pre-commit hooks
- document how to run contrast checks for templates

## Testing
- `DJANGO_SECRET_KEY=dev python manage.py makemigrations --check`
- `pre-commit run --files .pre-commit-config.yaml theme/static_src/package.json theme/static_src/package-lock.json tools/check_contrast.py docs/kontrastpruefung.md pa11y.json`
- `npm --prefix theme/static_src run contrast -- base.html`


------
https://chatgpt.com/codex/tasks/task_e_689ba1e6cc78832b87e0530254d6afe6