### PR TITLE
fix: improve gray text contrast in templates

### DIFF
--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -10,11 +10,11 @@
             <p class="text-error mb-4">{% trans 'Bitte gültige Zugangsdaten eingeben.' %}</p>
         {% endif %}
         <div class="mb-4">
-            <label for="id_username" class="block text-sm font-medium text-gray-700 mb-1">{% trans 'Benutzername' %}</label>
+            <label for="id_username" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{% trans 'Benutzername' %}</label>
             <input type="text" name="username" id="id_username" class="w-full border-gray-300 rounded px-3 py-2" autofocus required>
         </div>
         <div class="mb-6">
-            <label for="id_password" class="block text-sm font-medium text-gray-700 mb-1">{% trans 'Passwort' %}</label>
+            <label for="id_password" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{% trans 'Passwort' %}</label>
             <input type="password" name="password" id="id_password" class="w-full border-gray-300 rounded px-3 py-2" required>
         </div>
         <input type="hidden" name="next" value="{{ next }}" />

--- a/templates/admin_anlage1.html
+++ b/templates/admin_anlage1.html
@@ -33,18 +33,18 @@
                     <input type="checkbox" name="delete{{ q.id }}">
                 </td>
                 <td class="py-1">
-                    <textarea name="text{{ q.id }}" rows="2" class="border rounded p-2 w-full text-gray-900">{{ q.text }}</textarea>
+                    <textarea name="text{{ q.id }}" rows="2" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100">{{ q.text }}</textarea>
                 </td>
             </tr>
             <tr class="border-b align-top text-sm">
                 <td colspan="4" class="py-1">
                     {% for v in q.variants.all %}
                         <div class="flex items-center mb-1">
-                            <textarea name="variant{{ v.id }}" rows="1" class="border rounded p-2 flex-1 text-gray-900">{{ v.text }}</textarea>
+                            <textarea name="variant{{ v.id }}" rows="1" class="border rounded p-2 flex-1 text-gray-900 dark:text-gray-100">{{ v.text }}</textarea>
                             <label class="ml-2 text-sm"><input type="checkbox" name="delvar{{ v.id }}"> löschen</label>
                         </div>
                     {% endfor %}
-                    <textarea name="new_variant{{ q.id }}" rows="1" class="border rounded p-2 w-full text-gray-900" placeholder="Neue Variante"></textarea>
+                    <textarea name="new_variant{{ q.id }}" rows="1" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100" placeholder="Neue Variante"></textarea>
                 </td>
             </tr>
         {% endfor %}
@@ -58,7 +58,7 @@
             </td>
             <td class="py-1 text-center"></td>
             <td class="py-1">
-                <textarea name="new_text" rows="2" class="border rounded p-2 w-full text-gray-900"></textarea>
+                <textarea name="new_text" rows="2" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100"></textarea>
             </td>
         </tr>
         </tbody>

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -13,11 +13,11 @@
     <input type="hidden" name="active_tab" id="active_tab" value="{{ active_tab }}">
     <input type="hidden" name="phrase_key" id="phrase_key" value="">
     <nav class="border-b border-gray-200 space-x-2 mb-4">
-        <button type="button" data-tab="table" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Tabellen-Parser</button>
-        <button type="button" data-tab="general" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Allgemein</button>
-        <button type="button" data-tab="rules" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Parser-Antwortregeln</button>
-        <button type="button" data-tab="rules2" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Regeln Fallback</button>
-        <button type="button" data-tab="a4" class="px-4 py-2 text-gray-600 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Anlage 4 Parser</button>
+        <button type="button" data-tab="table" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Tabellen-Parser</button>
+        <button type="button" data-tab="general" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Allgemein</button>
+        <button type="button" data-tab="rules" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Parser-Antwortregeln</button>
+        <button type="button" data-tab="rules2" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Regeln Fallback</button>
+        <button type="button" data-tab="a4" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Anlage 4 Parser</button>
     </nav>
     <div id="tab-table" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Tabellen-Parser: Spaltenüberschriften (Alias)</h2>
@@ -60,7 +60,7 @@
                 {{ config_form.enforce_subquestion_override }}
                 {{ config_form.enforce_subquestion_override.label }}
             </label>
-            <p class="text-sm text-gray-600">
+            <p class="text-sm text-gray-600 dark:text-gray-300">
                 {{ config_form.enforce_subquestion_override.help_text }}
             </p>
             {{ config_form.enforce_subquestion_override.errors }}
