### PR TITLE
feat: set custom header background color

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -19,7 +19,7 @@
     {% block extra_head %}{% endblock %}
 </head>
 <body class="flex flex-col min-h-screen bg-white text-gray-900">
-    <header class="header-bg text-gray-900 border-b items-center">
+    <header class="bg-header text-white border-b items-center">
         <div class="container mx-auto flex items-center justify-between p-4">
             <div class="text-xl font-semibold">
                 <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -27,8 +27,8 @@ export default {
           DEFAULT: '#4f46e5',
           light: '#6366f1',
           dark: '#4338ca',
-          header-bg: '#0d1b2a',
         },
+        header: '#0d1b2a',
         gray: {
           50: '#f8fafc',
           100: '#f1f5f9',


### PR DESCRIPTION
## Summary
- add `header` color (#0d1b2a) to Tailwind config
- use new `bg-header` class in base layout

## Testing
- `npm run build`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a41bf2a298832bbe31bd94848d7375