### PR TITLE
Ensure CSS build before app startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,11 @@ RUN chmod +x /app/entrypoint.sh
 
 
 # Schritt 7: Frontend-Abhängigkeiten installieren und CSS bauen
-# Wechseln in das Verzeichnis, in dem sich die package.json befindet
 WORKDIR /app/theme/static_src
-RUN npm install
+RUN npm install && npm run build
 
-# Zurück zum Hauptverzeichnis für die Django-Befehle
+# Zurück zum Hauptverzeichnis für die weiteren Django-Befehle
 WORKDIR /app
-
-# TailwindCSS kompilieren
-RUN python manage.py tailwind build
 
 # Schritt 8: Statische Dateien für die Produktion sammeln
 # Django sammelt alle statischen Dateien (inkl. dem kompilierten CSS) an einem Ort

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Dieses Projekt ist eine Django-Anwendung als persönlicher und personalisierter 
 4. Installiere zusätzliche Systempakete wie `pandoc`, damit der Export nach
    DOCX funktioniert. Unter Debian/Ubuntu lautet der Befehl beispielsweise
    `sudo apt-get install pandoc`.
+5. Baue die CSS-Dateien mit Tailwind:
+   ```bash
+   npm --prefix theme/static_src run build
+   ```
 
 ## Entwickler-Setup
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,6 +60,11 @@ PYCODE
   fi
 }
 
+build_static() {
+  echo "Baue CSS mit Tailwind..."
+  npm --prefix theme/static_src run build
+}
+
 if [ "${1:-}" = "migrate" ]; then
   wait_for_db
   run_migrations
@@ -75,6 +80,7 @@ elif [ "${1:-}" = "web" ]; then
     run_migrations
     maybe_create_superuser
   fi
+  build_static
   echo "Starte Gunicorn..."
   exec gunicorn noesis.wsgi:application --bind 0.0.0.0:${PORT:-8080} --workers ${WORKERS:-2}
 else


### PR DESCRIPTION
## Summary
- run Tailwind build in entrypoint before starting Gunicorn
- build CSS assets during Docker image creation
- document `npm --prefix theme/static_src run build` in setup guide

## Testing
- `npm --prefix theme/static_src run build`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4c9a8eab8832b9f5fc9b4ec776650