### PR TITLE
Fix ui_extras template tag registration

### DIFF
--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -93,6 +93,9 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "core.context_processors.is_admin",
             ],
+            "libraries": {
+                "ui_extras": "core.templatetags.ui_extras",
+            },
         },
     },
 ]


### PR DESCRIPTION
## Summary
- ensure Django recognizes ui_extras tags by registering the library in template options

## Testing
- `python manage.py makemigrations --check`
- `python manage.py check`
- `python manage.py shell -c "from django.template import Template, Context; Template('{% load ui_extras %}').render(Context())"`
- `python manage.py runserver 0.0.0.0:8000 &>/tmp/server.log & sleep 3 && head -n 20 /tmp/server.log`


------
https://chatgpt.com/codex/tasks/task_e_689ba87ef4ac832b989261702b8f130c