### PR TITLE
fix: set logout button to light gray

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
 
                     <form action="{% url 'logout' %}" method="post" class="inline">
                         {% csrf_token %}
-                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent hover:underline px-0 py-0' %}
+                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent text-gray-300 hover:underline px-0 py-0' %}
                     </form>
 
                 {% else %}


### PR DESCRIPTION
## Summary
- adjust logout button color to light gray

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: No module named 'selenium'; KeyError 'technisch_verfuegbar')*

------
https://chatgpt.com/codex/tasks/task_e_68a439d145b0832bb6c314c8165c1410