### PR TITLE
feat: add primary color token

### DIFF
--- a/theme/static_src/package.json
+++ b/theme/static_src/package.json
@@ -1,13 +1,14 @@
 {
   "name": "theme",
   "version": "4.2.0",
+  "type": "module",
   "description": "",
   "scripts": {
     "start": "npm run dev",
     "build": "npm run build:clean && npm run build:tailwind",
     "build:clean": "rimraf ../static/css/dist",
-    "build:tailwind": "cross-env NODE_ENV=production postcss ./src/styles.css -o ../static/css/dist/styles.css --minify",
-    "dev": "cross-env NODE_ENV=development postcss ./src/styles.css -o ../static/css/dist/styles.css --watch",
+    "build:tailwind": "cross-env NODE_ENV=production TAILWIND_CONFIG=./tailwind.config.js postcss ./src/styles.css -o ../static/css/dist/styles.css --minify",
+    "dev": "cross-env NODE_ENV=development TAILWIND_CONFIG=./tailwind.config.js postcss ./src/styles.css -o ../static/css/dist/styles.css --watch",
     "contrast": "python ../../tools/check_contrast.py"
   },
   "keywords": [],

--- a/theme/static_src/postcss.config.js
+++ b/theme/static_src/postcss.config.js
@@ -1,7 +1,8 @@
-module.exports = {
+export default {
   plugins: {
     "@tailwindcss/postcss": {},
     "postcss-simple-vars": {},
-    "postcss-nested": {}
+    "postcss-nested": {},
   },
 }
+

--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+@theme {
+  --color-primary: #2563eb;
+  --color-primary-light: #3b82f6;
+  --color-primary-dark: #1e40af;
+}
+
 @import "./components.css";
 
 /**

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -1,4 +1,6 @@
-const btnVariants = {
+import forms from '@tailwindcss/forms';
+
+export const btnVariants = {
   primary: 'bg-primary text-white hover:bg-primary-dark',
   secondary: 'bg-gray-300 text-black hover:bg-gray-400',
   success: 'bg-green-600 text-white hover:bg-green-700',
@@ -9,14 +11,14 @@ const btnVariants = {
   disabled: 'bg-gray-300 text-gray-500 cursor-not-allowed',
 };
 
-module.exports = {
+export default {
   btnVariants,
   content: [
-    "../templates/**/*.html",
-    "../../templates/**/*.html",
-    "../../core/templates/**/*.html",
-    "../../**/templates/**/*.html",
-    "../../**/*.py",
+    '../templates/**/*.html',
+    '../../templates/**/*.html',
+    '../../core/templates/**/*.html',
+    '../../**/templates/**/*.html',
+    '../../**/*.py',
   ],
   theme: {
     extend: {
@@ -51,7 +53,6 @@ module.exports = {
       },
     },
   },
-  plugins: [
-    require('@tailwindcss/forms'),
-  ],
-}
+  plugins: [forms],
+};
+


### PR DESCRIPTION
## Summary
- define primary color theme token and expose via Tailwind config
- switch Tailwind/PostCSS configs to ESM and use explicit config path in build scripts
- build Tailwind assets so bg-primary class is available

## Testing
- `npm run build`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_689c4162a7a4832b91accbc07c640ef7