### PR TITLE
feat: unify template colors with theme

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -13,7 +13,7 @@
         <h2 class="text-xl font-bold mb-4">Admin-Navigation</h2>
         <nav class="space-y-4 text-sm">
             <div>
-                <a href="/projects-admin/" class="flex items-center px-3 py-2 rounded bg-blue-600 text-white font-semibold">
+                <a href="/projects-admin/" class="flex items-center px-3 py-2 rounded bg-accent text-background font-semibold">
                     <i class="fas fa-project-diagram fa-fw mr-2"></i>
                     Projekt-Admin
                 </a>
@@ -25,15 +25,15 @@
                     <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if open_ki in 'admin_llm_roles admin_prompts admin_models' %}rotate-180{% endif %}"></i>
                 </h3>
                 <div class="accordion-content pl-2 space-y-1 {% if open_ki in 'admin_llm_roles admin_prompts admin_models' %}block{% else %}hidden{% endif %}">
-                    <a href="{% url 'admin_llm_roles' %}" class="flex items-center px-3 py-2 rounded text-blue-700 hover:bg-blue-100 {% if request.resolver_match.url_name == 'admin_llm_roles' %}bg-blue-600 text-white font-semibold{% endif %}">
+                    <a href="{% url 'admin_llm_roles' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_llm_roles' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-user-gear fa-fw mr-2"></i>
                         LLM-Rollen
                     </a>
-                    <a href="{% url 'admin_prompts' %}" class="flex items-center px-3 py-2 rounded text-blue-700 hover:bg-blue-100 {% if request.resolver_match.url_name == 'admin_prompts' %}bg-blue-600 text-white font-semibold{% endif %}">
+                    <a href="{% url 'admin_prompts' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_prompts' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-pencil-alt fa-fw mr-2"></i>
                         Prompts
                     </a>
-                    <a href="{% url 'admin_models' %}" class="flex items-center px-3 py-2 rounded text-blue-700 hover:bg-blue-100 {% if request.resolver_match.url_name == 'admin_models' %}bg-blue-600 text-white font-semibold{% endif %}">
+                    <a href="{% url 'admin_models' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_models' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-robot fa-fw mr-2"></i>
                         LLM-Modelle
                     </a>
@@ -47,19 +47,19 @@
                     <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if open_sys in 'admin_user_list auth_group_changelist' %}rotate-180{% endif %}"></i>
                 </h3>
                 <div class="accordion-content pl-2 space-y-1 {% if open_sys in 'admin_user_list auth_group_changelist' %}block{% else %}hidden{% endif %}">
-                    <a href="{% url 'admin_user_list' %}" class="flex items-center px-3 py-2 rounded text-blue-700 hover:bg-blue-100 {% if request.resolver_match.url_name == 'admin_user_list' %}bg-blue-600 text-white font-semibold{% endif %}">
+                    <a href="{% url 'admin_user_list' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_user_list' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-users fa-fw mr-2"></i>
                         Benutzer verwalten
                     </a>
-                    <a href="{% url 'admin:auth_group_changelist' %}" class="flex items-center px-3 py-2 rounded text-blue-700 hover:bg-blue-100 {% if request.resolver_match.url_name == 'auth_group_changelist' %}bg-blue-600 text-white font-semibold{% endif %}">
+                    <a href="{% url 'admin:auth_group_changelist' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'auth_group_changelist' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-user-shield fa-fw mr-2"></i>
                         Gruppen
                     </a>
-                    <a href="{% url 'admin_role_editor' %}" class="flex items-center px-3 py-2 rounded text-blue-700 hover:bg-blue-100 {% if request.resolver_match.url_name == 'admin_role_editor' %}bg-blue-600 text-white font-semibold{% endif %}">
+                    <a href="{% url 'admin_role_editor' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_role_editor' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-check-square fa-fw mr-2"></i>
                         Rollen &amp; Rechte
                     </a>
-                    <a href="{% url 'config_transfer' %}" class="flex items-center px-3 py-2 rounded text-blue-700 hover:bg-blue-100 {% if request.resolver_match.url_name == 'config_transfer' %}bg-blue-600 text-white font-semibold{% endif %}">
+                    <a href="{% url 'config_transfer' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'config_transfer' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-exchange-alt fa-fw mr-2"></i>
                         Konfigurationen übertragen
                     </a>

--- a/templates/admin/config_transfer.html
+++ b/templates/admin/config_transfer.html
@@ -4,11 +4,11 @@
 <h1 class="text-xl font-bold mb-4">Konfigurationen exportieren / importieren</h1>
 <form method="post" class="mb-6">
     {% csrf_token %}
-    <button type="submit" name="export" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</button>
+    <button type="submit" name="export" class="px-4 py-2 bg-accent text-background rounded">Exportieren</button>
 </form>
 <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
     <input type="file" name="config_file" accept="application/json" required>
-    <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</button>
+    <button type="submit" class="px-4 py-2 bg-success text-background rounded">Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -7,7 +7,7 @@
         {% csrf_token %}
         <h1 class="text-2xl font-semibold mb-4 text-center">{% trans 'Admin-Anmeldung' %}</h1>
         {% if form.errors %}
-            <p class="text-red-600 mb-4">{% trans 'Bitte gültige Zugangsdaten eingeben.' %}</p>
+            <p class="text-error mb-4">{% trans 'Bitte gültige Zugangsdaten eingeben.' %}</p>
         {% endif %}
         <div class="mb-4">
             <label for="id_username" class="block text-sm font-medium text-gray-700 mb-1">{% trans 'Benutzername' %}</label>
@@ -18,7 +18,7 @@
             <input type="password" name="password" id="id_password" class="w-full border-gray-300 rounded px-3 py-2" required>
         </div>
         <input type="hidden" name="next" value="{{ next }}" />
-        <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded">{% trans 'Anmelden' %}</button>
+        <button type="submit" class="w-full bg-accent hover:bg-accent-dark text-background font-semibold py-2 px-4 rounded">{% trans 'Anmelden' %}</button>
     </form>
 </div>
 {% endblock %}

--- a/templates/admin_anlage1.html
+++ b/templates/admin_anlage1.html
@@ -3,8 +3,8 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_anlage1_import' %}" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">Importieren</a>
-    <a href="{% url 'admin_anlage1_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Exportieren</a>
+    <a href="{% url 'admin_anlage1_import' %}" class="px-4 py-2 bg-success text-background rounded hover:bg-success-dark">Importieren</a>
+    <a href="{% url 'admin_anlage1_export' %}" class="px-4 py-2 bg-accent text-background rounded hover:bg-accent-dark">Exportieren</a>
 </div>
 <form method="post" class="space-y-4">
     {% csrf_token %}
@@ -64,6 +64,6 @@
         </tbody>
     </table>
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/admin_anlage1_import.html
+++ b/templates/admin_anlage1_import.html
@@ -13,6 +13,6 @@
     <div>
         <label class="mr-2">{{ form.clear_first }} Datenbank vorher leeren</label>
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -52,7 +52,7 @@
             </tbody>
         </table>
         </div>
-        <button type="submit" name="action" value="save_table" class="mt-6 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+        <button type="submit" name="action" value="save_table" class="mt-6 px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
     </div>
     <div id="tab-general" class="tab-content">
         <div>
@@ -79,7 +79,7 @@
             <div id="parser-order-inputs"></div>
             {{ config_form.parser_order.errors }}
         </div>
-        <button type="submit" name="action" value="save_general" class="mt-6 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+        <button type="submit" name="action" value="save_general" class="mt-6 px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
     </div>
     <div id="tab-rules" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Parser-Antwortregeln</h2>
@@ -89,7 +89,7 @@
         <div class="mt-2 space-x-2">
             <!-- HTMX-Funktion vorübergehend deaktiviert -->
             <button type="button" class="px-3 py-1 bg-gray-300 rounded" disabled>Neue Regel hinzufügen</button>
-            <button type="submit" name="action" value="save_rules" class="px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+            <button type="submit" name="action" value="save_rules" class="px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
         </div>
     </div>
     <div id="tab-rules2" class="tab-content">
@@ -97,7 +97,7 @@
         <div class="overflow-x-auto">
             {% include 'partials/_response_rules_table_simple.html' with formset=rule_formset_fb raw_actions=raw_actions action_formsets=action_formsets %}
         </div>
-        <button type="submit" name="action" value="save_rules_fb" class="mt-2 px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+        <button type="submit" name="action" value="save_rules_fb" class="mt-2 px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
     </div>
     <div id="tab-a4" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Anlage 4 Parser</h2>
@@ -122,7 +122,7 @@
                 {{ a4_parser_form.fachbereiche_phrase }}
                 {{ a4_parser_form.fachbereiche_phrase.errors }}
             </div>
