### PR TITLE
fix: Proxy-Header in Cloud Run beachten

### DIFF
--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -40,6 +40,9 @@ ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 # In Cloud Run wird K_SERVICE gesetzt; dann zusätzliche Hostfreigabe
 if os.environ.get("K_SERVICE"):
     ALLOWED_HOSTS.append("*.a.run.app")
+    # Proxy-Header vertrauen, um korrekte Host- und Schema-Informationen zu erhalten
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    USE_X_FORWARDED_HOST = True
 
 # Vertrauenswürdige Ursprünge für CSRF-Schutz (Cloud Run)
 CSRF_TRUSTED_ORIGINS = ["https://*.a.run.app"]


### PR DESCRIPTION
## Summary
- honor reverse proxy headers in Cloud Run

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_selenium` (fails: ModuleNotFoundError: No module named 'selenium')
- `python manage.py test core.tests.test_general.Anlage2ReviewTests.test_get_shows_table -v 2` (fails: AssertionError: Couldn't find 'Login' in response)

------
https://chatgpt.com/codex/tasks/task_e_689d18d3f524832bbe4408c21c070aec