### PR TITLE
fix: improve form template dark mode styles

### DIFF
--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -10,12 +10,12 @@
             <p class="text-error mb-4">{% trans 'Bitte gültige Zugangsdaten eingeben.' %}</p>
         {% endif %}
         <div class="mb-4">
-            <label for="id_username" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{% trans 'Benutzername' %}</label>
-            <input type="text" name="username" id="id_username" class="w-full border-gray-300 rounded px-3 py-2" autofocus required>
+            <label for="id_username" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{% trans 'Benutzername' %}</label>
+            <input type="text" name="username" id="id_username" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" autofocus required>
         </div>
         <div class="mb-6">
-            <label for="id_password" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">{% trans 'Passwort' %}</label>
-            <input type="password" name="password" id="id_password" class="w-full border-gray-300 rounded px-3 py-2" required>
+            <label for="id_password" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{% trans 'Passwort' %}</label>
+            <input type="password" name="password" id="id_password" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" required>
         </div>
         <input type="hidden" name="next" value="{{ next }}" />
         <button type="submit" class="w-full bg-accent hover:bg-accent-dark text-background font-semibold py-2 px-4 rounded">{% trans 'Anmelden' %}</button>

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -13,11 +13,11 @@
     <input type="hidden" name="active_tab" id="active_tab" value="{{ active_tab }}">
     <input type="hidden" name="phrase_key" id="phrase_key" value="">
     <nav class="border-b border-gray-200 space-x-2 mb-4">
-        <button type="button" data-tab="table" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Tabellen-Parser</button>
-        <button type="button" data-tab="general" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Allgemein</button>
-        <button type="button" data-tab="rules" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Parser-Antwortregeln</button>
-        <button type="button" data-tab="rules2" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Regeln Fallback</button>
-        <button type="button" data-tab="a4" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 border-b-0 rounded-t cursor-pointer">Anlage 4 Parser</button>
+        <button type="button" data-tab="table" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Tabellen-Parser</button>
+        <button type="button" data-tab="general" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Allgemein</button>
+        <button type="button" data-tab="rules" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Parser-Antwortregeln</button>
+        <button type="button" data-tab="rules2" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Regeln Fallback</button>
+        <button type="button" data-tab="a4" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Anlage 4 Parser</button>
     </nav>
     <div id="tab-table" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Tabellen-Parser: Spaltenüberschriften (Alias)</h2>

--- a/templates/admin_anlage4_config.html
+++ b/templates/admin_anlage4_config.html
@@ -22,12 +22,12 @@
             <div id="ges-aliases-container">
                 {% for val in form.instance.gesellschaft_aliases %}
                 <div class="flex mb-2">
-                    <input type="text" name="gesellschaft_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="gesellschaft_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="gesellschaft_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="gesellschaft_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -43,12 +43,12 @@
             <div id="fb-aliases-container">
                 {% for val in form.instance.fachbereich_aliases %}
                 <div class="flex mb-2">
-                    <input type="text" name="fachbereich_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="fachbereich_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="fachbereich_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="fachbereich_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -59,12 +59,12 @@
             <div id="name-aliases-container">
                 {% for val in form.instance.name_aliases %}
                 <div class="flex mb-2">
-                    <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -75,12 +75,12 @@
             <div id="negative-inputs-container">
                 {% for pat in form.instance.negative_patterns %}
                 <div class="flex mb-2">