@@ -134,11 +134,11 @@ function showTab(tab){
     document.getElementById('active_tab').value=tab;
     document.querySelectorAll('[data-tab]').forEach(btn=>{
         if(btn.dataset.tab===tab){
-            btn.classList.remove('bg-gray-200','text-gray-600','border-b-0');
+            btn.classList.remove('bg-gray-200','text-gray-600','dark:text-gray-300','border-b-0');
             btn.classList.add('bg-background','text-accent','font-semibold','border-b-transparent');
         }else{
             btn.classList.remove('bg-background','text-accent','font-semibold','border-b-transparent');
-            btn.classList.add('bg-gray-200','text-gray-600','border-b-0');
+            btn.classList.add('bg-gray-200','text-gray-600','dark:text-gray-300','border-b-0');
         }
     });
 }

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -55,7 +55,7 @@
                         </label>
                 </td>
                 <td class="py-1">
-                        <textarea name="text" rows="4" class="border rounded p-2 w-full text-gray-900">{{ p.text }}</textarea>
+                        <textarea name="text" rows="4" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100">{{ p.text }}</textarea>
                         <button name="action" value="save" class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>
@@ -78,7 +78,7 @@
                     <form method="post" class="space-y-2">
                         {% csrf_token %}
                         <input type="hidden" name="action" value="save_a4_config">
-                        <textarea name="prompt_template" rows="4" class="border rounded p-2 w-full text-gray-900">{{ a4_config.prompt_template }}</textarea>
+                        <textarea name="prompt_template" rows="4" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100">{{ a4_config.prompt_template }}</textarea>
                         <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>
@@ -90,7 +90,7 @@
                         {% csrf_token %}
                         <input type="hidden" name="action" value="save_a4_parser_prompts">
                         <input type="hidden" name="field" value="prompt_plausibility">
-                        <textarea name="prompt_text" rows="4" class="border rounded p-2 w-full text-gray-900">{{ a4_parser.prompt_plausibility }}</textarea>
+                        <textarea name="prompt_text" rows="4" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100">{{ a4_parser.prompt_plausibility }}</textarea>
                         <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>

--- a/templates/partials/_role_tile_form.html
+++ b/templates/partials/_role_tile_form.html
@@ -2,7 +2,7 @@
 <form method="post" class="space-y-4">
     {% csrf_token %}
     <input type="hidden" name="group_id" value="{{ selected_group.id }}">
-    <p class="text-gray-700">Wähle die sichtbaren Kacheln für diese Rolle aus.</p>
+    <p class="text-gray-700 dark:text-gray-200">Wähle die sichtbaren Kacheln für diese Rolle aus.</p>
     {% for area, items in tiles_by_area.items %}
         <h2 class="text-xl font-semibold mt-4">{{ area.name }}-Dashboard</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-2">

--- a/templates/partials/projekt_cockpit.html
+++ b/templates/partials/projekt_cockpit.html
@@ -34,10 +34,10 @@
         Anlage {{ nr }}:
         {% if file %}
           <a href="{{ file.upload.url }}" class="underline" title="{{ file.upload.name|clean_filename }}">{{ file.upload.name|clean_filename }}</a>
-          {% if file.processing_status == 'COMPLETE' %}<i class="fas fa-check text-success"></i>{% elif file.processing_status == 'FAILED' %}<i class="fas fa-times text-error"></i>{% elif file.processing_status == 'PROCESSING' %}{% include 'partials/spinner.html' %}{% else %}<i class="fas fa-clock text-gray-500"></i>{% endif %}
-          {% if file.verhandlungsfaehig %}<i class="fas fa-handshake text-success ml-1" title="Verhandlungsfähig"></i>{% else %}<i class="fas fa-handshake-slash text-gray-400 ml-1" title="Nicht verhandlungsfähig"></i>{% endif %}
+{% if file.processing_status == 'COMPLETE' %}<i class="fas fa-check text-success"></i>{% elif file.processing_status == 'FAILED' %}<i class="fas fa-times text-error"></i>{% elif file.processing_status == 'PROCESSING' %}{% include 'partials/spinner.html' %}{% else %}<i class="fas fa-clock text-gray-500 dark:text-gray-400"></i>{% endif %}
+{% if file.verhandlungsfaehig %}<i class="fas fa-handshake text-success ml-1" title="Verhandlungsfähig"></i>{% else %}<i class="fas fa-handshake-slash text-gray-400 dark:text-gray-500 ml-1" title="Nicht verhandlungsfähig"></i>{% endif %}
         {% else %}
-          <span class="text-gray-500">fehlt</span>
+          <span class="text-gray-500 dark:text-gray-400">fehlt</span>
         {% endif %}
       </li>
       {% endwith %}

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -15,12 +15,12 @@
         <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 rounded bg-gray-100 hover:bg-gray-200" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 dark:text-gray-200 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% else %}
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 dark:text-gray-200 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% endif %}
         {% if row.source_text and row.source_text != 'N/A' %}

--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -28,7 +28,7 @@
                         {{ row.entry.description|markdownify }}
                     </div>
                 {% elif row.entry and row.entry.is_known_by_llm is False %}
