### PR TITLE
fix: set header background color

### DIFF
--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -28,7 +28,7 @@ export default {
           light: '#6366f1',
           dark: '#4338ca',
         },
-        header: '#0d1b2a',
+        header: '#020a1d',
         gray: {
           50: '#f8fafc',
           100: '#f1f5f9',


### PR DESCRIPTION
## Summary
- update Tailwind header color to `#020a1d`

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a43c17d218832b8df936bac1ca1a19