-            <button type="submit" name="action" value="save_a4" class="px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+            <button type="submit" name="action" value="save_a4" class="px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
         </div>
     </div>
 </form>
@@ -135,9 +135,9 @@ function showTab(tab){
     document.querySelectorAll('[data-tab]').forEach(btn=>{
         if(btn.dataset.tab===tab){
             btn.classList.remove('bg-gray-200','text-gray-600','border-b-0');
-            btn.classList.add('bg-white','text-blue-600','font-semibold','border-b-transparent');
+            btn.classList.add('bg-background','text-accent','font-semibold','border-b-transparent');
         }else{
-            btn.classList.remove('bg-white','text-blue-600','font-semibold','border-b-transparent');
+            btn.classList.remove('bg-background','text-accent','font-semibold','border-b-transparent');
             btn.classList.add('bg-gray-200','text-gray-600','border-b-0');
         }
     });

--- a/templates/admin_anlage2_config_import.html
+++ b/templates/admin_anlage2_config_import.html
@@ -10,6 +10,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_anlage2_parser_rule_import.html
+++ b/templates/admin_anlage2_parser_rule_import.html
@@ -10,6 +10,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_anlage4_config.html
+++ b/templates/admin_anlage4_config.html
@@ -106,7 +106,7 @@
             <button type="button" id="add-column-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Spalte hinzufügen</button>
         </div>
     </section>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded shadow-md hover:bg-blue-700">Speichern</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
 </form>
 {% endblock %}
 {% block extra_js %}

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -22,7 +22,7 @@
                         <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if current in 'admin_anlage1' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'admin_anlage1' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'admin_anlage1' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'admin_anlage1' %}bg-primary text-white{% else %}text-primary{% endif %}">Fragen</a>
+                        <a href="{% url 'admin_anlage1' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'admin_anlage1' %}bg-primary text-background{% else %}text-primary{% endif %}">Fragen</a>
                     </div>
                 </div>
                 <div>
@@ -31,8 +31,8 @@
                         <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if current in 'anlage2_function_list anlage2_config' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'anlage2_function_list anlage2_config' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'anlage2_function_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage2_function_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Funktionen</a>
-                        <a href="{% url 'anlage2_config' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage2_config' %}bg-primary text-white{% else %}text-primary{% endif %}">Globale Phrasen</a>
+                        <a href="{% url 'anlage2_function_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage2_function_list' %}bg-primary text-background{% else %}text-primary{% endif %}">Funktionen</a>
+                        <a href="{% url 'anlage2_config' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage2_config' %}bg-primary text-background{% else %}text-primary{% endif %}">Globale Phrasen</a>
                     </div>
                 </div>
                 <div>
@@ -41,7 +41,7 @@
                         <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if current in 'anlage3_rule_list' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'anlage3_rule_list' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'anlage3_rule_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage3_rule_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Parser Regeln</a>
+                        <a href="{% url 'anlage3_rule_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage3_rule_list' %}bg-primary text-background{% else %}text-primary{% endif %}">Parser Regeln</a>
                     </div>
                 </div>
                 <div>
@@ -50,7 +50,7 @@
                         <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if current in 'anlage4_config' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'anlage4_config' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'anlage4_config' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage4_config' %}bg-primary text-white{% else %}text-primary{% endif %}">Konfiguration</a>
+                        <a href="{% url 'anlage4_config' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'anlage4_config' %}bg-primary text-background{% else %}text-primary{% endif %}">Konfiguration</a>
                     </div>
                 </div>
                 <div>
@@ -59,9 +59,9 @@
                         <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if current in 'parser_rule_list zweckkategoriea_list supervisionnote_list' %}rotate-180{% endif %}"></i>
                     </h4>
                     <div class="accordion-content pl-2 space-y-1 {% if current in 'parser_rule_list zweckkategoriea_list supervisionnote_list' %}block{% else %}hidden{% endif %}">
-                        <a href="{% url 'parser_rule_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'parser_rule_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Exakter Parser Regeln</a>
-                        <a href="{% url 'zweckkategoriea_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'zweckkategoriea_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Zwecke verwalten</a>
-                        <a href="{% url 'supervisionnote_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'supervisionnote_list' %}bg-primary text-white{% else %}text-primary{% endif %}">Supervision-Notizen</a>
+                        <a href="{% url 'parser_rule_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'parser_rule_list' %}bg-primary text-background{% else %}text-primary{% endif %}">Exakter Parser Regeln</a>
+                        <a href="{% url 'zweckkategoriea_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'zweckkategoriea_list' %}bg-primary text-background{% else %}text-primary{% endif %}">Zwecke verwalten</a>
+                        <a href="{% url 'supervisionnote_list' %}" class="block px-2 py-1 rounded hover:bg-primary-light {% if current == 'supervisionnote_list' %}bg-primary text-background{% else %}text-primary{% endif %}">Supervision-Notizen</a>
                     </div>
                 </div>
                 {% endwith %}

--- a/templates/admin_llm_role_form.html
+++ b/templates/admin_llm_role_form.html
@@ -19,7 +19,7 @@
         <label>{{ form.is_default }} Standard</label>
         {{ form.is_default.errors }}
     </div>
-<button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+<button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
 </form>
 {% endblock %}
 

--- a/templates/admin_llm_role_import.html
+++ b/templates/admin_llm_role_import.html
@@ -10,6 +10,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_llm_roles.html
+++ b/templates/admin_llm_roles.html
@@ -3,9 +3,9 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">LLM Rollen</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_llm_role_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
-    <a href="{% url 'admin_llm_role_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
-    <a href="{% url 'admin_llm_role_new' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Neue Rolle hinzufügen</a>
+    <a href="{% url 'admin_llm_role_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
+    <a href="{% url 'admin_llm_role_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
+    <a href="{% url 'admin_llm_role_new' %}" class="px-4 py-2 bg-accent text-background rounded">Neue Rolle hinzufügen</a>
 </div>
 <div class="overflow-x-auto">
 <table class="min-w-full">
