### PR TITLE
fix: replace gray utility classes in templates

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -9,7 +9,7 @@
 <div class="max-w-screen-2xl mx-auto">
     <section class="flex-1 p-4">
         <div class="flex flex-col md:flex-row gap-6">
-            <aside class="bg-gray-50 p-4 border-r border-gray-200 overflow-y-auto w-full md:w-64 flex-shrink-0">
+            <aside class="bg-background p-4 border-r border-gray-200 overflow-y-auto w-full md:w-64 flex-shrink-0">
         <h2 class="text-xl font-bold mb-4">Admin-Navigation</h2>
         <nav class="space-y-4 text-sm">
             <div>
@@ -20,7 +20,7 @@
             </div>
             <div>
                 {% with open_ki=request.resolver_match.url_name %}
-                <h3 data-accordion-header class="flex justify-between items-center font-semibold my-2 cursor-pointer text-gray-600 uppercase tracking-wider text-sm">
+                <h3 data-accordion-header class="flex justify-between items-center font-semibold my-2 cursor-pointer text-text opacity-70 uppercase tracking-wider text-sm">
                     <span>KI-Konfiguration</span>
                     <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if open_ki in 'admin_llm_roles admin_prompts admin_models' %}rotate-180{% endif %}"></i>
                 </h3>
@@ -42,7 +42,7 @@
             </div>
             <div>
                 {% with open_sys=request.resolver_match.url_name %}
-                <h3 data-accordion-header class="flex justify-between items-center font-semibold my-2 cursor-pointer text-gray-600 uppercase tracking-wider text-sm">
+                <h3 data-accordion-header class="flex justify-between items-center font-semibold my-2 cursor-pointer text-text opacity-70 uppercase tracking-wider text-sm">
                     <span>Systemverwaltung</span>
                     <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if open_sys in 'admin_user_list auth_group_changelist' %}rotate-180{% endif %}"></i>
                 </h3>

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -5,16 +5,16 @@
 <div class="max-w-screen-2xl mx-auto">
     <section class="p-4">
         <div class="flex flex-col md:flex-row gap-6">
-            <aside class="w-full md:w-64 bg-gray-50 p-4 border-r border-gray-200">
+            <aside class="w-full md:w-64 bg-background p-4 border-r border-gray-200">
         <h2 class="text-xl font-bold mb-4">Admin-Navigation</h2>
         <nav class="space-y-4 text-sm">
             <div>
-                <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">Projekt-Konfiguration</h3>
+                <h3 class="font-semibold text-text opacity-70 uppercase tracking-wider text-sm mb-2">Projekt-Konfiguration</h3>
                 <a href="{% url 'admin_projects' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Projekt-Liste</a><br>
                 <a href="{% url 'admin_project_statuses' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Projekt-Status</a><br>
             </div>
             <div>
-                <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">Anlagen-Konfiguration</h3>
+                <h3 class="font-semibold text-text opacity-70 uppercase tracking-wider text-sm mb-2">Anlagen-Konfiguration</h3>
                 {% with current=request.resolver_match.url_name %}
                 <div>
                     <h4 data-accordion-header class="flex justify-between items-center font-semibold my-2 cursor-pointer">
@@ -67,13 +67,13 @@
                 {% endwith %}
             </div>
             <div>
-                <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">KI-Konfiguration</h3>
+                <h3 class="font-semibold text-text opacity-70 uppercase tracking-wider text-sm mb-2">KI-Konfiguration</h3>
                 <a href="{% url 'admin_llm_roles' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">LLM-Rollen</a><br>
                 <a href="{% url 'admin_prompts' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Prompts</a><br>
                 <a href="{% url 'admin_models' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">LLM-Modelle</a><br>
             </div>
             <div>
-                <h3 class="font-semibold text-gray-500 uppercase tracking-wider text-sm mb-2">Systemverwaltung</h3>
+                <h3 class="font-semibold text-text opacity-70 uppercase tracking-wider text-sm mb-2">Systemverwaltung</h3>
                 <a href="{% url 'admin_user_list' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Benutzer verwalten</a><br>
                 <a href="{% url 'admin:auth_group_changelist' %}" class="block px-2 py-1 rounded text-primary hover:bg-primary-light">Gruppen</a><br>
             </div>

--- a/templates/admin_talkdiary.html
+++ b/templates/admin_talkdiary.html
@@ -4,10 +4,10 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Admin TalkDiary</h1>
 <div class="mb-4 space-x-2">
-    <a href="?" class="px-3 py-1 rounded bg-gray-200 {% if not active_filter %}bg-gray-400{% endif %}">Alle</a>
-    <a href="?filter=missing_audio" class="px-3 py-1 rounded bg-gray-200 {% if active_filter == 'missing_audio' %}bg-gray-400{% endif %}">Missing Audio</a>
-    <a href="?filter=missing_transcript" class="px-3 py-1 rounded bg-gray-200 {% if active_filter == 'missing_transcript' %}bg-gray-400{% endif %}">Missing Transcript</a>
-    <a href="?filter=incomplete" class="px-3 py-1 rounded bg-gray-200 {% if active_filter == 'incomplete' %}bg-gray-400{% endif %}">Incomplete</a>
+    <a href="?" class="px-3 py-1 rounded bg-background {% if not active_filter %}bg-primary text-background{% endif %}">Alle</a>
+    <a href="?filter=missing_audio" class="px-3 py-1 rounded bg-background {% if active_filter == 'missing_audio' %}bg-primary text-background{% endif %}">Missing Audio</a>
+    <a href="?filter=missing_transcript" class="px-3 py-1 rounded bg-background {% if active_filter == 'missing_transcript' %}bg-primary text-background{% endif %}">Missing Transcript</a>
+    <a href="?filter=incomplete" class="px-3 py-1 rounded bg-background {% if active_filter == 'incomplete' %}bg-primary text-background{% endif %}">Incomplete</a>
 </div>
 <form method="post">
     {% csrf_token %}
