### PR TITLE
fix: add dark mode accent link styles

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -25,15 +25,15 @@
                     <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if open_ki in 'admin_llm_roles admin_prompts admin_models' %}rotate-180{% endif %}"></i>
                 </h3>
                 <div class="accordion-content pl-2 space-y-1 {% if open_ki in 'admin_llm_roles admin_prompts admin_models' %}block{% else %}hidden{% endif %}">
-                    <a href="{% url 'admin_llm_roles' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_llm_roles' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_llm_roles' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_llm_roles' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-user-gear fa-fw mr-2"></i>
                         LLM-Rollen
                     </a>
-                    <a href="{% url 'admin_prompts' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_prompts' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_prompts' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_prompts' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-pencil-alt fa-fw mr-2"></i>
                         Prompts
                     </a>
-                    <a href="{% url 'admin_models' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_models' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_models' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_models' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-robot fa-fw mr-2"></i>
                         LLM-Modelle
                     </a>
@@ -47,19 +47,19 @@
                     <i data-accordion-icon class="fas fa-chevron-down ml-2 transition-transform duration-300 {% if open_sys in 'admin_user_list auth_group_changelist' %}rotate-180{% endif %}"></i>
                 </h3>
                 <div class="accordion-content pl-2 space-y-1 {% if open_sys in 'admin_user_list auth_group_changelist' %}block{% else %}hidden{% endif %}">
-                    <a href="{% url 'admin_user_list' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_user_list' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_user_list' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_user_list' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-users fa-fw mr-2"></i>
                         Benutzer verwalten
                     </a>
-                    <a href="{% url 'admin:auth_group_changelist' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'auth_group_changelist' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin:auth_group_changelist' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'auth_group_changelist' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-user-shield fa-fw mr-2"></i>
                         Gruppen
                     </a>
-                    <a href="{% url 'admin_role_editor' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_role_editor' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_role_editor' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_role_editor' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-check-square fa-fw mr-2"></i>
                         Rollen &amp; Rechte
                     </a>
-                    <a href="{% url 'config_transfer' %}" class="flex items-center px-3 py-2 rounded text-accent-dark hover:bg-accent-light {% if request.resolver_match.url_name == 'config_transfer' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'config_transfer' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'config_transfer' %}bg-accent text-background font-semibold{% endif %}">
                         <i class="fas fa-exchange-alt fa-fw mr-2"></i>
                         Konfigurationen übertragen
                     </a>

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -15,7 +15,7 @@
     <tbody>
     {% for a in anlagen %}
         <tr class="border-t">
-            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-accent-dark underline">{{ a.upload.name|basename }}</a></td>
+            <td class="px-2 py-1"><a href="{{ a.upload.url }}" class="text-accent-dark dark:text-accent-light underline">{{ a.upload.name|basename }}</a></td>
             <td class="px-2 py-1 text-center">
                 <form method="post" action="{% url 'projekt_file_check_view' a.pk %}?llm=1">
                     {% csrf_token %}
@@ -48,7 +48,7 @@
                 </div>
                 <div class="mt-1 space-x-2">
                     <a href="{% url 'projekt_file_edit_json' a.pk %}" class="btn-action">Bearbeiten</a>
-                    <a href="{{ a.upload.url }}" class="text-accent-dark underline">Download</a>
+                    <a href="{{ a.upload.url }}" class="text-accent-dark dark:text-accent-light underline">Download</a>
                 </div>
             </td>
         </tr>

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -5,9 +5,9 @@
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>
 <div class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
 <p class="mt-4">
-    <a href="{% url 'gutachten_edit' gutachten.id %}" class="text-accent-dark underline">Bearbeiten</a>
+    <a href="{% url 'gutachten_edit' gutachten.id %}" class="text-accent-dark dark:text-accent-light underline">Bearbeiten</a>
     |
-    <a href="{% url 'gutachten_download' gutachten.id %}" class="text-accent-dark underline">Download</a>
+    <a href="{% url 'gutachten_download' gutachten.id %}" class="text-accent-dark dark:text-accent-light underline">Download</a>
 </p>
 {% if projekt.gutachten_function_note %}
 <div class="mt-4">

--- a/templates/partials/_project_list_rows.html
+++ b/templates/partials/_project_list_rows.html
@@ -1,6 +1,6 @@
 {% for p in projekte %}
     <tr class="border-b text-sm">
-        <td class="py-1"><a href="{% url 'projekt_detail' p.pk %}" class="text-accent-dark hover:underline">{{ p.title }}</a></td>
+        <td class="py-1"><a href="{% url 'projekt_detail' p.pk %}" class="text-accent-dark dark:text-accent-light hover:underline">{{ p.title }}</a></td>
         <td class="py-1">{{ p.beschreibung|truncatechars:50 }}</td>
         <td class="py-1">{{ p.software_string }}</td>
         <td class="py-1">

--- a/templates/projekt_file_anlage6_review.html
+++ b/templates/projekt_file_anlage6_review.html
@@ -2,7 +2,7 @@
 {% block title %}Anlage 6 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 6 prüfen</h1>
-<p><a href="{{ anlage.upload.url }}" class="text-accent-dark underline">Download</a></p>
+<p><a href="{{ anlage.upload.url }}" class="text-accent-dark dark:text-accent-light underline">Download</a></p>
 <form method="post" class="space-y-4">
     {% csrf_token %}
     <div>

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -18,7 +18,7 @@
 </form>
 {% if projekt.gutachten_file %}
 <p class="mt-4">
-    <a href="{% url 'gutachten_download' projekt.pk %}" class="text-accent-dark underline">Gutachten herunterladen</a>
+    <a href="{% url 'gutachten_download' projekt.pk %}" class="text-accent-dark dark:text-accent-light underline">Gutachten herunterladen</a>
 </p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add dark theme variant to accent-colored links
- ensure navigation links support dark scheme

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4c29b2de4832ba7f106c97984cef6