### PR TITLE
feat: add dark header color variant

### DIFF
--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -29,7 +29,10 @@ export default {
           light: '#6366f1',
           dark: '#4338ca',
         },
-        header: '#0d1b2a',
+        header: {
+          DEFAULT: '#0d1b2a',
+          dark: '#1e293b',
+        },
         background: {
           DEFAULT: '#ffffff',
           dark: '#1e293b',


### PR DESCRIPTION
## Summary
- add high-contrast `header-dark` color in Tailwind config
- rebuild Tailwind assets to include new utility

## Testing
- `npm run build`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4c2842dd0832b8631e13ed533db1d