### PR TITLE
fix: configure CSRF trusted origins for Cloud Run

### DIFF
--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -36,6 +36,9 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+# Vertrauenswürdige Ursprünge für CSRF-Schutz (Cloud Run)
+CSRF_TRUSTED_ORIGINS = ["https://*.a.run.app"]
+
 INTERNAL_IPS = ["127.0.0.1", "0.0.0.0"]
 
 


### PR DESCRIPTION
## Summary
- allow Cloud Run domain in CSRF trusted origins to fix 403 errors on form posts

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'selenium'; IntegrityError; KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_689d11238290832ba7788d19cbbaf1cb