### PR TITLE
feat: add dark mode classes to table partials

### DIFF
--- a/templates/partials/_response_rules_table.html
+++ b/templates/partials/_response_rules_table.html
@@ -1,13 +1,13 @@
 {{ formset.management_form }}
 <table class="min-w-full mb-4">
     <thead>
-        <tr class="border-b text-left">
-            <th></th>
-            <th class="py-2">Name</th>
-            <th class="py-2">Phrase</th>
-            <th class="py-2">Anwendungsbereich</th>
-            <th class="py-2">Aktionen</th>
-            <th class="py-2 text-center">Entfernen</th>
+        <tr class="border-b text-left bg-background dark:bg-background-dark">
+            <th class="bg-background dark:bg-background-dark"></th>
+            <th class="py-2 bg-background dark:bg-background-dark">Name</th>
+            <th class="py-2 bg-background dark:bg-background-dark">Phrase</th>
+            <th class="py-2 bg-background dark:bg-background-dark">Anwendungsbereich</th>
+            <th class="py-2 bg-background dark:bg-background-dark">Aktionen</th>
+            <th class="py-2 text-center bg-background dark:bg-background-dark">Entfernen</th>
         </tr>
     </thead>
     <tbody id="rule-rows">

--- a/templates/partials/_response_rules_table_simple.html
+++ b/templates/partials/_response_rules_table_simple.html
@@ -3,13 +3,13 @@
 {{ formset.non_form_errors }}
 <table class="min-w-full mb-4">
     <thead>
-        <tr class="border-b text-left">
-            <th class="py-2">Name</th>
-            <th class="py-2">Phrase</th>
-            <th class="py-2">Anwendungsbereich</th>
-            <th class="py-2">Aktionen</th>
-            <th class="py-2">DB JSON</th>
-            <th class="py-2 text-center">Entfernen</th>
+        <tr class="border-b text-left bg-background dark:bg-background-dark">
+            <th class="py-2 bg-background dark:bg-background-dark">Name</th>
+            <th class="py-2 bg-background dark:bg-background-dark">Phrase</th>
+            <th class="py-2 bg-background dark:bg-background-dark">Anwendungsbereich</th>
+            <th class="py-2 bg-background dark:bg-background-dark">Aktionen</th>
+            <th class="py-2 bg-background dark:bg-background-dark">DB JSON</th>
+            <th class="py-2 text-center bg-background dark:bg-background-dark">Entfernen</th>
         </tr>
     </thead>
     <tbody>

--- a/templates/partials/anlagen_tab.html
+++ b/templates/partials/anlagen_tab.html
@@ -3,15 +3,15 @@
 <div class="overflow-x-auto">
 <table class="mb-4 w-full text-left">
     <thead>
-        <tr>
-            {% if show_nr %}<th class="px-2 py-1">Nr.</th>{% endif %}
-            <th class="px-2 py-1">Bezeichnung</th>
-            <th class="px-2 py-1">Hochgeladen am</th>
-            <th class="px-2 py-1">Version</th>
-            <th class="px-2 py-1 text-center">Analyse bearbeiten</th>
-            <th class="px-2 py-1 text-center">Vergleich</th>
-            <th class="px-2 py-1 text-center">Geprüft</th>
-            <th class="px-2 py-1 text-center">Verhandlungsfähig</th>
+        <tr class="bg-background dark:bg-background-dark">
+            {% if show_nr %}<th class="px-2 py-1 bg-background dark:bg-background-dark">Nr.</th>{% endif %}
+            <th class="px-2 py-1 bg-background dark:bg-background-dark">Bezeichnung</th>
+            <th class="px-2 py-1 bg-background dark:bg-background-dark">Hochgeladen am</th>
+            <th class="px-2 py-1 bg-background dark:bg-background-dark">Version</th>
+            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Analyse bearbeiten</th>
+            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Vergleich</th>
+            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Geprüft</th>
+            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Verhandlungsfähig</th>
         </tr>
     </thead>
     <tbody id="anlage-table-body">

