### PR TITLE
fix: style header links with Tailwind

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -24,27 +24,27 @@
             <div class="text-xl font-semibold">
                 <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
             </div>
-            <nav class="space-x-4">
-                <a href="{{ request.META.HTTP_REFERER|default:'#' }}" onclick="history.back(); return false;" class="mr-2 hover:underline">&larr; Zurück</a>
-                <a href="/" class="hover:underline">Startseite</a>
+            <nav class="text-background space-x-4">
+                <a href="{{ request.META.HTTP_REFERER|default:'#' }}" onclick="history.back(); return false;" class="mr-2 hover:underline hover:text-accent-light">&larr; Zurück</a>
+                <a href="/" class="hover:underline hover:text-accent-light">Startseite</a>
                 {% if user.is_authenticated %}
-                    <a href="/account/" class="hover:underline">Mein Konto</a>
+                    <a href="/account/" class="hover:underline hover:text-accent-light">Mein Konto</a>
                     {% if user.is_superuser or is_admin %}
-                        <a href="/projects-admin/" class="hover:underline">Projekt-Admin</a>
+                        <a href="/projects-admin/" class="hover:underline hover:text-accent-light">Projekt-Admin</a>
                     {% endif %}
                     {% if user.is_staff %}
-                        <a href="/admin/" class="hover:underline">System-Admin</a>
+                        <a href="/admin/" class="hover:underline hover:text-accent-light">System-Admin</a>
                     {% endif %}
 
                     <form action="{% url 'logout' %}" method="post" class="inline">
                         {% csrf_token %}
-                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent text-text hover:underline px-0 py-0' %}
+                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent hover:bg-transparent text-background hover:text-accent-light hover:underline px-0 py-0' %}
                     </form>
 
                 {% else %}
-                    <a href="/login/" class="hover:underline">Anmelden</a>
+                    <a href="/login/" class="hover:underline hover:text-accent-light">Anmelden</a>
                 {% endif %}
-                <button id="theme-toggle" class="ml-2" aria-label="Farbschema umschalten">
+                <button id="theme-toggle" class="ml-2 hover:text-accent-light" aria-label="Farbschema umschalten">
                     <i class="fa-solid fa-moon"></i>
                 </button>
             </nav>


### PR DESCRIPTION
## Summary
- use Tailwind text utilities for header navigation links
- add hover accent color to header links and logout button

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4b7d5a084832bb8ae379aeedb773a