### PR TITLE
feat: add autoprefixer to postcss build

### DIFF
--- a/theme/static_src/package.json
+++ b/theme/static_src/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.11",
+    "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
     "pa11y": "^9.0.0",
     "postcss": "^8.5.6",

--- a/theme/static_src/postcss.config.js
+++ b/theme/static_src/postcss.config.js
@@ -3,6 +3,7 @@ export default {
     "@tailwindcss/postcss": {},
     "postcss-simple-vars": {},
     "postcss-nested": {},
+    "autoprefixer": {},
   },
 }
 


### PR DESCRIPTION
## Summary
- add autoprefixer as dev dependency
- include autoprefixer in PostCSS plugins

## Testing
- `python manage.py makemigrations --check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c9a7123c832badb01fb017b4231e