### PR TITLE
fix: restore header layout with mobile menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -20,8 +20,8 @@
 </head>
 <body class="flex flex-col min-h-screen bg-background text-text dark:bg-background-dark dark:text-text-light">
     <header class="bg-header text-background border-b items-center dark:bg-header-dark dark:text-text-light">
-        <div class="container mx-auto p-4">
-            <div class="flex items-center justify-between">
+        <div class="container mx-auto p-4 flex flex-col md:flex-row md:items-center md:justify-between">
+            <div class="flex items-center justify-between w-full md:w-auto">
                 <div class="text-xl font-semibold">
                     <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
                 </div>


### PR DESCRIPTION
## Summary
- restore `justify-between` on header container for correct desktop layout
- integrate burger menu within flexible header structure

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68a4d11fe2e4832bb829564e78666ab8