### PR TITLE
fix: ensure tables scroll on small screens

### DIFF
--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -58,6 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
 {% if funktion %}
 <h2 class="text-xl font-semibold mt-8 mb-2">Unterfragen</h2>
 <a href="{% url 'anlage2_subquestion_new' funktion.id %}" class="inline-block mb-2 px-3 py-1 bg-success text-background rounded">Neue Unterfrage</a>
+<div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">
@@ -85,5 +86,6 @@ document.addEventListener('DOMContentLoaded', () => {
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endif %}
 {% endblock %}

--- a/templates/anlage2/function_list.html
+++ b/templates/anlage2/function_list.html
@@ -7,6 +7,7 @@
     <a href="{% url 'anlage2_function_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
     <a href="{% url 'anlage2_function_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
 </div>
+<div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">
@@ -34,4 +35,5 @@
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -3,6 +3,7 @@
 {% block title %}Anlage 3 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 3 Dateien für {{ projekt.title }} prüfen</h1>
+<div class="overflow-x-auto">
 <table class="mb-4 w-full text-left">
     <thead>
         <tr>
@@ -58,5 +59,6 @@
     {% endfor %}
     </tbody>
 </table>
+</div>
 <a href="{% url 'projekt_detail' projekt.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück</a>
 {% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -3,6 +3,7 @@
 {% block title %}Dashboard{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Meine Aufnahmen</h1>
+<div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
         <tr class="text-left border-b">
@@ -23,4 +24,5 @@
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/parser_rules/rule_list.html
+++ b/templates/parser_rules/rule_list.html
@@ -7,6 +7,7 @@
     <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
     <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
 </div>
+<div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
         <tr class="border-b text-left">
@@ -36,4 +37,5 @@
     {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -5,6 +5,7 @@
 <h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen prüfen</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
+    <div class="overflow-x-auto">
     <table class="table-auto w-full border">
         <thead>
             <tr>
@@ -29,6 +30,7 @@
         {% endfor %}
         </tbody>
     </table>
+    </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <div class="space-x-2 mt-2">
         {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}

--- a/templates/projekt_file_anlage4_review.html
+++ b/templates/projekt_file_anlage4_review.html
@@ -9,6 +9,7 @@
 {% include 'partials/version_switcher.html' %}
 <form method="post" class="space-y-4">
     {% csrf_token %}
+    <div class="overflow-x-auto">
     <table class="table-auto w-full border">
         <thead>
             <tr>
@@ -43,6 +44,7 @@
 {% endfor %}
         </tbody>
     </table>
+    </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
 </form>

--- a/templates/projekt_list.html
+++ b/templates/projekt_list.html
@@ -9,6 +9,7 @@
 {% include 'partials/_button.html' with href=admin_url label='Admin' variant='danger' classes='ml-2' %}
 {% endif %}
 <form method="get" action="{% url 'projekt_list' %}">
+<div class="overflow-x-auto">
 <table class="min-w-full mt-4">
     <thead>
         <tr class="text-left border-b">
@@ -34,6 +35,7 @@
         {% include 'partials/_project_list_rows.html' %}
     </tbody>
 </table>
+</div>
 
 </form>
 <script>

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -29,6 +29,7 @@
 </div>
 {% if parent_gaps %}
 <h2 class="text-xl font-semibold mt-6">Offene Gaps aus Version {{ parent.version }}</h2>
+<div class="overflow-x-auto">
 <table class="table-auto w-full border mt-2">
   <thead>
     <tr>
@@ -61,6 +62,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endif %}
 <div class="mt-4">
   <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück zum Projekt</a>

--- a/templates/version_compare_anlage1.html
+++ b/templates/version_compare_anlage1.html
@@ -4,6 +4,7 @@
 <h1 class="text-2xl font-semibold mb-4">Anlage 1: Version {{ file.version }} mit Vorgänger vergleichen</h1>
 <h2 class="text-xl font-semibold mb-2">GAP-Fragen</h2>
 {% if gap_rows %}
+<div class="overflow-x-auto">
 <table class="table-auto w-full border">
   <thead>
     <tr>
@@ -44,11 +45,13 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% else %}
 <p>Keine offenen Gaps.</p>
 {% endif %}
 
 <h2 class="text-xl font-semibold mt-6">Alle Fragen</h2>
+<div class="overflow-x-auto">
 <table class="table-auto w-full border mt-2">
   <thead>
     <tr>
@@ -75,6 +78,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 <div class="mt-4">
   <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück zum Projekt</a>
 </div>


### PR DESCRIPTION
## Summary
- wrap dashboard and other template tables in `<div class="overflow-x-auto">` for horizontal scrolling
- update various review and admin templates to use the same overflow wrapper

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: KeyboardInterrupt during core/tests/test_general.py)*
- `npx -y playwright screenshot file:///workspace/NOESIS/templates/dashboard.html dashboard_mobile.png --viewport-size=375,667`
- `npx -y playwright screenshot file:///workspace/NOESIS/templates/dashboard.html dashboard_tablet.png --viewport-size=768,1024`


------
https://chatgpt.com/codex/tasks/task_e_68a4c9a3bdc0832bafc64ddb7c3a0cb7