### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/static/js/theme_toggle.js
+++ b/static/js/theme_toggle.js
@@ -1,0 +1,32 @@
+// JS für Farbmodus-Toggle
+(function () {
+    const storageKey = 'color-theme';
+    const toggleBtn = document.getElementById('theme-toggle');
+    const root = document.documentElement;
+
+    function setTheme(theme) {
+        if (theme === 'dark') {
+            root.classList.add('dark');
+        } else {
+            root.classList.remove('dark');
+        }
+        localStorage.setItem(storageKey, theme);
+    }
+
+    function initTheme() {
+        const stored = localStorage.getItem(storageKey);
+        if (stored) {
+            setTheme(stored);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        initTheme();
+        if (toggleBtn) {
+            toggleBtn.addEventListener('click', function () {
+                const isDark = root.classList.contains('dark');
+                setTheme(isDark ? 'light' : 'dark');
+            });
+        }
+    });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,6 +44,9 @@
                 {% else %}
                     <a href="/login/" class="hover:underline">Anmelden</a>
                 {% endif %}
+                <button id="theme-toggle" class="ml-2" aria-label="Farbschema umschalten">
+                    <i class="fa-solid fa-moon"></i>
+                </button>
             </nav>
         </div>
     </header>
@@ -66,6 +69,7 @@
     </footer>
     <script src="{% static 'js/utils.js' %}"></script>
     <script src="{% static 'js/file_upload.js' %}"></script>
+    <script src="{% static 'js/theme_toggle.js' %}"></script>
     <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
     <script src="{% static 'js/markdown_editor.js' %}"></script>
     {% block extra_js %}{% endblock %}

--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -31,6 +31,11 @@
   }
 }
 
+html.dark {
+  --color-background: var(--color-background-dark);
+  --color-text: var(--color-text-light);
+}
+
 /**
   * A catch-all path to Django template files, JavaScript, and Python files
   * that contain Tailwind CSS classes and will be scanned by Tailwind to generate the final CSS file.


### PR DESCRIPTION
## Summary
- add dark mode toggle to base template with persisted preference
- implement theme_toggle.js to toggle `dark` class and store choice
- extend CSS variables to respond to `html.dark`

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4b42eaee8832b8ad2f03103da9c7b