### PR TITLE
Fix button color scheme and dark mode contrast

### DIFF
--- a/core/templatetags/ui_extras.py
+++ b/core/templatetags/ui_extras.py
@@ -3,14 +3,13 @@ from django import template
 register = template.Library()
 
 BTN_VARIANTS = {
-    "primary": "bg-primary text-white hover:bg-primary-dark",
-    "secondary": "bg-gray-300 text-black hover:bg-gray-400",
-    "success": "bg-green-600 text-white hover:bg-green-700",
-    "danger": "bg-red-600 text-white hover:bg-red-700",
-    "danger-light": "bg-red-100 hover:bg-red-200 text-red-700",
-    "purple": "bg-purple-600 text-white hover:bg-purple-700",
-    "muted": "bg-gray-200 hover:bg-gray-300 text-gray-800",
-    "disabled": "bg-gray-300 text-gray-500 cursor-not-allowed",
+    "primary": "bg-primary text-text dark:text-text-light hover:bg-primary-dark",
+    "secondary": "bg-background text-text dark:text-text-light hover:bg-background-dark",
+    "success": "bg-success text-text dark:text-text-light hover:bg-success-dark",
+    "danger": "bg-error text-text dark:text-text-light hover:bg-error-dark",
+    "danger-light": "bg-error-light text-error-dark dark:text-error-dark hover:bg-error-lighter",
+    "muted": "bg-background text-text dark:text-text-light hover:bg-background-dark",
+    "disabled": "bg-background text-text dark:text-text-light cursor-not-allowed",
 }
 
 @register.simple_tag

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -10,7 +10,7 @@
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen prüfen</h1>
 <p>
   {% url 'anlage2_supervision' anlage.project.pk as supervision_url %}
-{% include 'partials/_button.html' with href=supervision_url label='Zur neuen Supervisions-Ansicht wechseln' variant='purple' classes='px-3 py-1 rounded' %}
+{% include 'partials/_button.html' with href=supervision_url label='Zur neuen Supervisions-Ansicht wechseln' variant='primary' classes='px-3 py-1 rounded' %}
 </p>
 {% if anlage.processing_status == 'PROCESSING' or anlage.is_verification_running %}
 <div id="anlage-edit-{{ anlage.pk }}" class="p-4 text-center"

--- a/templates/projekt_file_check_result.html
+++ b/templates/projekt_file_check_result.html
@@ -12,7 +12,7 @@
     {% endfor %}
     {% include 'partials/_button.html' with type='submit' label='Neu prüfen' variant='primary' classes='px-4 py-2 rounded ml-2' %}
     {% if anlage.anlage_nr == 2 %}
-    {% include 'partials/_button.html' with type='submit' name='llm' value='1' label='LLM-Check' variant='purple' classes='px-4 py-2 rounded ml-2' %}
+    {% include 'partials/_button.html' with type='submit' name='llm' value='1' label='LLM-Check' variant='primary' classes='px-4 py-2 rounded ml-2' %}
     {% endif %}
 </form>
 <form method="post" class="space-y-4">

--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -3,7 +3,7 @@
     @apply bg-background rounded-lg shadow p-4;
   }
   .badge {
-    @apply inline-block px-2 py-0.5 rounded-full text-xs font-bold;
+    @apply inline-block px-2 py-0.5 rounded-full text-xs font-bold text-text dark:text-text-light;
   }
   .badge-blue {
     @apply bg-accent text-text dark:bg-accent-dark dark:text-text-light;
@@ -21,7 +21,7 @@
     @apply bg-background text-text dark:bg-background-dark dark:text-text-light;
   }
   .alert {
-    @apply p-2 rounded;
+    @apply p-2 rounded text-text dark:text-text-light;
   }
   .alert-success {
     @apply p-2 rounded bg-success text-text dark:bg-success-dark dark:text-text-light;

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -1,14 +1,19 @@
 import forms from '@tailwindcss/forms';
 
+const brandBlue = {
+  DEFAULT: '#2563eb',
+  light: '#3b82f6',
+  dark: '#1e40af',
+};
+
 export const btnVariants = {
-  primary: 'bg-primary text-text hover:bg-primary-dark',
-  secondary: 'bg-background text-text hover:bg-background-dark',
-  success: 'bg-success text-text hover:bg-success-dark',
-  danger: 'bg-error text-text hover:bg-error-dark',
-  'danger-light': 'bg-error-light hover:bg-error-lighter text-error-dark',
-  purple: 'bg-accent text-text hover:bg-accent-dark',
-  muted: 'bg-background hover:bg-background-dark text-text',
-  disabled: 'bg-background text-text cursor-not-allowed',
+  primary: 'bg-primary text-text dark:text-text-light hover:bg-primary-dark',
+  secondary: 'bg-background text-text dark:text-text-light hover:bg-background-dark',
+  success: 'bg-success text-text dark:text-text-light hover:bg-success-dark',
+  danger: 'bg-error text-text dark:text-text-light hover:bg-error-dark',
+  'danger-light': 'bg-error-light text-error-dark dark:text-error-dark hover:bg-error-lighter',
+  muted: 'bg-background text-text dark:text-text-light hover:bg-background-dark',
+  disabled: 'bg-background text-text dark:text-text-light cursor-not-allowed',
 };
 
 export default {
@@ -24,11 +29,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: {
-          DEFAULT: '#4f46e5',
-          light: '#6366f1',
-          dark: '#4338ca',
-        },
+        primary: brandBlue,
         header: {
           DEFAULT: '#0d1b2a',
           dark: '#0d1b2a',
@@ -41,11 +42,7 @@ export default {
           DEFAULT: '#0f172a',
           light: '#f8fafc',
         },
-        accent: {
-          DEFAULT: '#2563eb',
-          light: '#3b82f6',
-          dark: '#1e40af',
-        },
+        accent: brandBlue,
         success: {
           DEFAULT: '#059669',
           dark: '#047857',


### PR DESCRIPTION
## Summary
- unify primary and accent to a single blue and remove purple button variant
- add dark mode text colors for buttons, badges and alerts
- standardize button partials to the primary variant

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a592c5a0f8832ba12bdc5dd1eeadcf