### PR TITLE
fix: Header-Element vertikal zentriert

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,7 @@
     {% block extra_head %}{% endblock %}
 </head>
 <body class="flex flex-col min-h-screen bg-white text-gray-900">
-    <header class="bg-gray-200 text-gray-800 border-b">
+    <header class="bg-gray-200 text-gray-800 border-b items-center">
         <div class="container mx-auto flex items-center justify-between p-4">
             <div class="text-xl font-semibold">
                 <a href="/"><img src="{% static 'images/noesis_logo.jpg' %}" alt="Noesis Logo" class="h-18 inline"></a>


### PR DESCRIPTION
## Zusammenfassung
- Ausrichtung der Header-Inhalte durch Hinzufügen der Tailwind-Klasse `items-center`

## Test
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a3a039f1b8832bbf6963e6f7797071