### PR TITLE
fix: avoid invalid equality expression in template

### DIFF
--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -51,7 +51,11 @@
             <label class="font-semibold">LLM-Modell:</label>
             {% for key, data in categories.items %}
                 <label class="ml-2">
-                    {% include 'partials/_form_input.html' with type='radio' name='model_category' value=key checked=(key == category) base_classes='mr-1' %}
+                    {% if key == category %}
+                        {% include 'partials/_form_input.html' with type='radio' name='model_category' value=key checked=True base_classes='mr-1' %}
+                    {% else %}
+                        {% include 'partials/_form_input.html' with type='radio' name='model_category' value=key base_classes='mr-1' %}
+                    {% endif %}
                     {{ data.label }}
                 </label>
             {% endfor %}


### PR DESCRIPTION
## Summary
- render LLM model radio buttons without invalid template expression

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_689bb4e66c64832bbecb85cb07b3b1c8