-                    <p class="text-sm text-gray-500">Die automatische Prüfung konnte diese Software nicht eindeutig identifizieren.</p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">Die automatische Prüfung konnte diese Software nicht eindeutig identifizieren.</p>
                 {% else %}
                 {% endif %}
             </td>

--- a/templates/partials/software_tab_gutachten.html
+++ b/templates/partials/software_tab_gutachten.html
@@ -18,7 +18,7 @@
                     {{ row.entry.gutachten.text|markdownify }}
                 </div>
             {% elif row.entry %}
-                <span class="text-sm text-gray-500">Noch kein Gutachten vorhanden</span>
+                <span class="text-sm text-gray-500 dark:text-gray-400">Noch kein Gutachten vorhanden</span>
             {% endif %}
             </td>
             <td class="px-2 py-1 text-center space-x-2">

--- a/templates/personal.html
+++ b/templates/personal.html
@@ -20,7 +20,7 @@
         {% endif %}
         <div class="p-4 bg-background">
             <h3 class="text-lg font-semibold mb-2">{{ tile.name }}</h3>
-            <p class="text-gray-600">{{ tile.description }}</p>
+            <p class="text-gray-600 dark:text-gray-300">{{ tile.description }}</p>
         </div>
     </a>
     {% endfor %}

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -47,7 +47,7 @@
 <h2 class="text-xl font-semibold mb-4">Anlagen</h2>
 <nav class="flex space-x-2 mb-4" id="anlage-tabs-nav">
   {% for nr in anlage_numbers %}
-  <button class="anlage-tab px-3 py-1 border-b-2 {% if forloop.first %}border-primary text-primary{% else %}border-transparent text-gray-600{% endif %}"
+  <button class="anlage-tab px-3 py-1 border-b-2 {% if forloop.first %}border-primary text-primary{% else %}border-transparent text-gray-600 dark:text-gray-300{% endif %}"
           hx-get="{% url 'hx_project_anlage_tab' projekt.pk nr %}"
           hx-target="#anlage-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-nr="{{ nr }}">
@@ -66,7 +66,7 @@
           hx-get="{% url 'hx_project_software_tab' projekt.pk 'tech' %}"
           hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-tab="tech">Technische Prüfung</button>
-  <button class="software-tab px-3 py-1 border-b-2 border-transparent text-gray-600"
+  <button class="software-tab px-3 py-1 border-b-2 border-transparent text-gray-600 dark:text-gray-300"
           hx-get="{% url 'hx_project_software_tab' projekt.pk 'gutachten' %}"
           hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-tab="gutachten">Gutachten</button>
@@ -240,17 +240,17 @@ document.addEventListener('htmx:beforeRequest',function(e){
   if(t.classList.contains('anlage-tab')){
     document.querySelectorAll('.anlage-tab').forEach(b=>{
       b.classList.remove('border-primary','text-primary');
-      b.classList.add('border-transparent','text-gray-600');
+      b.classList.add('border-transparent','text-gray-600','dark:text-gray-300');
     });
-    t.classList.remove('border-transparent','text-gray-600');
+    t.classList.remove('border-transparent','text-gray-600','dark:text-gray-300');
     t.classList.add('border-primary','text-primary');
   }
   if(t.classList.contains('software-tab')){
     document.querySelectorAll('.software-tab').forEach(b=>{
       b.classList.remove('border-primary','text-primary');
-      b.classList.add('border-transparent','text-gray-600');
+      b.classList.add('border-transparent','text-gray-600','dark:text-gray-300');
     });
-    t.classList.remove('border-transparent','text-gray-600');
+    t.classList.remove('border-transparent','text-gray-600','dark:text-gray-300');
     t.classList.add('border-primary','text-primary');
   }
 });

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -64,7 +64,7 @@
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 hover:bg-gray-100">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 dark:text-gray-200 hover:bg-gray-100">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
@@ -72,7 +72,7 @@
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 hover:bg-gray-100">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 dark:text-gray-200 hover:bg-gray-100">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}

--- a/templates/talkdiary_detail.html
+++ b/templates/talkdiary_detail.html
@@ -3,7 +3,7 @@
 {% block title %}Transcript{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">{{ recording.audio_file.name|basename }}</h1>
-<p class="text-sm text-gray-600 mb-4">{{ recording.created_at|date:'d.m.Y H:i' }} - {{ recording.bereich }}</p>
+<p class="text-sm text-gray-600 dark:text-gray-300 mb-4">{{ recording.created_at|date:'d.m.Y H:i' }} - {{ recording.bereich }}</p>
 <audio controls src="{{ recording.audio_file.url }}" class="mb-4 w-full"></audio>
 <div class="prose max-w-none">
     {{ transcript_text|markdownify }}


### PR DESCRIPTION
## Summary
- replace static gray text classes with dark mode variants

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4c2931044832ba295d84abf5e7c9e