### PR TITLE
feat: replace hardcoded colors with theme variables

### DIFF
--- a/templates/admin_project_status_form.html
+++ b/templates/admin_project_status_form.html
@@ -28,6 +28,6 @@
         <label>{{ form.is_done_status }} Abschlussstatus</label>
         {{ form.is_done_status.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-text rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,8 +18,8 @@
     </script>
     {% block extra_head %}{% endblock %}
 </head>
-<body class="flex flex-col min-h-screen bg-white text-gray-900">
-    <header class="bg-header text-white border-b items-center">
+<body class="flex flex-col min-h-screen bg-background text-text">
+    <header class="bg-header text-background border-b items-center">
         <div class="container mx-auto flex items-center justify-between p-4">
             <div class="text-xl font-semibold">
                 <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
@@ -38,7 +38,7 @@
 
                     <form action="{% url 'logout' %}" method="post" class="inline">
                         {% csrf_token %}
-                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent text-gray-300 hover:underline px-0 py-0' %}
+                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent text-text hover:underline px-0 py-0' %}
                     </form>
 
                 {% else %}
@@ -61,7 +61,7 @@
         {% block content %}{% endblock %}
     </main>
 
-    <footer class="bg-gray-100 text-center py-4">
+    <footer class="bg-background text-center py-4">
         <p>&copy; 2025 Frank Vendolsky</p>
     </footer>
     <script src="{% static 'js/utils.js' %}"></script>

--- a/templates/partials/_admin_project_rows.html
+++ b/templates/partials/_admin_project_rows.html
@@ -7,9 +7,9 @@
             {% include 'partials/status_badge.html' with status_key=p.status.key label=p.status.name %}
         </td>
         <td class="py-1 text-center flex items-center justify-center space-x-2">
-            <a href="{% url 'projekt_edit' p.pk %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
-            <a href="{% url 'admin_project_cleanup' p.pk %}" class="px-2 py-1 bg-yellow-600 text-white rounded">Bereinigen</a>
-            <button type="submit" name="delete_single" value="{{ p.id }}" form="post-actions-form" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Projekt wirklich löschen?');">Löschen</button>
+            <a href="{% url 'projekt_edit' p.pk %}" class="px-2 py-1 bg-accent text-text rounded">Bearbeiten</a>
+            <a href="{% url 'admin_project_cleanup' p.pk %}" class="px-2 py-1 bg-accent text-text rounded">Bereinigen</a>
+            <button type="submit" name="delete_single" value="{{ p.id }}" form="post-actions-form" class="px-2 py-1 bg-accent text-text rounded" onclick="return confirm('Projekt wirklich löschen?');">Löschen</button>
         </td>
         <td class="py-1 text-center"><input type="checkbox" name="selected_projects" value="{{ p.id }}" form="post-actions-form" class="form-checkbox"></td>
     </tr>

--- a/templates/partials/anlagen_row.html
+++ b/templates/partials/anlagen_row.html
@@ -17,14 +17,14 @@
                 {{ form.parser_order.errors }}
             </div>
             {% endif %}
-            <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded mt-2">Speichern</button>
+            <button type="submit" class="bg-accent text-text px-2 py-1 rounded mt-2">Speichern</button>
         </form>
     </td>
 </tr>
 {% else %}
 <tr class="border-t">
     {% if show_nr %}<td class="px-2 py-1">{{ anlage.anlage_nr }}</td>{% endif %}
-    <td class="px-2 py-1"><a href="{{ anlage.upload.url }}" class="text-blue-700 underline" title="{{ anlage.upload.name|clean_filename }}">Anlage {{ anlage.anlage_nr }}</a></td>
+    <td class="px-2 py-1"><a href="{{ anlage.upload.url }}" class="text-accent underline" title="{{ anlage.upload.name|clean_filename }}">Anlage {{ anlage.anlage_nr }}</a></td>
     <td class="px-2 py-1">{{ anlage.created_at|date:"d.m.Y" }}</td>
     <td class="px-2 py-1">{{ anlage.version }}</td>
     <td class="px-2 py-1 text-center" id="anlage-edit-{{ anlage.pk }}">
@@ -32,7 +32,7 @@
     </td>
     <td class="px-2 py-1 text-center">
         {% if anlage.parent %}
-            <a href="{% url 'compare_versions' anlage.pk %}" class="inline-block px-1 py-0.5 rounded bg-primary text-white text-sm hover:bg-primary-dark">Mit Vorgänger vergleichen</a>
+            <a href="{% url 'compare_versions' anlage.pk %}" class="inline-block px-1 py-0.5 rounded bg-accent text-text text-sm hover:bg-accent-dark">Mit Vorgänger vergleichen</a>
         {% endif %}
     </td>
     <td class="px-2 py-1 text-center">
@@ -42,9 +42,9 @@
             <input type="hidden" name="value" value="{{ anlage.manual_reviewed|yesno:'0,1' }}">
             <button class="p-0 bg-transparent border-0 cursor-pointer text-base focus:outline-none" title="Geprüft umschalten">
                 {% if anlage.manual_reviewed %}
-                <span class="text-green-600">✓</span>
+                <span class="text-accent">✓</span>
                 {% else %}
-                <span class="text-gray-400">✗</span>
+                <span class="text-text">✗</span>
                 {% endif %}
             </button>
         </form>
@@ -56,9 +56,9 @@
             <input type="hidden" name="value" value="{{ anlage.verhandlungsfaehig|yesno:'0,1' }}">
             <button class="p-0 bg-transparent border-0 cursor-pointer text-base focus:outline-none" title="Verhandlungsfähigkeit umschalten">
                 {% if anlage.verhandlungsfaehig %}
-                <span class="text-green-600">✓</span>
+                <span class="text-accent">✓</span>
                 {% else %}
-                <span class="text-gray-400">✗</span>
+                <span class="text-text">✗</span>
                 {% endif %}
             </button>
         </form>

--- a/templates/partials/supervision_row_content.html
+++ b/templates/partials/supervision_row_content.html
@@ -1,25 +1,25 @@
 <div class="p-2 space-y-4">
-  <div class="border rounded bg-gray-50 p-2 space-y-1">
+  <div class="border rounded bg-background p-2 space-y-1">
     <h3 class="font-semibold">Parser</h3>
     <p>{{ row.doc_val|yesno:"Vorhanden,Nicht vorhanden,?" }}</p>
     {% if row.doc_snippet %}
-      <pre class="whitespace-pre-wrap bg-gray-100 p-2 rounded">{{ row.doc_snippet }}</pre>
+      <pre class="whitespace-pre-wrap bg-background p-2 rounded">{{ row.doc_snippet }}</pre>
     {% endif %}
   </div>
-  <div class="border rounded bg-blue-50 p-2 space-y-1">
+  <div class="border rounded bg-accent-light p-2 space-y-1">
     <h3 class="font-semibold">KI</h3>
     <p>{{ row.ai_val|yesno:"Vorhanden,Nicht vorhanden,?" }}</p>
     {% if row.ai_reason %}
-      <p class="whitespace-pre-wrap bg-gray-100 p-2 rounded">{{ row.ai_reason }}</p>
+      <p class="whitespace-pre-wrap bg-background p-2 rounded">{{ row.ai_reason }}</p>
     {% endif %}
   </div>
-  <div class="border rounded bg-gray-50 p-2 space-y-1">
+  <div class="border rounded bg-background p-2 space-y-1">
     <h3 class="font-semibold">Manuell</h3>
     <p>{{ row.final_val|yesno:"Vorhanden,Nicht vorhanden,?" }}</p>
   </div>
-  <div class="border rounded bg-white p-2 space-y-2">
+  <div class="border rounded bg-background p-2 space-y-2">
     <form hx-post="{% url 'hx_supervision_confirm' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="inline">
-      <button class="bg-green-600 text-white px-2 py-1 rounded" type="submit">GAP bestätigen</button>
+      <button class="bg-accent text-text px-2 py-1 rounded" type="submit">GAP bestätigen</button>
     </form>
     <div class="space-x-2">
       {% for note in standard_notes %}
@@ -27,7 +27,7 @@
               hx-post="{% url 'hx_supervision_add_standard_note' row.result_id %}"
               hx-vals='{"note_text": "{{ note.note_text }}"}'
               hx-target="closest details" hx-swap="outerHTML"
-              class="bg-gray-200 px-2 py-1 rounded">
+              class="bg-background px-2 py-1 rounded">
         {{ note.note_text }}
       </button>
       {% endfor %}
@@ -35,11 +35,11 @@
     <form hx-post="{% url 'hx_supervision_save_notes' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="space-y-2">
       <textarea name="notes" rows="2" class="border rounded w-full p-2">{{ row.notes }}</textarea>
       <div class="space-x-2">
-        <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Speichern</button>
+        <button type="submit" class="bg-accent text-text px-2 py-1 rounded">Speichern</button>
         <button type="button"
                 hx-post="{% url 'hx_supervision_revert_to_document' row.result_id %}"
                 hx-target="closest details" hx-swap="outerHTML"
-                class="bg-gray-300 px-2 py-1 rounded">
+                class="bg-background px-2 py-1 rounded">
           GAP auflösen
         </button>
       </div>

--- a/templates/work.html
+++ b/templates/work.html
@@ -14,13 +14,13 @@
         {% if tile.image %}
         <img src="{{ tile.image.url }}" class="h-32 w-full object-cover" alt="{{ tile.name }}">
         {% else %}
-        <div class="h-32 bg-gradient-to-r from-primary to-primary-dark text-white flex items-center justify-center">
-            <i class="{{ tile.icon }} text-white text-4xl"></i>
+        <div class="h-32 bg-gradient-to-r from-primary to-primary-dark text-background flex items-center justify-center">
+            <i class="{{ tile.icon }} text-background text-4xl"></i>
         </div>
         {% endif %}
-        <div class="p-4 bg-white">
+        <div class="p-4 bg-background">
             <h3 class="text-lg font-semibold mb-2">{{ tile.name }}</h3>
-            <p class="text-gray-600">{{ tile.description }}</p>
+            <p class="text-text">{{ tile.description }}</p>
         </div>
     </a>
     {% endfor %}

--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -1,29 +1,29 @@
 @layer components {
   .card {
-    @apply bg-white rounded-lg shadow p-4;
+    @apply bg-background rounded-lg shadow p-4;
   }
   .badge {
     @apply inline-block px-2 py-0.5 rounded-full text-xs font-bold;
   }
   .badge-blue {
-    @apply bg-blue-600 text-white;
+    @apply bg-accent text-text;
   }
   .badge-yellow {
-    @apply bg-yellow-400 text-black;
+    @apply bg-accent text-text;
   }
   .badge-green {
-    @apply bg-green-600 text-white;
+    @apply bg-accent text-text;
   }
   .badge-red {
-    @apply bg-red-600 text-white;
+    @apply bg-accent text-text;
   }
   .badge-gray {
-    @apply bg-gray-500 text-white;
+    @apply bg-background text-text;
   }
   .alert {
     @apply p-2 rounded;
   }
   .alert-success {
-    @apply p-2 rounded bg-green-100 text-green-800;
+    @apply p-2 rounded bg-background text-text;
   }
 }

--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -4,6 +4,13 @@
   --color-primary: #2563eb;
   --color-primary-light: #3b82f6;
   --color-primary-dark: #1e40af;
+  --color-background: #ffffff;
+  --color-background-dark: #1e293b;
+  --color-text: #0f172a;
+  --color-text-light: #f8fafc;
+  --color-accent: #2563eb;
+  --color-accent-light: #3b82f6;
+  --color-accent-dark: #1e40af;
 }
 
 @import "./components.css";

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -29,6 +29,19 @@ export default {
           dark: '#4338ca',
         },
         header: '#0d1b2a',
+        background: {
+          DEFAULT: '#ffffff',
+          dark: '#1e293b',
+        },
+        text: {
+          DEFAULT: '#0f172a',
+          light: '#f8fafc',
+        },
+        accent: {
+          DEFAULT: '#2563eb',
+          light: '#3b82f6',
+          dark: '#1e40af',
+        },
         gray: {
           50: '#f8fafc',
           100: '#f1f5f9',


### PR DESCRIPTION
## Summary
- add semantic background, text and accent colors to Tailwind theme
- expose matching CSS variables and use them in components and templates

## Testing
- `npm install`
- `npm run build`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4502f4f14832bb25b6ff48548bb0a