--- a/templates/partials/negotiable_cell.html
+++ b/templates/partials/negotiable_cell.html
@@ -1,5 +1,5 @@
 {% if row.result_id %}
-<td class="border px-2 text-center negotiable-cell {% if is_negotiable %}bg-success/20 text-success-dark{% else %}bg-error-light text-error-dark{% endif %}{% if override is not none %} border-warning{% endif %}"
+<td class="border px-2 text-center negotiable-cell {% if is_negotiable %}bg-success/20 dark:bg-success-dark/30 text-success-dark dark:text-success-light{% else %}bg-error-light dark:bg-error-dark/30 text-error-dark dark:text-error-light{% endif %}{% if override is not none %} border-warning{% endif %}"
     hx-post="{% url 'hx_toggle_negotiable' result_id=row.result_id %}"
     hx-target="closest td" hx-swap="outerHTML">
     {% if is_negotiable %}

--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -5,15 +5,15 @@
     {% with doc_val=row.doc_result|get_item:field_name ai_val=row.ai_result|get_item:field_name manual_val=row.manual_result|get_item:field_name %}
     <button class="tri-state-icon rounded-full px-2 py-1 text-sm{% if field_name == 'technisch_vorhanden' and row.sub %} opacity-50 pointer-events-none{% endif %}
         {% if manual_val != '' and manual_val != doc_val %}
-            bg-warning/20 text-warning-dark
+            bg-warning/20 dark:bg-warning-dark/30 text-warning-dark dark:text-warning-light
         {% elif manual_val == '' and doc_val != '' and ai_val != '' and doc_val != ai_val %}
-            bg-warning/20 text-warning-dark
+            bg-warning/20 dark:bg-warning-dark/30 text-warning-dark dark:text-warning-light
         {% elif state is True %}
-            bg-success/20 text-success-dark
+            bg-success/20 dark:bg-success-dark/30 text-success-dark dark:text-success-light
         {% elif state is False %}
-            bg-error-light text-error-dark
+            bg-error-light dark:bg-error-dark/30 text-error-dark dark:text-error-light
         {% else %}
-            bg-warning/20 text-warning-dark
+            bg-warning/20 dark:bg-warning-dark/30 text-warning-dark dark:text-warning-light
         {% endif %}"
             data-field-name="{{ field_name }}"
             data-is-manual="{{ is_manual|yesno:'true,false' }}"

--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -2,11 +2,11 @@
 <div class="overflow-x-auto">
 <table id="knowledge-table" class="mb-4 w-full text-left">
     <thead>
-        <tr>
-            <th class="px-2 py-1">Software</th>
-            <th class="px-2 py-1 text-center">Bekannt?</th>
-            <th class="px-2 py-1">Beschreibung</th>
-            <th class="px-2 py-1 text-center">Aktionen</th>
+        <tr class="bg-background dark:bg-background-dark">
+            <th class="px-2 py-1 bg-background dark:bg-background-dark">Software</th>
+            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Bekannt?</th>
+            <th class="px-2 py-1 bg-background dark:bg-background-dark">Beschreibung</th>
+            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Aktionen</th>
         </tr>
     </thead>
     <tbody>

--- a/templates/partials/software_tab_gutachten.html
+++ b/templates/partials/software_tab_gutachten.html
@@ -2,10 +2,10 @@
 <div class="overflow-x-auto">
 <table class="mb-4 w-full text-left">
     <thead>
-        <tr>
-            <th class="px-2 py-1">Software</th>
-            <th class="px-2 py-1">Gutachten</th>
-            <th class="px-2 py-1 text-center">Aktionen</th>
+        <tr class="bg-background dark:bg-background-dark">
+            <th class="px-2 py-1 bg-background dark:bg-background-dark">Software</th>
+            <th class="px-2 py-1 bg-background dark:bg-background-dark">Gutachten</th>
+            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Aktionen</th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Summary
- extend negotiable and review cells with dark theme success/warning/error classes
- apply dark-mode background styling to table headers across partials

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4c5c97814832b90276934c0fbb58f