### PR TITLE
fix: stabilisiere Submit-Button-Erkennung beim Datei-Upload

### DIFF
--- a/static/js/file_upload.js
+++ b/static/js/file_upload.js
@@ -154,7 +154,10 @@
         const form = input ? input.closest('form') : null;
         const container = document.getElementById('preview-container');
         const anlageSelect = document.getElementById('id_anlage_nr');
-        const submitButton = form ? form.querySelector('[type=submit]') : null;
+        // Submit-Button im gesamten Dokument suchen, falls er nicht direkt im Formular liegt
+        const submitButton = form
+            ? (document.querySelector(`[type=submit][form="${form.id}"]`) || form.querySelector('[type=submit]'))
+            : null;
 
         const uploadUrl = form ? (form.getAttribute('hx-post') || form.action) : '';
         const projMatch = uploadUrl.match(/projekte\/(\d+)\//);


### PR DESCRIPTION
## Summary
- finde den Submit-Button auch außerhalb des Formulars, um DOM-Variationen zu tolerieren

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a4dbccca60832b98f271f09a39388d