### PR TITLE
feat: wende gespeichertes Farbschema frühzeitig an

### DIFF
--- a/static/js/theme_toggle.js
+++ b/static/js/theme_toggle.js
@@ -10,13 +10,24 @@
         } else {
             root.classList.remove('dark');
         }
-        localStorage.setItem(storageKey, theme);
+        try {
+            localStorage.setItem(storageKey, theme);
+        } catch (e) {
+            // localStorage ist möglicherweise nicht verfügbar
+        }
     }
 
     function initTheme() {
-        const stored = localStorage.getItem(storageKey);
-        if (stored) {
-            setTheme(stored);
+        if (root.classList.contains('dark')) {
+            return;
+        }
+        try {
+            const stored = localStorage.getItem(storageKey);
+            if (stored === 'dark') {
+                root.classList.add('dark');
+            }
+        } catch (e) {
+            // localStorage ist möglicherweise nicht verfügbar
         }
     }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Neomind Assistant{% endblock %}</title>
+    <script>
+        try {
+            const storedTheme = localStorage.getItem('color-theme');
+            if (storedTheme === 'dark') {
+                document.documentElement.classList.add('dark');
+            }
+        } catch (e) {
+            // localStorage ist möglicherweise nicht verfügbar
+        }
+    </script>
     {% tailwind_css %}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">


### PR DESCRIPTION
## Summary
- setze gespeichertes Farbschema per Inline-Skript vor dem Laden von CSS
- passe Theme-Toggle-Skript als Fallback an und sichere localStorage-Zugriff ab

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a5675f79a0832b8b999c47ff241972