@@ -23,12 +23,12 @@
             <td class="py-1">{{ r.name }}</td>
             <td class="py-1">{{ r.is_default|yesno:"Ja,Nein" }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'admin_llm_role_edit' r.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
+                <a href="{% url 'admin_llm_role_edit' r.id %}" class="px-2 py-1 bg-accent text-background rounded">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form action="{% url 'admin_llm_role_delete' r.id %}" method="post" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Rolle wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Rolle wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/admin_models.html
+++ b/templates/admin_models.html
@@ -60,6 +60,6 @@
         </tbody>
     </table>
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/admin_project_cleanup.html
+++ b/templates/admin_project_cleanup.html
@@ -25,7 +25,7 @@
                     {% csrf_token %}
                     <input type="hidden" name="action" value="delete_file">
                     <input type="hidden" name="file_id" value="{{ f.id }}">
-                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Anlage wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Anlage wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>
@@ -41,7 +41,7 @@
 <form method="post" class="mb-4">
     {% csrf_token %}
     <input type="hidden" name="action" value="delete_gutachten">
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded" onclick="return confirm('Gutachten wirklich löschen?');">Gutachten löschen</button>
+    <button type="submit" class="px-4 py-2 bg-error text-background rounded" onclick="return confirm('Gutachten wirklich löschen?');">Gutachten löschen</button>
 </form>
 {% else %}
 <p class="mb-4">Kein Gutachten vorhanden.</p>
@@ -52,7 +52,7 @@
 <form method="post" class="mb-4">
     {% csrf_token %}
     <input type="hidden" name="action" value="delete_classification">
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded" onclick="return confirm('Bewertung wirklich löschen?');">Bewertung löschen</button>
+    <button type="submit" class="px-4 py-2 bg-error text-background rounded" onclick="return confirm('Bewertung wirklich löschen?');">Bewertung löschen</button>
 </form>
 {% else %}
 <p class="mb-4">Keine Bewertung vorhanden.</p>
@@ -63,7 +63,7 @@
 <form method="post" class="mb-4">
     {% csrf_token %}
     <input type="hidden" name="action" value="delete_gap_report">
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded" onclick="return confirm('GAP-Bericht wirklich löschen?');">GAP-Bericht löschen</button>
+    <button type="submit" class="px-4 py-2 bg-error text-background rounded" onclick="return confirm('GAP-Bericht wirklich löschen?');">GAP-Bericht löschen</button>
 </form>
 {% else %}
 <p class="mb-4">Kein GAP-Bericht vorhanden.</p>

--- a/templates/admin_project_status_import.html
+++ b/templates/admin_project_status_import.html
@@ -10,6 +10,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_project_statuses.html
+++ b/templates/admin_project_statuses.html
@@ -3,10 +3,10 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Projektstatus</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_project_status_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
-    <a href="{% url 'admin_project_status_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
+    <a href="{% url 'admin_project_status_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
+    <a href="{% url 'admin_project_status_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
 </div>
-<a href="{% url 'admin_project_status_new' %}" class="inline-block mb-4 px-4 py-2 bg-blue-600 text-white rounded">Neuen Status hinzufügen</a>
+<a href="{% url 'admin_project_status_new' %}" class="inline-block mb-4 px-4 py-2 bg-accent text-background rounded">Neuen Status hinzufügen</a>
 <div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
@@ -29,12 +29,12 @@
             <td class="py-1 text-center">{{ s.is_default|yesno:"Ja,Nein" }}</td>
             <td class="py-1 text-center">{{ s.is_done_status|yesno:"Ja,Nein" }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'admin_project_status_edit' s.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
+                <a href="{% url 'admin_project_status_edit' s.id %}" class="px-2 py-1 bg-accent text-background rounded">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form action="{% url 'admin_project_status_delete' s.id %}" method="post" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Status wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Status wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/admin_prompt_import.html
+++ b/templates/admin_prompt_import.html
@@ -13,6 +13,6 @@
     <div>
         <label class="mr-2">{{ form.clear_first }} Vorhandene Prompts löschen</label>
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -4,12 +4,12 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Admin Prompts</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_prompt_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
-    <a href="{% url 'admin_prompt_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
+    <a href="{% url 'admin_prompt_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
+    <a href="{% url 'admin_prompt_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
 </div>
 <div class="mb-4 space-x-2">
     {% for key, label, items in grouped %}
-        <button data-tab="{{ key }}" class="px-3 py-1 bg-blue-600 text-white rounded">{{ label }}</button>
+        <button data-tab="{{ key }}" class="px-3 py-1 bg-accent text-background rounded">{{ label }}</button>
     {% endfor %}
 </div>
 
@@ -56,7 +56,7 @@
                 </td>
                 <td class="py-1">
                         <textarea name="text" rows="4" class="border rounded p-2 w-full text-gray-900">{{ p.text }}</textarea>
-                        <button name="action" value="save" class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
+                        <button name="action" value="save" class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>
                 <td class="py-1 text-center">
@@ -64,7 +64,7 @@
                         {% csrf_token %}
                         <input type="hidden" name="pk" value="{{ p.id }}">
                         <input type="hidden" name="action" value="delete">
-                        <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Prompt wirklich löschen?');">Löschen</button>
+                        <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Prompt wirklich löschen?');">Löschen</button>
                     </form>
                 </td>
             </tr>
@@ -79,7 +79,7 @@
                         {% csrf_token %}
                         <input type="hidden" name="action" value="save_a4_config">
                         <textarea name="prompt_template" rows="4" class="border rounded p-2 w-full text-gray-900">{{ a4_config.prompt_template }}</textarea>
-                        <button class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
+                        <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>
             </tr>
@@ -91,7 +91,7 @@
                         <input type="hidden" name="action" value="save_a4_parser_prompts">
                         <input type="hidden" name="field" value="prompt_plausibility">
                         <textarea name="prompt_text" rows="4" class="border rounded p-2 w-full text-gray-900">{{ a4_parser.prompt_plausibility }}</textarea>
-                        <button class="px-2 py-1 bg-blue-600 text-white rounded">Speichern</button>
+                        <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>
             </tr>

--- a/templates/admin_roles.html
+++ b/templates/admin_roles.html
@@ -10,7 +10,7 @@
             <option value="{{ g.id }}" {% if selected_group and g.id == selected_group.id %}selected{% endif %}>{{ g.name }}</option>
         {% endfor %}
     </select>
-    <a href="{% url 'admin:auth_group_add' %}" class="ml-2 px-2 py-1 bg-blue-600 text-white rounded">Neue Rolle</a>
+    <a href="{% url 'admin:auth_group_add' %}" class="ml-2 px-2 py-1 bg-accent text-background rounded">Neue Rolle</a>
 </div>
 <div id="role-form">
     {% if selected_group %}

--- a/templates/admin_talkdiary.html
+++ b/templates/admin_talkdiary.html
@@ -13,25 +13,25 @@
     {% csrf_token %}
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
     {% for rec in recordings %}
-        <div class="border rounded p-4 shadow {% if rec.incomplete %}bg-red-50{% endif %}">
+        <div class="border rounded p-4 shadow {% if rec.incomplete %}bg-error-light{% endif %}">
             <div class="flex items-center justify-between">
                 <span class="text-sm text-gray-600">{{ rec.created_at|date:'d.m.Y H:i' }}</span>
                 <input type="checkbox" name="delete" value="{{ rec.id }}" class="form-checkbox"/>
             </div>
             <p class="font-semibold mt-1">{{ rec.audio_file.name|basename }}</p>
             {% if rec.audio_missing %}
-            <p class="text-red-600 text-sm">Audio fehlt</p>
+            <p class="text-error text-sm">Audio fehlt</p>
             {% else %}
             <audio controls src="{{ rec.audio_file.url }}" class="w-full mt-1"></audio>
             {% endif %}
             {% if rec.transcript_file %}
                 {% if rec.transcript_missing %}
-                <p class="text-red-600 text-sm mt-1">Transcript fehlt</p>
+                <p class="text-error text-sm mt-1">Transcript fehlt</p>
                 {% else %}
                 <p class="text-sm whitespace-pre-line mt-1">{{ rec.excerpt }}</p>
                 {% endif %}
             {% else %}
-                <p class="text-red-600 text-sm mt-1">Transcript fehlt</p>
+                <p class="text-error text-sm mt-1">Transcript fehlt</p>
             {% endif %}
             {% if rec.notes %}
             <p class="text-xs text-gray-500 mt-2">{{ rec.notes }}</p>
@@ -43,7 +43,7 @@
     </div>
     {% if recordings %}
     <div class="mt-4">
-        <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded" onclick="return confirm('Einträge wirklich löschen?');">Löschen</button>
+        <button type="submit" class="px-4 py-2 bg-error text-background rounded" onclick="return confirm('Einträge wirklich löschen?');">Löschen</button>
     </div>
     {% endif %}
 </form>

--- a/templates/admin_user_import.html
+++ b/templates/admin_user_import.html
@@ -10,6 +10,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_user_list.html
+++ b/templates/admin_user_list.html
@@ -3,8 +3,8 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Benutzer</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_import_users_permissions' %}" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">Importieren</a>
-    <a href="{% url 'admin_export_users_permissions' %}" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Exportieren</a>
+    <a href="{% url 'admin_import_users_permissions' %}" class="px-4 py-2 bg-success text-background rounded hover:bg-success-dark">Importieren</a>
+    <a href="{% url 'admin_export_users_permissions' %}" class="px-4 py-2 bg-accent text-background rounded hover:bg-accent-dark">Exportieren</a>
 </div>
 <div class="overflow-x-auto">
 <table class="min-w-full">
@@ -25,7 +25,7 @@
             <td class="py-1">{{ u.groups.all|join:", " }}</td>
             <td class="py-1">{{ u.tiles.all|join:", " }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'admin_edit_user_permissions' u.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Berechtigungen bearbeiten</a>
+                <a href="{% url 'admin_edit_user_permissions' u.id %}" class="px-2 py-1 bg-accent text-background rounded">Berechtigungen bearbeiten</a>
             </td>
         </tr>
     {% empty %}

--- a/templates/admin_user_permissions_form.html
+++ b/templates/admin_user_permissions_form.html
@@ -15,6 +15,6 @@
         {{ form.tiles }}
         {{ form.tiles.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 {% if funktion %}
 <h2 class="text-xl font-semibold mt-8 mb-2">Unterfragen</h2>
-<a href="{% url 'anlage2_subquestion_new' funktion.id %}" class="inline-block mb-2 px-3 py-1 bg-green-600 text-white rounded">Neue Unterfrage</a>
+<a href="{% url 'anlage2_subquestion_new' funktion.id %}" class="inline-block mb-2 px-3 py-1 bg-success text-background rounded">Neue Unterfrage</a>
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">
@@ -71,12 +71,12 @@ document.addEventListener('DOMContentLoaded', () => {
         <tr class="border-b text-sm">
             <td class="py-1">{{ q.frage_text|truncatechars:80 }}</td>
             <td class="py-1 text-center">
-                  <a href="{% url 'anlage2_subquestion_edit' q.id %}" class="px-2 py-1 bg-primary text-white rounded">Bearbeiten</a>
+                  <a href="{% url 'anlage2_subquestion_edit' q.id %}" class="px-2 py-1 bg-primary text-background rounded">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form action="{% url 'anlage2_subquestion_delete' q.id %}" method="post" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Unterfrage wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Unterfrage wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/anlage2/function_import.html
+++ b/templates/anlage2/function_import.html
@@ -13,6 +13,6 @@
     <div>
         <label class="mr-2">{{ form.clear_first }} Datenbank vorher leeren</label>
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Importieren</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Importieren</button>
 </form>
 {% endblock %}

--- a/templates/anlage2/function_list.html
+++ b/templates/anlage2/function_list.html
@@ -3,9 +3,9 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'anlage2_function_new' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Neue Funktion</a>
-    <a href="{% url 'anlage2_function_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
-    <a href="{% url 'anlage2_function_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
+    <a href="{% url 'anlage2_function_new' %}" class="px-4 py-2 bg-accent text-background rounded">Neue Funktion</a>
+    <a href="{% url 'anlage2_function_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
+    <a href="{% url 'anlage2_function_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
 </div>
 <table class="min-w-full">
     <thead>
@@ -20,12 +20,12 @@
         <tr class="border-b text-sm">
             <td class="py-1">{{ f.name }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'anlage2_function_edit' f.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
+                <a href="{% url 'anlage2_function_edit' f.id %}" class="px-2 py-1 bg-accent text-background rounded">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form action="{% url 'anlage2_function_delete' f.id %}" method="post" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Funktion wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Funktion wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -15,29 +15,29 @@
     <tbody>
     {% for a in anlagen %}
         <tr class="border-t">
-            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-blue-700 underline">{{ a.upload.name|basename }}</a></td>
+            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-accent-dark underline">{{ a.upload.name|basename }}</a></td>
             <td class="px-2 py-1 text-center">
                 <form method="post" action="{% url 'projekt_file_check_view' a.pk %}?llm=1">
                     {% csrf_token %}
-                    <button class="bg-purple-600 text-white px-2 py-1 rounded">LLM-Prüfung</button>
+                    <button class="bg-primary text-background px-2 py-1 rounded">LLM-Prüfung</button>
                 </form>
             </td>
             <td class="px-2 py-1 text-center">
                 <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
                     {% csrf_token %}
                     <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-green-600 text-white{% else %}bg-gray-300{% endif %}">
+                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-success text-background{% else %}bg-gray-300{% endif %}">
                         {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
                     </button>
                 </form>
             </td>
             <td class="px-2 py-1 text-center space-x-1">
-                <a href="{% url 'projekt_file_edit_json' a.pk %}" class="bg-purple-600 text-white px-2 py-1 rounded">Analyse bearbeiten</a>
+                <a href="{% url 'projekt_file_edit_json' a.pk %}" class="bg-primary text-background px-2 py-1 rounded">Analyse bearbeiten</a>
                 <form method="post" action="{% url 'projekt_file_delete_result' a.pk %}" class="inline">
                     {% csrf_token %}
-                    <button class="bg-red-600 text-white px-2 py-1 rounded" onclick="return confirm('Ergebnis wirklich löschen?')">Ergebnis löschen</button>
+                    <button class="bg-error text-background px-2 py-1 rounded" onclick="return confirm('Ergebnis wirklich löschen?')">Ergebnis löschen</button>
                 </form>
-                <a href="{{ a.upload.url }}" class="bg-blue-600 text-white px-2 py-1 rounded">Download</a>
+                <a href="{{ a.upload.url }}" class="bg-accent text-background px-2 py-1 rounded">Download</a>
             </td>
         </tr>
         {% if a.analysis_json %}
@@ -48,7 +48,7 @@
                 </div>
                 <div class="mt-1 space-x-2">
                     <a href="{% url 'projekt_file_edit_json' a.pk %}" class="btn-action">Bearbeiten</a>
-                    <a href="{{ a.upload.url }}" class="text-blue-700 underline">Download</a>
+                    <a href="{{ a.upload.url }}" class="text-accent-dark underline">Download</a>
                 </div>
             </td>
         </tr>
@@ -58,5 +58,5 @@
     {% endfor %}
     </tbody>
 </table>
-<a href="{% url 'projekt_detail' projekt.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück</a>
+<a href="{% url 'projekt_detail' projekt.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück</a>
 {% endblock %}

--- a/templates/edit_ki_justification.html
+++ b/templates/edit_ki_justification.html
@@ -10,6 +10,6 @@
     {% else %}
     <input type="hidden" name="subquestion" value="{{ object.id }}">
     {% endif %}
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/gap_report.html
+++ b/templates/gap_report.html
@@ -12,7 +12,7 @@
 
 <form method="post" action="{% url 'delete_gap_report' projekt.pk %}" class="inline-block">
     {% csrf_token %}
-    <button type="submit" class="bg-red-600 text-white px-4 py-2 rounded">Bericht verwerfen &amp; neu generieren</button>
+    <button type="submit" class="bg-error text-background px-4 py-2 rounded">Bericht verwerfen &amp; neu generieren</button>
 </form>
 {% endblock %}
 {% block extra_js %}

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -5,9 +5,9 @@
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>
 <div class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
 <p class="mt-4">
-    <a href="{% url 'gutachten_edit' gutachten.id %}" class="text-blue-700 underline">Bearbeiten</a>
+    <a href="{% url 'gutachten_edit' gutachten.id %}" class="text-accent-dark underline">Bearbeiten</a>
     |
-    <a href="{% url 'gutachten_download' gutachten.id %}" class="text-blue-700 underline">Download</a>
+    <a href="{% url 'gutachten_download' gutachten.id %}" class="text-accent-dark underline">Download</a>
 </p>
 {% if projekt.gutachten_function_note %}
 <div class="mt-4">
@@ -24,7 +24,7 @@
             {{ data.label }}
         </label>
     {% endfor %}
-    <button type="button" id="llm-check-btn" class="bg-purple-600 text-white px-4 py-2 rounded ml-2">LLM-Funktionscheck</button>
+    <button type="button" id="llm-check-btn" class="bg-primary text-background px-4 py-2 rounded ml-2">LLM-Funktionscheck</button>
 </form>
 <script>
 document.getElementById('llm-check-btn').addEventListener('click',function(){

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,8 +8,8 @@
         {% if work_area and work_area.image %}
         <img src="{{ work_area.image.url }}" class="h-48 w-full object-cover" alt="{{ work_area.name }}">
         {% else %}
-        <div class="h-48 bg-gradient-to-r from-primary to-primary-dark text-white flex items-center justify-center">
-            <i class="fas fa-briefcase text-white text-5xl"></i>
+        <div class="h-48 bg-gradient-to-r from-primary to-primary-dark text-background flex items-center justify-center">
+            <i class="fas fa-briefcase text-background text-5xl"></i>
         </div>
         {% endif %}
         <div class="p-4">
@@ -21,8 +21,8 @@
         {% if personal_area and personal_area.image %}
         <img src="{{ personal_area.image.url }}" class="h-48 w-full object-cover" alt="{{ personal_area.name }}">
         {% else %}
-        <div class="h-48 bg-gradient-to-r from-primary to-primary-dark text-white flex items-center justify-center">
-            <i class="fas fa-user text-white text-5xl"></i>
+        <div class="h-48 bg-gradient-to-r from-primary to-primary-dark text-background flex items-center justify-center">
+            <i class="fas fa-user text-background text-5xl"></i>
         </div>
         {% endif %}
         <div class="p-4">

--- a/templates/involvement_detail.html
+++ b/templates/involvement_detail.html
@@ -9,6 +9,6 @@
     {% csrf_token %}
     {{ form.justification.label_tag }}
     {{ form.justification }}
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/justification_detail.html
+++ b/templates/justification_detail.html
@@ -9,8 +9,8 @@
     {% csrf_token %}
     {{ form.justification.label_tag }}
     {{ form.justification }}
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
-    <a href="{% url 'justification_delete' project_file.id function_name %}" class="bg-red-600 text-white px-4 py-2 rounded ml-2">Begründung löschen</a>
+    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Speichern</button>
+    <a href="{% url 'justification_delete' project_file.id function_name %}" class="bg-error text-background px-4 py-2 rounded ml-2">Begründung löschen</a>
 </form>
 {% endblock %}
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -8,7 +8,7 @@
         {% csrf_token %}
         <h1 class="text-2xl font-semibold mb-4 text-center">Anmelden</h1>
         {% if form.errors %}
-            <p class="text-red-600 mb-4">Bitte gültige Zugangsdaten eingeben.</p>
+            <p class="text-error mb-4">Bitte gültige Zugangsdaten eingeben.</p>
         {% endif %}
         <div class="mb-4">
             <label for="id_username" class="block text-sm font-medium text-gray-700 mb-1">Benutzername</label>
@@ -18,7 +18,7 @@
             <label for="id_password" class="block text-sm font-medium text-gray-700 mb-1">Passwort</label>
             <input type="password" name="password" id="id_password" class="w-full border-gray-300 rounded px-3 py-2" required>
         </div>
-        <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded">Anmelden</button>
+        <button type="submit" class="w-full bg-accent hover:bg-accent-dark text-background font-semibold py-2 px-4 rounded">Anmelden</button>
     </form>
 </div>
 {% endblock %}

--- a/templates/parser_rules/rule_confirm_delete.html
+++ b/templates/parser_rules/rule_confirm_delete.html
@@ -5,7 +5,7 @@
 <p>Möchten Sie die Regel "{{ object.regel_name }}" wirklich löschen?</p>
 <form method="post">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Löschen</button>
+    <button type="submit" class="px-4 py-2 bg-error text-background rounded">Löschen</button>
     <a href="{% url 'parser_rule_list' %}" class="ml-2 px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
 </form>
 {% endblock %}

--- a/templates/parser_rules/rule_form.html
+++ b/templates/parser_rules/rule_form.html
@@ -25,7 +25,7 @@
         {{ form.prioritaet.label_tag }}<br>
         {{ form.prioritaet }}{{ form.prioritaet.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
 </form>
 
 {% endblock %}

--- a/templates/parser_rules/rule_list.html
+++ b/templates/parser_rules/rule_list.html
@@ -3,9 +3,9 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Regeln für Exakten Parser</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'parser_rule_add' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Neue Regel</a>
-    <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-green-600 text-white rounded">Importieren</a>
-    <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Exportieren</a>
+    <a href="{% url 'parser_rule_add' %}" class="px-4 py-2 bg-accent text-background rounded">Neue Regel</a>
+    <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
+    <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
 </div>
 <table class="min-w-full">
     <thead>
@@ -22,12 +22,12 @@
             <td class="py-1">{{ r.regel_name }}</td>
             <td class="py-1">{{ r.erkennungs_phrase }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'parser_rule_edit' r.id %}" class="px-2 py-1 bg-blue-600 text-white rounded">Bearbeiten</a>
+                <a href="{% url 'parser_rule_edit' r.id %}" class="px-2 py-1 bg-accent text-background rounded">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form method="post" action="{% url 'parser_rule_delete' r.id %}" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Regel wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Regel wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/partials/_project_list_rows.html
+++ b/templates/partials/_project_list_rows.html
@@ -1,6 +1,6 @@
 {% for p in projekte %}
     <tr class="border-b text-sm">
-        <td class="py-1"><a href="{% url 'projekt_detail' p.pk %}" class="text-blue-700 hover:underline">{{ p.title }}</a></td>
+        <td class="py-1"><a href="{% url 'projekt_detail' p.pk %}" class="text-accent-dark hover:underline">{{ p.title }}</a></td>
         <td class="py-1">{{ p.beschreibung|truncatechars:50 }}</td>
         <td class="py-1">{{ p.software_string }}</td>
         <td class="py-1">

--- a/templates/partials/_response_rule_row.html
+++ b/templates/partials/_response_rule_row.html
@@ -8,11 +8,11 @@
     <td class="py-1">{{ form.actions_json }}</td>
     <td class="py-1 text-center">
         {% if form.instance.pk %}
-        <button type="button" hx-delete="{% url 'anlage2_rule_delete' form.instance.pk %}" hx-target="closest tr" hx-swap="delete" hx-on:afterRequest="updateTotals()" class="text-red-600">
+        <button type="button" hx-delete="{% url 'anlage2_rule_delete' form.instance.pk %}" hx-target="closest tr" hx-swap="delete" hx-on:afterRequest="updateTotals()" class="text-error">
             <i class="fa fa-trash"></i>
         </button>
         {% else %}
-        <button type="button" onclick="this.closest('tr').remove();updateTotals();" class="text-red-600"><i class="fa fa-trash"></i></button>
+        <button type="button" onclick="this.closest('tr').remove();updateTotals();" class="text-error"><i class="fa fa-trash"></i></button>
         {% endif %}
     </td>
 </tr>

--- a/templates/partials/_role_tile_form.html
+++ b/templates/partials/_role_tile_form.html
@@ -16,6 +16,6 @@
             {% endfor %}
         </div>
     {% endfor %}
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
 </form>
 {% endif %}

--- a/templates/partials/anlage_status.html
+++ b/templates/partials/anlage_status.html
@@ -17,25 +17,25 @@
     {% endif %}>
 
 {% if anlage.processing_status == 'PROCESSING' or anlage.is_verification_running %}
-<span class="inline-block px-1 py-0.5 rounded bg-gray-500 text-white text-sm opacity-50 pointer-events-none">{% include 'partials/spinner.html' %} Analyse läuft...</span>
+<span class="inline-block px-1 py-0.5 rounded bg-gray-500 text-background text-sm opacity-50 pointer-events-none">{% include 'partials/spinner.html' %} Analyse läuft...</span>
 {% elif anlage.processing_status == 'COMPLETE' %}
-<a href="{{ edit_url }}" class="inline-block px-1 py-0.5 rounded bg-primary text-white text-sm hover:bg-primary-dark">Analyse bearbeiten</a>
+<a href="{{ edit_url }}" class="inline-block px-1 py-0.5 rounded bg-primary text-background text-sm hover:bg-primary-dark">Analyse bearbeiten</a>
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline ml-2">
   {% csrf_token %}
-  <button class="inline-block px-1 py-0.5 rounded bg-primary text-white text-sm hover:bg-primary-dark" title="Erneut analysieren">
+  <button class="inline-block px-1 py-0.5 rounded bg-primary text-background text-sm hover:bg-primary-dark" title="Erneut analysieren">
       <i class="fas fa-sync-alt"></i>
   </button>
 </form>
 {% elif anlage.processing_status == 'FAILED' %}
-<span class="text-red-600 mr-2">Analyse fehlgeschlagen</span>
+<span class="text-error mr-2">Analyse fehlgeschlagen</span>
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">
   {% csrf_token %}
-  <button class="inline-block px-1 py-0.5 rounded bg-primary text-white text-sm hover:bg-primary-dark">Erneut versuchen</button>
+  <button class="inline-block px-1 py-0.5 rounded bg-primary text-background text-sm hover:bg-primary-dark">Erneut versuchen</button>
 </form>
 {% else %}
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">
   {% csrf_token %}
-  <button class="inline-block px-1 py-0.5 rounded bg-primary text-white text-sm hover:bg-primary-dark">Analyse starten</button>
+  <button class="inline-block px-1 py-0.5 rounded bg-primary text-background text-sm hover:bg-primary-dark">Analyse starten</button>
 </form>
 {% endif %}
 

--- a/templates/partials/anlagen_assign_row.html
+++ b/templates/partials/anlagen_assign_row.html
@@ -9,7 +9,7 @@
                 <option value="{{ n }}">{{ n }}</option>
                 {% endfor %}
             </select>
-            <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Speichern</button>
+            <button type="submit" class="bg-accent text-background px-2 py-1 rounded">Speichern</button>
         </form>
     </td>
 </tr>

--- a/templates/partials/markdown_editor.html
+++ b/templates/partials/markdown_editor.html
@@ -6,8 +6,8 @@
   <div id="{{ id_prefix }}-view" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
   <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border rounded p-2">{{ text }}</textarea>
   <div class="flex space-x-2">
-    <button type="button" id="{{ id_prefix }}-edit" class="bg-blue-600 text-white px-4 py-2 rounded">Bearbeiten</button>
-    <button type="submit" id="{{ id_prefix }}-save" class="hidden bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
-    <button type="button" id="{{ id_prefix }}-cancel" class="hidden bg-gray-300 text-black px-4 py-2 rounded">Abbrechen</button>
+    <button type="button" id="{{ id_prefix }}-edit" class="bg-accent text-background px-4 py-2 rounded">Bearbeiten</button>
+    <button type="submit" id="{{ id_prefix }}-save" class="hidden bg-accent text-background px-4 py-2 rounded">Speichern</button>
+    <button type="button" id="{{ id_prefix }}-cancel" class="hidden bg-gray-300 text-text px-4 py-2 rounded">Abbrechen</button>
   </div>
 </div>

--- a/templates/partials/negotiable_cell.html
+++ b/templates/partials/negotiable_cell.html
@@ -1,5 +1,5 @@
 {% if row.result_id %}
-<td class="border px-2 text-center negotiable-cell {% if is_negotiable %}bg-green-100 text-green-800{% else %}bg-red-100 text-red-800{% endif %}{% if override is not none %} border-yellow-400{% endif %}"
+<td class="border px-2 text-center negotiable-cell {% if is_negotiable %}bg-success/20 text-success-dark{% else %}bg-error-light text-error-dark{% endif %}{% if override is not none %} border-warning{% endif %}"
     hx-post="{% url 'hx_toggle_negotiable' result_id=row.result_id %}"
     hx-target="closest td" hx-swap="outerHTML">
     {% if is_negotiable %}

--- a/templates/partials/projekt_cockpit.html
+++ b/templates/partials/projekt_cockpit.html
@@ -34,8 +34,8 @@
         Anlage {{ nr }}:
         {% if file %}
           <a href="{{ file.upload.url }}" class="underline" title="{{ file.upload.name|clean_filename }}">{{ file.upload.name|clean_filename }}</a>
-          {% if file.processing_status == 'COMPLETE' %}<i class="fas fa-check text-green-600"></i>{% elif file.processing_status == 'FAILED' %}<i class="fas fa-times text-red-600"></i>{% elif file.processing_status == 'PROCESSING' %}{% include 'partials/spinner.html' %}{% else %}<i class="fas fa-clock text-gray-500"></i>{% endif %}
-          {% if file.verhandlungsfaehig %}<i class="fas fa-handshake text-green-600 ml-1" title="Verhandlungsfähig"></i>{% else %}<i class="fas fa-handshake-slash text-gray-400 ml-1" title="Nicht verhandlungsfähig"></i>{% endif %}
+          {% if file.processing_status == 'COMPLETE' %}<i class="fas fa-check text-success"></i>{% elif file.processing_status == 'FAILED' %}<i class="fas fa-times text-error"></i>{% elif file.processing_status == 'PROCESSING' %}{% include 'partials/spinner.html' %}{% else %}<i class="fas fa-clock text-gray-500"></i>{% endif %}
+          {% if file.verhandlungsfaehig %}<i class="fas fa-handshake text-success ml-1" title="Verhandlungsfähig"></i>{% else %}<i class="fas fa-handshake-slash text-gray-400 ml-1" title="Nicht verhandlungsfähig"></i>{% endif %}
         {% else %}
           <span class="text-gray-500">fehlt</span>
         {% endif %}

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -5,15 +5,15 @@
     {% with doc_val=row.doc_result|get_item:field_name ai_val=row.ai_result|get_item:field_name manual_val=row.manual_result|get_item:field_name %}
     <button class="tri-state-icon rounded-full px-2 py-1 text-sm{% if field_name == 'technisch_vorhanden' and row.sub %} opacity-50 pointer-events-none{% endif %}
         {% if manual_val != '' and manual_val != doc_val %}
-            bg-yellow-100 text-yellow-800
+            bg-warning/20 text-warning-dark
         {% elif manual_val == '' and doc_val != '' and ai_val != '' and doc_val != ai_val %}
-            bg-yellow-100 text-yellow-800
+            bg-warning/20 text-warning-dark
         {% elif state is True %}
-            bg-green-100 text-green-800
+            bg-success/20 text-success-dark
         {% elif state is False %}
-            bg-red-100 text-red-800
+            bg-error-light text-error-dark
         {% else %}
-            bg-yellow-100 text-yellow-800
+            bg-warning/20 text-warning-dark
         {% endif %}"
             data-field-name="{{ field_name }}"
             data-is-manual="{{ is_manual|yesno:'true,false' }}"

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -15,12 +15,12 @@
         <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 rounded bg-gray-100 hover:bg-gray-200" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-white text-gray-700 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% else %}
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-white text-gray-700 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% endif %}
         {% if row.source_text and row.source_text != 'N/A' %}

--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -48,4 +48,4 @@
     </tbody>
 </table>
 </div>
-<button id="start-checks" class="bg-green-600 text-white px-4 py-2 rounded">Prüfung starten</button>
+<button id="start-checks" class="bg-success text-background px-4 py-2 rounded">Prüfung starten</button>

--- a/templates/partials/supervision_group.html
+++ b/templates/partials/supervision_group.html
@@ -1,5 +1,5 @@
 <details class="border rounded" {% if group.function and group.function.has_discrepancy %}open{% endif %}>
-  <summary class="p-2 cursor-pointer {% if group.function and group.function.has_discrepancy %}bg-red-100{% else %}bg-gray-100{% endif %}">
+  <summary class="p-2 cursor-pointer {% if group.function and group.function.has_discrepancy %}bg-error-light{% else %}bg-gray-100{% endif %}">
     {% if group.function %}{{ group.function.name }}{% else %}{{ group.name }}{% endif %}
     {% if group.subrows %}<span class="ms-2">+</span>{% endif %}
   </summary>

--- a/templates/partials/supervision_row.html
+++ b/templates/partials/supervision_row.html
@@ -1,7 +1,7 @@
 <details class="border rounded" {% if row.has_discrepancy %}open{% endif %}>
-  <summary class="p-2 cursor-pointer {% if row.has_discrepancy %}bg-red-100{% else %}bg-gray-100{% endif %}">
+  <summary class="p-2 cursor-pointer {% if row.has_discrepancy %}bg-error-light{% else %}bg-gray-100{% endif %}">
     {{ row.name }}
-    {% if row.has_discrepancy %}<span class="ms-2 text-red-600">⚠️</span>{% endif %}
+    {% if row.has_discrepancy %}<span class="ms-2 text-error">⚠️</span>{% endif %}
   </summary>
   {% include 'partials/supervision_row_content.html' with row=row standard_notes=standard_notes %}
 </details>

--- a/templates/partials/version_switcher.html
+++ b/templates/partials/version_switcher.html
@@ -11,7 +11,7 @@
   {% for v in versions %}
   <form method="post" action="{% url 'delete_project_file_version' v.pk %}" class="inline">
     {% csrf_token %}
-    <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded" onclick="return confirm('Sind Sie sicher?')">v{{ v.version }} löschen</button>
+    <button type="submit" class="bg-error text-background px-2 py-1 rounded" onclick="return confirm('Sind Sie sicher?')">v{{ v.version }} löschen</button>
   </form>
   {% endfor %}
 </div>

--- a/templates/personal.html
+++ b/templates/personal.html
@@ -14,11 +14,11 @@
         {% if tile.image %}
         <img src="{{ tile.image.url }}" class="h-32 w-full object-cover" alt="{{ tile.name }}">
         {% else %}
-        <div class="h-32 bg-gradient-to-r from-primary to-primary-dark text-white flex items-center justify-center">
-            <i class="{{ tile.icon }} text-white text-4xl"></i>
+        <div class="h-32 bg-gradient-to-r from-primary to-primary-dark text-background flex items-center justify-center">
+            <i class="{{ tile.icon }} text-background text-4xl"></i>
         </div>
         {% endif %}
-        <div class="p-4 bg-white">
+        <div class="p-4 bg-background">
             <h3 class="text-lg font-semibold mb-2">{{ tile.name }}</h3>
             <p class="text-gray-600">{{ tile.description }}</p>
         </div>

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -99,21 +99,21 @@ function renderLLM(data){
  const sec=document.getElementById('llm-section');
  sec.innerHTML='';
  if(!data.ist_llm_geprueft && !data.llm_initial_output){
-   sec.innerHTML=`<button id="run" class="bg-green-600 text-white px-4 py-2 rounded">LLM-Check starten</button>`;
+   sec.innerHTML=`<button id="run" class="bg-success text-background px-4 py-2 rounded">LLM-Check starten</button>`;
  }else if(data.ist_llm_geprueft && !data.llm_validated){
-   sec.innerHTML=`<div class="text-red-600 mb-2">LLM-Check unvollständig oder technisch fehlerhaft.</div>
+   sec.innerHTML=`<div class="text-error mb-2">LLM-Check unvollständig oder technisch fehlerhaft.</div>
    <textarea id="edit" class="border rounded w-full p-2 mb-2">${data.llm_initial_output||''}</textarea>
    <input id="context" type="text" placeholder="Weiterer Kontext" class="border rounded w-full p-2 mb-2 hidden">
    <div class="space-x-2">
-     <button id="edit-btn" class="bg-primary text-white px-4 py-2 rounded">Antwort bearbeiten & erneut prüfen</button>
-     <button id="ctx-btn" class="bg-primary text-white px-4 py-2 rounded">Zusätzlichen Kontext & erneut prüfen</button>
+     <button id="edit-btn" class="bg-primary text-background px-4 py-2 rounded">Antwort bearbeiten & erneut prüfen</button>
+     <button id="ctx-btn" class="bg-primary text-background px-4 py-2 rounded">Zusätzlichen Kontext & erneut prüfen</button>
    </div>`;
  }else if(data.ist_llm_geprueft && data.llm_validated){
-  sec.innerHTML=`<button id="toggle" class="bg-green-600 text-white px-4 py-2 rounded mb-2">Antwort ein-/ausblenden</button>
+  sec.innerHTML=`<button id="toggle" class="bg-success text-background px-4 py-2 rounded mb-2">Antwort ein-/ausblenden</button>
   <div id="output" class="prose max-w-none bg-gray-100 p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
  }
  if(data.llm_initial_output){
-  sec.innerHTML += `<button id="recheck" class="bg-primary text-white px-4 py-2 rounded mt-2">Erneut prüfen</button>`;
+  sec.innerHTML += `<button id="recheck" class="bg-primary text-background px-4 py-2 rounded mt-2">Erneut prüfen</button>`;
  }
  attachHandlers();
 }

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -47,7 +47,7 @@
         </thead>
         <tbody id="anlage2-table-body">
         {% for row in rows %}
-            <tr class="{% if row.sub %}subquestion-row hidden subquestions-for-{{ row.func_id }} bg-yellow-50 {% endif %}{% if row.is_negotiable %}opacity-60{% endif %}"
+            <tr class="{% if row.sub %}subquestion-row hidden subquestions-for-{{ row.func_id }} bg-warning/10 {% endif %}{% if row.is_negotiable %}opacity-60{% endif %}"
                 data-relevant="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'true,false,unknown' }}"
                 data-parsed-status="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'True,False,None' }}"
                 data-parsed-notes="{{ row.doc_result|raw_item:'technisch_vorhanden'|get_item:'note' }}"
@@ -64,7 +64,7 @@
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-white text-gray-700 hover:bg-gray-100">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 hover:bg-gray-100">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
@@ -72,7 +72,7 @@
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-white text-gray-700 hover:bg-gray-100">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 hover:bg-gray-100">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
@@ -114,13 +114,13 @@
         {% if allow_ai_check %}
         {% include 'partials/_button.html' with type='button' id='btn-verify-all' label='Alle Funktionen prüfen 🤖' variant='success' classes='px-2 py-1 rounded' attrs='data-project-id="'|add:anlage.project.pk|add:'"' %}
         {% endif %}
-        <a href="{% url 'projekt_file_parse_anlage2' anlage.pk %}" class="bg-blue-600 text-white px-2 py-1 rounded ml-4">Parser-Analyse starten</a>
+        <a href="{% url 'projekt_file_parse_anlage2' anlage.pk %}" class="bg-accent text-background px-2 py-1 rounded ml-4">Parser-Analyse starten</a>
     </div>
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <div class="space-x-2 mt-2">
-        <button type="reset" id="reset-fields" class="bg-gray-300 text-black px-4 py-2 rounded">Reset</button>
-        <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-black px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>
+        <button type="reset" id="reset-fields" class="bg-gray-300 text-text px-4 py-2 rounded">Reset</button>
+        <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-text px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>
     </div>
 </form>
 <details>
@@ -138,7 +138,7 @@
             {{ parser_form.parser_order }}
             {{ parser_form.parser_order.errors }}
         </div>
-        <button type="submit" name="save_parser_settings" class="bg-blue-600 text-white px-3 py-1 rounded">Einstellungen speichern</button>
+        <button type="submit" name="save_parser_settings" class="bg-accent text-background px-3 py-1 rounded">Einstellungen speichern</button>
     </form>
 </details>
 </div>
@@ -221,7 +221,7 @@ function setSubRowsEnabled(funcId, enabled) {
 
 function updateNegotiableCell(cell, value, override) {
     if (!cell) return;
-    cell.innerHTML = value ? '<span class="text-green-600">✅</span>' : '<span class="text-red-600">❌</span>';
+    cell.innerHTML = value ? '<span class="text-success">✅</span>' : '<span class="text-error">❌</span>';
     if (override !== null && override !== undefined) {
         cell.innerHTML += '<span class="ms-1">👤</span>';
     }
@@ -309,11 +309,11 @@ function updateRowAppearance(row) {
         if (docVal && typeof docVal === 'object' && 'value' in docVal) docVal = docVal.value;
         let aiVal = ai[aiKey];
         if (aiVal && typeof aiVal === 'object' && 'value' in aiVal) aiVal = aiVal.value;
-        icon.classList.remove('bg-green-500','bg-red-500','bg-yellow-500','text-white');
+        icon.classList.remove('bg-success','bg-error','bg-warning','text-background');
         if (f === 'einsatz_bei_telefonica' || f === 'zur_lv_kontrolle') {
             // Farbgebung ausschließlich anhand des Dokumentenwertes
             const displayVal = docVal === true;
-            icon.classList.add(displayVal ? 'bg-green-500' : 'bg-red-500', 'text-white');
+            icon.classList.add(displayVal ? 'bg-success' : 'bg-error', 'text-background');
             updatePopoverContent(icon);
             if (calcNeedsReview(manualVal, docVal, aiVal, hasManual, f)) {
                 needsReviewRow = true;
@@ -321,17 +321,17 @@ function updateRowAppearance(row) {
             return;
         }
         const displayVal = hasManual ? manualVal : (docVal !== undefined ? docVal : aiVal);
-        let cls = 'bg-yellow-500';
-        if (displayVal === true) cls = 'bg-green-500';
-        else if (displayVal === false) cls = 'bg-red-500';
+        let cls = 'bg-warning';
+        if (displayVal === true) cls = 'bg-success';
+        else if (displayVal === false) cls = 'bg-error';
         if (f !== 'ki_beteiligung') {
             if (hasManual) {
-                cls = manualVal === docVal ? 'bg-green-500' : 'bg-yellow-500';
+                cls = manualVal === docVal ? 'bg-success' : 'bg-warning';
             } else if (docVal !== undefined && aiVal !== undefined) {
-                cls = docVal === aiVal ? 'bg-green-500' : 'bg-red-500';
+                cls = docVal === aiVal ? 'bg-success' : 'bg-error';
             }
         }
-        icon.classList.add(cls, 'text-white');
+        icon.classList.add(cls, 'text-background');
         updatePopoverContent(icon);
         if (calcNeedsReview(manualVal, docVal, aiVal, hasManual, f)) {
             needsReviewRow = true;

--- a/templates/projekt_file_anlage6_review.html
+++ b/templates/projekt_file_anlage6_review.html
@@ -2,7 +2,7 @@
 {% block title %}Anlage 6 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 6 prüfen</h1>
-<p><a href="{{ anlage.upload.url }}" class="text-blue-700 underline">Download</a></p>
+<p><a href="{{ anlage.upload.url }}" class="text-accent-dark underline">Download</a></p>
 <form method="post" class="space-y-4">
     {% csrf_token %}
     <div>

--- a/templates/projekt_file_json_form.html
+++ b/templates/projekt_file_json_form.html
@@ -29,7 +29,7 @@
         {{ form.verhandlungsfaehig }} {{ form.verhandlungsfaehig.label_tag }}
         {{ form.verhandlungsfaehig.errors }}
     </div>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Speichern</button>
 </form>
 {% endblock %}
 {% block extra_js %}

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -18,7 +18,7 @@
 </form>
 {% if projekt.gutachten_file %}
 <p class="mt-4">
-    <a href="{% url 'gutachten_download' projekt.pk %}" class="text-blue-700 underline">Gutachten herunterladen</a>
+    <a href="{% url 'gutachten_download' projekt.pk %}" class="text-accent-dark underline">Gutachten herunterladen</a>
 </p>
 {% endif %}
 {% endblock %}

--- a/templates/recording.html
+++ b/templates/recording.html
@@ -6,9 +6,9 @@
 <h1 class="text-2xl font-semibold mb-4">Aufnahme {{ bereich|capfirst }}</h1>
 <div class="mb-6">
     {% if is_recording %}
-    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-white bg-red-600 hover:bg-red-700">Aufnahme stoppen</a>
+    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-background bg-error hover:bg-error-dark">Aufnahme stoppen</a>
     {% else %}
-    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-white bg-green-600 hover:bg-green-700">Aufnahme starten</a>
+    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-background bg-success hover:bg-success-dark">Aufnahme starten</a>
     {% endif %}
 </div>
 <h2 class="text-xl font-semibold mb-2">Vergangene Aufnahmen</h2>

--- a/templates/talkdiary.html
+++ b/templates/talkdiary.html
@@ -7,47 +7,47 @@
 <h2 class="text-lg font-semibold mb-2">Aufnahme</h2>
 <div class="mb-6 flex flex-wrap items-center space-x-4">
     {% if is_recording %}
-    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-white bg-red-600 hover:bg-red-700 flex items-center">
+    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-background bg-error hover:bg-error-dark flex items-center">
         Aufnahme stoppen
         <span class="ml-2 animate-pulse">&#9679;</span>
     </a>
-    <span class="text-red-700 font-semibold">Recording…</span>
+    <span class="text-error-dark font-semibold">Recording…</span>
     {% else %}
-    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-white bg-green-600 hover:bg-green-700">Aufnahme starten</a>
+    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-background bg-success hover:bg-success-dark">Aufnahme starten</a>
     {% endif %}
 
     <form method="get" class="inline-block">
-        <button name="rescan" value="1" class="px-4 py-2 bg-gray-600 text-white rounded">Rescan</button>
+        <button name="rescan" value="1" class="px-4 py-2 bg-gray-600 text-background rounded">Rescan</button>
     </form>
-    <a href="{% url 'upload_recording' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Datei hochladen</a>
+    <a href="{% url 'upload_recording' %}" class="px-4 py-2 bg-accent text-background rounded">Datei hochladen</a>
     {% if is_admin %}
-    <a href="{% url 'admin_talkdiary' %}" class="px-4 py-2 bg-purple-600 text-white rounded">Admin</a>
+    <a href="{% url 'admin_talkdiary' %}" class="px-4 py-2 bg-primary text-background rounded">Admin</a>
     {% endif %}
 </div>
 
 <h2 class="text-xl font-semibold mb-2">Original Files</h2>
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
     {% for rec in recordings %}
-    <div class="border p-3 rounded shadow text-sm {{ rec.transcript_file|yesno:'bg-green-50,' }}">
+    <div class="border p-3 rounded shadow text-sm {{ rec.transcript_file|yesno:'bg-success/10,' }}">
         <audio controls src="{{ rec.audio_file.url }}" class="w-full mb-1"></audio>
         <div class="flex space-x-2 mt-1">
             <form action="{% url 'transcribe_recording' rec.pk %}" method="post" class="transcribe-form">
                 {% csrf_token %}
                 <input type="hidden" name="track" value="1">
-                <button type="submit" class="px-2 py-1 text-white bg-blue-600 rounded">Transkribieren</button>
+                <button type="submit" class="px-2 py-1 text-background bg-accent rounded">Transkribieren</button>
             </form>
             {% if rec.transcript_file %}
-            <a href="{% url 'talkdiary_detail' rec.pk %}" class="px-2 py-1 bg-green-600 text-white rounded">Transcript</a>
+            <a href="{% url 'talkdiary_detail' rec.pk %}" class="px-2 py-1 bg-success text-background rounded">Transcript</a>
             {% endif %}
             <form action="{% url 'recording_delete' rec.pk %}" method="post">
                 {% csrf_token %}
-                <button type="submit" class="px-2 py-1 bg-red-600 text-white rounded" onclick="return confirm('Aufnahme wirklich löschen?');">Löschen</button>
+                <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Aufnahme wirklich löschen?');">Löschen</button>
             </form>
         </div>
         <p class="mt-1 flex items-center break-all">
-            <i class="fas fa-microphone text-blue-600 mr-2"></i>
+            <i class="fas fa-microphone text-accent mr-2"></i>
             {{ rec.audio_file.name|basename|truncatechars:30 }}
-            {% if rec.transcript_file %}<i class="fas fa-check text-green-600 ml-2"></i>{% endif %}
+            {% if rec.transcript_file %}<i class="fas fa-check text-success ml-2"></i>{% endif %}
         </p>
         <p class="text-xs text-gray-500">{{ rec.created_at|date:'d.m.Y H:i' }}</p>
     </div>
@@ -61,7 +61,7 @@
         {% if rec.transcript_file %}
         <a href="{% url 'talkdiary_detail' rec.pk %}" class="block border rounded p-3 bg-gray-50 hover:bg-gray-100 text-sm">
             <h3 class="font-semibold flex items-center">
-                <i class="fas fa-file-alt text-green-600 mr-2"></i>
+                <i class="fas fa-file-alt text-success mr-2"></i>
                 {{ rec.audio_file.name|basename|truncatechars:30 }}
             </h3>
             <p class="text-sm whitespace-pre-line mt-1">{{ rec.excerpt }}</p>
@@ -74,10 +74,10 @@
 {% if is_admin %}
 <div class="mt-8">
     <a href="{% url 'admin_talkdiary' %}" class="block rounded-lg overflow-hidden shadow-lg transform transition duration-300 hover:scale-105">
-        <div class="h-32 bg-gradient-to-r from-primary to-primary-dark text-white flex items-center justify-center">
-            <i class="fas fa-tools text-white text-4xl"></i>
+        <div class="h-32 bg-gradient-to-r from-primary to-primary-dark text-background flex items-center justify-center">
+            <i class="fas fa-tools text-background text-4xl"></i>
         </div>
-        <div class="p-4 bg-white">
+        <div class="p-4 bg-background">
             <h3 class="text-lg font-semibold mb-2">Transcript Verwaltung</h3>
             <p class="text-gray-600">Alle Einträge prüfen und bereinigen</p>
         </div>

--- a/templates/upload_recording.html
+++ b/templates/upload_recording.html
@@ -15,6 +15,6 @@
         {{ form.audio_file }}
         {{ form.audio_file.errors }}
     </div>
-    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
+    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Upload</button>
 </form>
 {% endblock %}

--- a/templates/upload_transcript.html
+++ b/templates/upload_transcript.html
@@ -12,6 +12,6 @@
         {{ form.transcript_file.label_tag }}<br>
         {{ form.transcript_file }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -9,7 +9,7 @@
       Aktuelle Version (v{{ file.version }})
       <form method="post" action="{% url 'delete_project_file_version' file.pk %}" class="inline">
         {% csrf_token %}
-        <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
+        <button type="submit" class="bg-error text-background px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
       </form>
     </h2>
     <pre class="whitespace-pre-wrap border p-2 bg-gray-100">{{ file.manual_analysis_json|default:file.analysis_json|tojson }}</pre>
@@ -20,7 +20,7 @@
       Vorherige Version (v{{ parent.version }})
       <form method="post" action="{% url 'delete_project_file_version' parent.pk %}" class="inline">
         {% csrf_token %}
-        <button type="submit" class="bg-red-600 text-white px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
+        <button type="submit" class="bg-error text-background px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
       </form>
     </h2>
     <pre class="whitespace-pre-wrap border p-2 bg-gray-100">{{ parent.manual_analysis_json|default:parent.analysis_json|tojson }}</pre>
@@ -49,12 +49,12 @@
         <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline">
           <input type="hidden" name="result_id" value="{{ gap.id }}">
           <input type="hidden" name="action" value="carry">
-          <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Übernehmen</button>
+          <button type="submit" class="bg-accent text-background px-2 py-1 rounded">Übernehmen</button>
         </form>
         <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline ms-2">
           <input type="hidden" name="result_id" value="{{ gap.id }}">
           <input type="hidden" name="action" value="fix">
-          <button type="submit" class="bg-green-600 text-white px-2 py-1 rounded">Behoben</button>
+          <button type="submit" class="bg-success text-background px-2 py-1 rounded">Behoben</button>
         </form>
       </td>
     </tr>
@@ -63,6 +63,6 @@
 </table>
 {% endif %}
 <div class="mt-4">
-  <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück zum Projekt</a>
+  <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück zum Projekt</a>
 </div>
 {% endblock %}

--- a/templates/version_compare_anlage1.html
+++ b/templates/version_compare_anlage1.html
@@ -30,14 +30,14 @@
           {% csrf_token %}
           <input type="hidden" name="action" value="negotiate">
           <input type="hidden" name="question" value="{{ row.num }}">
-          <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Verhandlungsfähig</button>
+          <button type="submit" class="bg-accent text-background px-2 py-1 rounded">Verhandlungsfähig</button>
         </form>
         <form method="post" class="inline">
           {% csrf_token %}
           <input type="hidden" name="action" value="add_gap">
           <input type="hidden" name="question" value="{{ row.num }}">
           <input type="hidden" name="note" value="Offen">
-          <button type="submit" class="bg-green-600 text-white px-2 py-1 rounded">Gap hinzufügen</button>
+          <button type="submit" class="bg-success text-background px-2 py-1 rounded">Gap hinzufügen</button>
         </form>
       </td>
     </tr>
@@ -66,7 +66,7 @@
         {% if row.parent.hinweis %}<p>Hinweis: {{ row.parent.hinweis }}</p>{% endif %}
         {% if row.parent.vorschlag %}<p>Vorschlag: {{ row.parent.vorschlag }}</p>{% endif %}
       </td>
-      <td class="border px-2 {% if row.changed %}bg-yellow-100{% endif %}">
+      <td class="border px-2 {% if row.changed %}bg-warning/20{% endif %}">
         {% if row.current.answer %}<p>{{ row.current.answer }}</p>{% endif %}
         {% if row.current.hinweis %}<p>Hinweis: {{ row.current.hinweis }}</p>{% endif %}
         {% if row.current.vorschlag %}<p>Vorschlag: {{ row.current.vorschlag }}</p>{% endif %}
@@ -76,6 +76,6 @@
   </tbody>
 </table>
 <div class="mt-4">
-  <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-black px-4 py-2 rounded">Zurück zum Projekt</a>
+  <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück zum Projekt</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace hard-coded Tailwind color classes with theme variables across templates
- ensure base layout and components use bg-background, text-text, bg-accent, etc.
- rebuild Tailwind CSS for updated palette

## Testing
- `python manage.py makemigrations --check`
- `cd theme/static_src && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a454f0e900832bbe56775d630d5445