### PR TITLE
fix: improve header readability in dark mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -28,17 +28,17 @@
     {% block extra_head %}{% endblock %}
 </head>
 <body class="flex flex-col min-h-screen bg-background text-text dark:bg-background-dark dark:text-text-light">
-    <header class="bg-header text-background border-b items-center dark:bg-header-dark dark:text-text-light">
+    <header class="bg-header text-text-light border-b items-center">
         <div class="container mx-auto p-4 flex flex-col md:flex-row md:items-center md:justify-between">
             <div class="flex items-center justify-between w-full md:w-auto">
                 <div class="text-xl font-semibold">
                     <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
                 </div>
-                <button id="menu-toggle" class="md:hidden text-background dark:text-text-light" aria-label="Menü umschalten">
+                <button id="menu-toggle" class="md:hidden text-text-light" aria-label="Menü umschalten">
                     <i class="fa-solid fa-bars"></i>
                 </button>
             </div>
-            <nav id="nav-menu" class="hidden flex-col md:flex md:flex-row md:items-center text-background dark:text-text-light space-y-2 md:space-y-0 md:space-x-4 mt-2 md:mt-0">
+            <nav id="nav-menu" class="hidden flex-col md:flex md:flex-row md:items-center text-text-light space-y-2 md:space-y-0 md:space-x-4 mt-2 md:mt-0">
                 <a href="{{ request.META.HTTP_REFERER|default:'#' }}" onclick="history.back(); return false;" class="md:mr-2 hover:underline hover:text-accent-light">&larr; Zurück</a>
                 <a href="/" class="hover:underline hover:text-accent-light">Startseite</a>
                 {% if user.is_authenticated %}
@@ -52,13 +52,13 @@
 
                     <form action="{% url 'logout' %}" method="post" class="md:inline">
                         {% csrf_token %}
-                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent hover:bg-transparent text-background hover:text-accent-light hover:underline px-0 py-0' %}
+                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent hover:bg-transparent text-text-light hover:text-accent-light hover:underline px-0 py-0' %}
                     </form>
 
                 {% else %}
                     <a href="/login/" class="hover:underline hover:text-accent-light">Anmelden</a>
                 {% endif %}
-                <button id="theme-toggle" class="md:ml-2 hover:text-accent-light" aria-label="Farbschema umschalten">
+                <button id="theme-toggle" class="md:ml-2 text-text-light hover:text-accent-light" aria-label="Farbschema umschalten">
                     <i class="fa-solid fa-moon"></i>
                 </button>
             </nav>

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -31,7 +31,7 @@ export default {
         },
         header: {
           DEFAULT: '#0d1b2a',
-          dark: '#1e293b',
+          dark: '#0d1b2a',
         },
         background: {
           DEFAULT: '#ffffff',


### PR DESCRIPTION
## Summary
- ensure header background color consistent across themes
- apply light text color to header buttons and links for dark mode readability

## Testing
- `python3 manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a58d2514d8832baf41bb04d1783d36