### PR TITLE
fix: remove header button background

### DIFF
--- a/core/templatetags/ui_extras.py
+++ b/core/templatetags/ui_extras.py
@@ -11,6 +11,7 @@ BTN_VARIANTS = {
     "purple": "bg-purple-600 text-white hover:bg-purple-700",
     "muted": "bg-gray-200 hover:bg-gray-300 text-gray-800",
     "disabled": "bg-gray-300 text-gray-500 cursor-not-allowed",
+    "link": "bg-transparent text-white hover:bg-transparent hover:underline",
 }
 
 @register.simple_tag

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
 
                     <form action="{% url 'logout' %}" method="post" class="inline">
                         {% csrf_token %}
-                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent hover:underline px-0 py-0' %}
+                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='link' classes='px-0 py-0' %}
                     </form>
 
                 {% else %}


### PR DESCRIPTION
## Summary
- add transparent link variant for buttons
- use link variant for logout button to avoid unwanted background color

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a42c4d12f0832bbb112247bd488b06