-                    <input type="text" name="negative_patterns" value="{{ pat }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="negative_patterns" value="{{ pat }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="negative_patterns" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="negative_patterns" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -94,12 +94,12 @@
             <div id="column-inputs-container">
                 {% for col in form.instance.table_columns %}
                 <div class="flex mb-2">
-                    <input type="text" name="table_columns" value="{{ col }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="table_columns" value="{{ col }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="table_columns" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                    <input type="text" name="table_columns" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -125,7 +125,7 @@
                 const input = document.createElement('input');
                 input.type = 'text';
                 input.name = name;
-                input.className = 'mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow';
+                input.className = 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow';
                 const del = document.createElement('button');
                 del.type = 'button';
                 del.textContent = 'x';

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -15,12 +15,12 @@
         <div id="alias-container">
             {% for val in aliases %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                 <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
             {% endfor %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                 <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
         </div>
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const input = document.createElement('input');
         input.type = 'text';
         input.name = 'name_aliases';
-        input.className = 'mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow';
+        input.className = 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow';
         const del = document.createElement('button');
         del.type = 'button';
         del.textContent = 'x';

--- a/templates/anlage2/subquestion_form.html
+++ b/templates/anlage2/subquestion_form.html
@@ -15,12 +15,12 @@
         <div id="alias-container">
             {% for val in aliases %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                 <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
             {% endfor %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow">
+                <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                 <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
         </div>
@@ -40,7 +40,7 @@
             const input = document.createElement('input');
             input.type = 'text';
             input.name = 'name_aliases';
-            input.className = 'mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary flex-grow';
+            input.className = 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow';
             const del = document.createElement('button');
             del.type = 'button';
             del.textContent = 'x';

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,11 +12,11 @@
         {% endif %}
         <div class="mb-4">
             <label for="id_username" class="block text-sm font-medium text-text mb-1">Benutzername</label>
-            <input type="text" name="username" id="id_username" class="w-full border-gray-300 rounded px-3 py-2" autofocus required>
+            <input type="text" name="username" id="id_username" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" autofocus required>
         </div>
         <div class="mb-6">
             <label for="id_password" class="block text-sm font-medium text-text mb-1">Passwort</label>
-            <input type="password" name="password" id="id_password" class="w-full border-gray-300 rounded px-3 py-2" required>
+            <input type="password" name="password" id="id_password" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" required>
         </div>
         <button type="submit" class="w-full bg-accent hover:bg-accent-dark text-background font-semibold py-2 px-4 rounded">Anmelden</button>
     </form>

--- a/templates/partials/_form_input.html
+++ b/templates/partials/_form_input.html
@@ -2,7 +2,7 @@
        name="{{ name }}"
        id="{{ id|default:name }}"
        value="{{ value|default:'' }}"
-       class="{{ base_classes|default:'mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary' }} {{ classes|default:'' }}"
+       class="{{ base_classes|default:'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800' }} {{ classes|default:'' }}"
        {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
        {% if required %}required{% endif %}
        {% if checked %}checked{% endif %}>

--- a/templates/partials/_form_select.html
+++ b/templates/partials/_form_select.html
@@ -1,6 +1,6 @@
 <select name="{{ name }}"
         id="{{ id|default:name }}"
-        class="mt-1 block w-full rounded-md border-gray-300 focus:border-primary focus:ring-primary {{ classes|default:'' }}"
+        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 {{ classes|default:'' }}"
         {% if multiple %}multiple{% endif %}>
   {% if include_blank %}<option value="">{{ include_blank }}</option>{% endif %}
   {% for option in options %}

--- a/templates/partials/_role_tile_form.html
+++ b/templates/partials/_role_tile_form.html
@@ -2,13 +2,13 @@
 <form method="post" class="space-y-4">
     {% csrf_token %}
     <input type="hidden" name="group_id" value="{{ selected_group.id }}">
-    <p class="text-gray-700 dark:text-gray-200">Wähle die sichtbaren Kacheln für diese Rolle aus.</p>
+    <p class="text-gray-700 dark:text-gray-300">Wähle die sichtbaren Kacheln für diese Rolle aus.</p>
     {% for area, items in tiles_by_area.items %}
         <h2 class="text-xl font-semibold mt-4">{{ area.name }}-Dashboard</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
             {% for item in items %}
                 <label class="flex items-center space-x-2">
-                    <input type="checkbox" name="tiles" value="{{ item.tile.id }}" {% if item.checked %}checked{% endif %}>
+                    <input type="checkbox" name="tiles" value="{{ item.tile.id }}" class="rounded border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:ring-primary" {% if item.checked %}checked{% endif %}>
                     <span>{{ item.tile.name }}</span>
                 </label>
             {% empty %}

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -12,15 +12,15 @@
     data-func-id="{{ row.func_id }}" {% if row.sub %}data-sub-id="{{ row.sub_id }}"{% endif %}>
     <td class="border px-2 {% if row.sub %}pl-8{% endif %}">
         {% if not row.sub %}
-        <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 rounded bg-gray-100 hover:bg-gray-200" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
+        <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 dark:text-gray-200 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% else %}
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 dark:text-gray-200 hover:bg-gray-100">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% endif %}
         {% if row.source_text and row.source_text != 'N/A' %}
@@ -42,7 +42,7 @@
     {% endfor %}
     {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}
     <td class="border px-2 text-center action-column">
-        <button type="button" class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 rounded bg-gray-100 hover:bg-gray-200"
+        <button type="button" class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600"
             data-state="robot" title="KI-Prüfung starten"
             data-project-file-id="{{ anlage.pk }}"
             data-function-id="{{ row.func_id }}"

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -60,11 +60,11 @@
                 data-func-id="{{ row.func_id }}" {% if row.sub %}data-sub-id="{{ row.sub_id }}"{% endif %}>
                 <td class="border px-2 {% if row.sub %}pl-8{% endif %}">
                     {% if not row.sub %}
-                    <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 rounded bg-gray-100 hover:bg-gray-200" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
+                    <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 dark:text-gray-200 hover:bg-gray-100">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
@@ -72,7 +72,7 @@
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 rounded bg-background text-gray-700 dark:text-gray-200 hover:bg-gray-100">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
@@ -98,7 +98,7 @@
                 <td class="border px-2 text-center action-column hidden">
                     {% if allow_ai_check %}
                     <button type="button"
-                        class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 rounded bg-gray-100 hover:bg-gray-200"
+                        class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600"
                         data-state="robot" data-popover-content="KI-Prüfung starten"
                         data-project-file-id="{{ anlage.pk }}"
                         data-function-id="{{ row.func_id }}"

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -23,13 +23,13 @@
                 {% if software_list %}
                     {% for name in software_list %}
                     <div class="flex items-center space-x-2">
-                        {% include 'partials/_form_input.html' with name='software_typen' value=name base_classes='flex-grow rounded-md border-gray-300 p-2 focus:border-primary focus:ring-primary' %}
+                        {% include 'partials/_form_input.html' with name='software_typen' value=name base_classes='flex-grow rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800' %}
                         {% include 'partials/_button.html' with type='button' label='Entfernen' variant='danger-light' classes='px-2 py-1 text-sm rounded remove-software-btn' %}
                     </div>
                     {% endfor %}
                 {% else %}
                     <div class="flex items-center space-x-2">
-                        {% include 'partials/_form_input.html' with name='software_typen' base_classes='flex-grow rounded-md border-gray-300 p-2 focus:border-primary focus:ring-primary' %}
+                        {% include 'partials/_form_input.html' with name='software_typen' base_classes='flex-grow rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800' %}
                         {% include 'partials/_button.html' with type='button' label='Entfernen' variant='danger-light' classes='px-2 py-1 text-sm rounded remove-software-btn' %}
                     </div>
                 {% endif %}
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const addSoftwareBtn = document.getElementById('add-software-btn');
     const container = document.getElementById('software-inputs-container');
 
-    const inputTemplate = `{% filter escapejs %}{% include 'partials/_form_input.html' with name='software_typen' base_classes='flex-grow rounded-md border-gray-300 p-2 focus:border-primary focus:ring-primary' %}{% endfilter %}`;
+    const inputTemplate = `{% filter escapejs %}{% include 'partials/_form_input.html' with name='software_typen' base_classes='flex-grow rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800' %}{% endfilter %}`;
     const removeBtnTemplate = `{% filter escapejs %}{% include 'partials/_button.html' with type='button' label='Entfernen' variant='danger-light' classes='px-2 py-1 text-sm rounded remove-software-btn' %}{% endfilter %}`;
 
     function addSoftwareField(value = '') {


### PR DESCRIPTION
## Summary
- extend form input partials with dark mode borders, backgrounds and focus ring offsets
- adjust login and review templates to use combined light/dark utilities
- ensure checkbox and select elements support dark theme

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4c5d9d44c832ba001d64213943412