### PR TITLE
Modernisierung der Anlage-1-Review-Ansicht

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -336,6 +336,16 @@ urlpatterns = [
         name="hx_toggle_negotiable",
     ),
     path(
+        "hx/anlage1/toggle/<int:pk>/<int:num>/",
+        views.hx_toggle_anlage1_ok,
+        name="hx_toggle_anlage1_ok",
+    ),
+    path(
+        "hx/anlage1/note/<int:pk>/<int:num>/<str:field>/",
+        views.hx_anlage1_note,
+        name="hx_anlage1_note",
+    ),
+    path(
         "hx/anlage/<int:pk>/toggle/<str:field>/",
         views.hx_toggle_project_file_flag,
         name="hx_toggle_project_file_flag",

--- a/templates/partials/anlage1_negotiable.html
+++ b/templates/partials/anlage1_negotiable.html
@@ -1,0 +1,6 @@
+<button type="button"
+    hx-post="{% url 'hx_toggle_anlage1_ok' anlage.pk num %}"
+    hx-target="this" hx-swap="outerHTML"
+    class="inline-flex items-center justify-center px-2 py-1 border rounded {% if is_ok %}bg-success/20 text-success-dark{% else %}bg-error-light text-error-dark{% endif %}">
+    {% if is_ok %}✅{% else %}❌{% endif %}
+</button>

--- a/templates/partials/anlage1_note.html
+++ b/templates/partials/anlage1_note.html
@@ -1,0 +1,20 @@
+{% load recording_extras %}
+<div id="note-{{ field }}-{{ num }}">
+{% if editing %}
+  <form hx-post="{% url 'hx_anlage1_note' anlage.pk num field %}"
+        hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML" class="space-y-2">
+    <textarea name="text" rows="3" class="w-full border rounded p-2">{{ text }}</textarea>
+    <div class="space-x-2">
+      <button type="submit" class="bg-accent text-background px-2 py-1 rounded">Speichern</button>
+      <button type="button" class="bg-gray-300 text-text px-2 py-1 rounded"
+              hx-get="{% url 'hx_anlage1_note' anlage.pk num field %}"
+              hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML">Abbrechen</button>
+    </div>
+  </form>
+{% else %}
+  <div class="prose max-w-none">{{ text|markdownify }}</div>
+  <button type="button" class="mt-1 bg-gray-200 px-2 py-1 rounded"
+          hx-get="{% url 'hx_anlage1_note' anlage.pk num field %}?edit=1"
+          hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML">Bearbeiten</button>
+{% endif %}
+</div>

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -3,37 +3,27 @@
 {% block title %}Anlage 1 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen prüfen</h1>
-<form method="post" class="space-y-4">
-    {% csrf_token %}
-    <div class="overflow-x-auto">
-    <table class="table-auto w-full border">
-        <thead>
-            <tr>
-                <th class="border px-2">Nr.</th>
-                <th class="border px-2">Frage</th>
-                <th class="border px-2">Antwort</th>
-                <th class="border px-2">Interne Arbeitsanmerkung (Gap-Analyse)</th>
-                <th class="border px-2">(Extern) Anmerkungen für den Fachbereich</th>
-                <th class="border px-2">Verhandlungsfähig</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for num, question, ans, hinweis_field, vorschlag_field, ok_field in qa %}
-            <tr>
-                <td class="border px-2">{{ num }}</td>
-                <td class="border px-2">{{ question }}</td>
-                <td class="border px-2">{{ ans|markdownify }}</td>
-                <td class="border px-2">{{ hinweis_field }}</td>
-                <td class="border px-2">{{ vorschlag_field }}</td>
-                <td class="border px-2">{{ ok_field }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
+<div class="space-y-4">
+    {% for q in qa %}
+    <div class="p-4 border rounded space-y-2">
+        <div class="font-semibold">{{ q.num }}. {{ q.question }}</div>
+        <div class="prose max-w-none">{{ q.answer|markdownify }}</div>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+                <h3 class="text-sm font-semibold">Interne Arbeitsanmerkung</h3>
+                {% include 'partials/anlage1_note.html' with anlage=anlage num=q.num field='hinweis' text=q.hinweis editing=False %}
+            </div>
+            <div>
+                <h3 class="text-sm font-semibold">(Extern) Anmerkungen</h3>
+                {% include 'partials/anlage1_note.html' with anlage=anlage num=q.num field='vorschlag' text=q.vorschlag editing=False %}
+            </div>
+            <div class="flex flex-col">
+                <h3 class="text-sm font-semibold mb-1">Verhandlungsfähig</h3>
+                {% include 'partials/anlage1_negotiable.html' with anlage=anlage num=q.num is_ok=q.ok %}
+            </div>
+        </div>
     </div>
-    <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    <div class="space-x-2 mt-2">
-        {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
-    </div>
-</form>
+    {% endfor %}
+</div>
+<p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
 {% endblock %}


### PR DESCRIPTION
## Zusammenfassung
- Refaktorisierte Anlage‑1 Review mit responsivem Layout und HTMX-Interaktionen
- Neue HTMX-Endpunkte zum Umschalten der Verhandlungsfähigkeit und Bearbeiten von Notizen
- Integration separater Partials für Notiz-Editor und Verhandlungsfähigkeits-Schalter

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fehlschlagend: ModuleNotFoundError: No module named 'selenium'; IntegrityError in Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a56912dcf4832b98bfcef27e7fdb6d