### PR TITLE
feat: use theme color tokens

### DIFF
--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -9,13 +9,13 @@
     @apply bg-accent text-text;
   }
   .badge-yellow {
-    @apply bg-accent text-text;
+    @apply bg-warning text-text;
   }
   .badge-green {
-    @apply bg-accent text-text;
+    @apply bg-success text-text;
   }
   .badge-red {
-    @apply bg-accent text-text;
+    @apply bg-error text-text;
   }
   .badge-gray {
     @apply bg-background text-text;
@@ -24,6 +24,9 @@
     @apply p-2 rounded;
   }
   .alert-success {
-    @apply p-2 rounded bg-background text-text;
+    @apply p-2 rounded bg-success text-text;
+  }
+  .alert-error {
+    @apply p-2 rounded bg-error text-text;
   }
 }

--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -11,6 +11,14 @@
   --color-accent: #2563eb;
   --color-accent-light: #3b82f6;
   --color-accent-dark: #1e40af;
+  --color-success: #059669;
+  --color-success-dark: #047857;
+  --color-error: #e11d48;
+  --color-error-light: #ffe4e6;
+  --color-error-lighter: #fecdd3;
+  --color-error-dark: #be123c;
+  --color-warning: #facc15;
+  --color-warning-dark: #eab308;
 }
 
 @import "./components.css";

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -1,14 +1,14 @@
 import forms from '@tailwindcss/forms';
 
 export const btnVariants = {
-  primary: 'bg-primary text-white hover:bg-primary-dark',
-  secondary: 'bg-gray-300 text-black hover:bg-gray-400',
-  success: 'bg-emerald-600 text-white hover:bg-emerald-700',
-  danger: 'bg-rose-600 text-white hover:bg-rose-700',
-  'danger-light': 'bg-rose-100 hover:bg-rose-200 text-rose-700',
-  purple: 'bg-purple-600 text-white hover:bg-purple-700',
-  muted: 'bg-gray-200 hover:bg-gray-300 text-gray-800',
-  disabled: 'bg-gray-300 text-gray-500 cursor-not-allowed',
+  primary: 'bg-primary text-text hover:bg-primary-dark',
+  secondary: 'bg-background text-text hover:bg-background-dark',
+  success: 'bg-success text-text hover:bg-success-dark',
+  danger: 'bg-error text-text hover:bg-error-dark',
+  'danger-light': 'bg-error-light hover:bg-error-lighter text-error-dark',
+  purple: 'bg-accent text-text hover:bg-accent-dark',
+  muted: 'bg-background hover:bg-background-dark text-text',
+  disabled: 'bg-background text-text cursor-not-allowed',
 };
 
 export default {
@@ -41,6 +41,20 @@ export default {
           DEFAULT: '#2563eb',
           light: '#3b82f6',
           dark: '#1e40af',
+        },
+        success: {
+          DEFAULT: '#059669',
+          dark: '#047857',
+        },
+        error: {
+          DEFAULT: '#e11d48',
+          light: '#ffe4e6',
+          lighter: '#fecdd3',
+          dark: '#be123c',
+        },
+        warning: {
+          DEFAULT: '#facc15',
+          dark: '#eab308',
         },
         gray: {
           50: '#f8fafc',


### PR DESCRIPTION
## Summary
- replace hardcoded button colors with theme variables
- expose success, error and warning colors
- switch badges and alerts to new color utilities

## Testing
- `python manage.py makemigrations --check`
- `cd theme/static_src && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4537724f0832bbfbe0cc215ebd1e9