### PR TITLE
feat: enable dark mode color scheme

### DIFF
--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -24,6 +24,13 @@
 
 @import "./components.css";
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: var(--color-background-dark);
+    --color-text: var(--color-text-light);
+  }
+}
+
 /**
   * A catch-all path to Django template files, JavaScript, and Python files
   * that contain Tailwind CSS classes and will be scanned by Tailwind to generate the final CSS file.


### PR DESCRIPTION
## Summary
- switch CSS variables for background and text when user prefers dark scheme
- rebuild Tailwind bundle

## Testing
- `npm --prefix theme/static_src run build`
- `pre-commit run --files theme/static_src/src/styles.css`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4a93a1a9c832bac49c187e8bdd81e