@@ -15,7 +15,7 @@
     {% for rec in recordings %}
         <div class="border rounded p-4 shadow {% if rec.incomplete %}bg-error-light{% endif %}">
             <div class="flex items-center justify-between">
-                <span class="text-sm text-gray-600">{{ rec.created_at|date:'d.m.Y H:i' }}</span>
+                <span class="text-sm text-text opacity-70">{{ rec.created_at|date:'d.m.Y H:i' }}</span>
                 <input type="checkbox" name="delete" value="{{ rec.id }}" class="form-checkbox"/>
             </div>
             <p class="font-semibold mt-1">{{ rec.audio_file.name|basename }}</p>
@@ -34,7 +34,7 @@
                 <p class="text-error text-sm mt-1">Transcript fehlt</p>
             {% endif %}
             {% if rec.notes %}
-            <p class="text-xs text-gray-500 mt-2">{{ rec.notes }}</p>
+            <p class="text-xs text-text opacity-70 mt-2">{{ rec.notes }}</p>
             {% endif %}
         </div>
     {% empty %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -11,11 +11,11 @@
             <p class="text-error mb-4">Bitte gültige Zugangsdaten eingeben.</p>
         {% endif %}
         <div class="mb-4">
-            <label for="id_username" class="block text-sm font-medium text-gray-700 mb-1">Benutzername</label>
+            <label for="id_username" class="block text-sm font-medium text-text mb-1">Benutzername</label>
             <input type="text" name="username" id="id_username" class="w-full border-gray-300 rounded px-3 py-2" autofocus required>
         </div>
         <div class="mb-6">
-            <label for="id_password" class="block text-sm font-medium text-gray-700 mb-1">Passwort</label>
+            <label for="id_password" class="block text-sm font-medium text-text mb-1">Passwort</label>
             <input type="password" name="password" id="id_password" class="w-full border-gray-300 rounded px-3 py-2" required>
         </div>
         <button type="submit" class="w-full bg-accent hover:bg-accent-dark text-background font-semibold py-2 px-4 rounded">Anmelden</button>

--- a/templates/talkdiary.html
+++ b/templates/talkdiary.html
@@ -17,7 +17,7 @@
     {% endif %}
 
     <form method="get" class="inline-block">
-        <button name="rescan" value="1" class="px-4 py-2 bg-gray-600 text-background rounded">Rescan</button>
+        <button name="rescan" value="1" class="px-4 py-2 bg-background-dark text-background rounded">Rescan</button>
     </form>
     <a href="{% url 'upload_recording' %}" class="px-4 py-2 bg-accent text-background rounded">Datei hochladen</a>
     {% if is_admin %}
@@ -49,7 +49,7 @@
             {{ rec.audio_file.name|basename|truncatechars:30 }}
             {% if rec.transcript_file %}<i class="fas fa-check text-success ml-2"></i>{% endif %}
         </p>
-        <p class="text-xs text-gray-500">{{ rec.created_at|date:'d.m.Y H:i' }}</p>
+        <p class="text-xs text-text opacity-70">{{ rec.created_at|date:'d.m.Y H:i' }}</p>
     </div>
     {% empty %}
     <p>Keine Aufnahmen vorhanden.</p>
@@ -59,7 +59,7 @@
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     {% for rec in recordings %}
         {% if rec.transcript_file %}
-        <a href="{% url 'talkdiary_detail' rec.pk %}" class="block border rounded p-3 bg-gray-50 hover:bg-gray-100 text-sm">
+        <a href="{% url 'talkdiary_detail' rec.pk %}" class="block border rounded p-3 bg-background hover:bg-background-dark text-sm">
             <h3 class="font-semibold flex items-center">
                 <i class="fas fa-file-alt text-success mr-2"></i>
                 {{ rec.audio_file.name|basename|truncatechars:30 }}
@@ -79,7 +79,7 @@
         </div>
         <div class="p-4 bg-background">
             <h3 class="text-lg font-semibold mb-2">Transcript Verwaltung</h3>
-            <p class="text-gray-600">Alle Einträge prüfen und bereinigen</p>
+            <p class="text-text opacity-70">Alle Einträge prüfen und bereinigen</p>
         </div>
     </a>
 </div>


### PR DESCRIPTION
## Summary
- use semantic Tailwind classes for admin TalkDiary filters and notes
- align TalkDiary and login templates with theme colors
- replace gray classes in admin layouts with semantic text and background utilities

## Testing
- `python manage.py tailwind build`
- `python manage.py makemigrations --check`
- `pre-commit run --files templates/admin/base_site.html templates/admin_base.html templates/admin_talkdiary.html templates/login.html templates/talkdiary.html`


------
https://chatgpt.com/codex/tasks/task_e_68a4ac867fcc832bb472dbf0744320f5