### PR TITLE
fix: refactor status badges

### DIFF
--- a/templates/partials/status_badge.html
+++ b/templates/partials/status_badge.html
@@ -1,3 +1,3 @@
 {% with key=status_key|lower %}
-<span class="{% if key == 'new' or key == 'classified' %}badge-blue{% elif key == 'in_pruefung_anlage_x' or key == 'fb_in_pruefung' %}badge-yellow{% elif key == 'gutachten_ok' or key == 'gutachten_freigegeben' or key == 'endgeprueft' or key == 'ja' %}badge-green{% elif key == 'error' %}badge-red{% elif key == 'nein' or key == 'unbekannt' %}badge-gray{% else %}badge-gray{% endif %}">{{ label }}</span>
+<span class="badge {% if key == 'new' or key == 'classified' %}badge-blue{% elif key == 'in_pruefung_anlage_x' or key == 'fb_in_pruefung' %}badge-yellow{% elif key == 'gutachten_ok' or key == 'gutachten_freigegeben' or key == 'endgeprueft' or key == 'ja' %}badge-green{% elif key == 'error' %}badge-red{% elif key == 'nein' or key == 'unbekannt' %}badge-gray{% else %}badge-gray{% endif %}">{{ label }}</span>
 {% endwith %}

--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -6,24 +6,24 @@
     @apply inline-block px-2 py-0.5 rounded-full text-xs font-bold;
   }
   .badge-blue {
-    @apply badge bg-blue-600 text-white;
+    @apply bg-blue-600 text-white;
   }
   .badge-yellow {
-    @apply badge bg-yellow-400 text-black;
+    @apply bg-yellow-400 text-black;
   }
   .badge-green {
-    @apply badge bg-green-600 text-white;
+    @apply bg-green-600 text-white;
   }
   .badge-red {
-    @apply badge bg-red-600 text-white;
+    @apply bg-red-600 text-white;
   }
   .badge-gray {
-    @apply badge bg-gray-500 text-white;
+    @apply bg-gray-500 text-white;
   }
   .alert {
     @apply p-2 rounded;
   }
   .alert-success {
-    @apply alert bg-green-100 text-green-800;
+    @apply p-2 rounded bg-green-100 text-green-800;
   }
 }


### PR DESCRIPTION
## Summary
- refactor badge styles to apply only color utilities
- add base `badge` class in status badge template
- inline alert utilities for Tailwind v4 compatibility

## Testing
- `python manage.py makemigrations --check`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689ba85b7d94832baeb7cfedf0f52bea