### PR TITLE
fix: use button partial for consistent text colors

### DIFF
--- a/templates/partials/anlage_status.html
+++ b/templates/partials/anlage_status.html
@@ -19,23 +19,21 @@
 {% if anlage.processing_status == 'PROCESSING' or anlage.is_verification_running %}
 <span class="inline-block px-1 py-0.5 rounded bg-gray-500 text-background text-sm opacity-50 pointer-events-none">{% include 'partials/spinner.html' %} Analyse läuft...</span>
 {% elif anlage.processing_status == 'COMPLETE' %}
-<a href="{{ edit_url }}" class="inline-block px-1 py-0.5 rounded bg-primary text-background text-sm hover:bg-primary-dark">Analyse bearbeiten</a>
+{% include 'partials/_button.html' with href=edit_url label='Analyse bearbeiten' variant='primary' classes='px-1 py-0.5 text-sm' %}
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline ml-2">
   {% csrf_token %}
-  <button class="inline-block px-1 py-0.5 rounded bg-primary text-background text-sm hover:bg-primary-dark" title="Erneut analysieren">
-      <i class="fa-solid fa-sync-alt"></i>
-  </button>
+  {% include 'partials/_button.html' with type='submit' label="<i class='fa-solid fa-sync-alt'></i>"|safe variant='primary' classes='px-1 py-0.5 text-sm' attrs='title="Erneut analysieren"' %}
 </form>
 {% elif anlage.processing_status == 'FAILED' %}
 <span class="text-error mr-2">Analyse fehlgeschlagen</span>
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">
   {% csrf_token %}
-  <button class="inline-block px-1 py-0.5 rounded bg-primary text-background text-sm hover:bg-primary-dark">Erneut versuchen</button>
+  {% include 'partials/_button.html' with type='submit' label='Erneut versuchen' variant='primary' classes='px-1 py-0.5 text-sm' %}
 </form>
 {% else %}
 <form method="post" action="{% url 'trigger_file_analysis' anlage.pk %}" class="inline">
   {% csrf_token %}
-  <button class="inline-block px-1 py-0.5 rounded bg-primary text-background text-sm hover:bg-primary-dark">Analyse starten</button>
+  {% include 'partials/_button.html' with type='submit' label='Analyse starten' variant='primary' classes='px-1 py-0.5 text-sm' %}
 </form>
 {% endif %}
 

--- a/templates/partials/anlagen_row.html
+++ b/templates/partials/anlagen_row.html
@@ -17,7 +17,7 @@
                 {{ form.parser_order.errors }}
             </div>
             {% endif %}
-            <button type="submit" class="bg-accent text-text px-2 py-1 rounded mt-2">Speichern</button>
+            {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-2 py-1 mt-2' %}
         </form>
     </td>
 </tr>
@@ -32,7 +32,8 @@
     </td>
     <td class="px-2 py-1 text-center">
         {% if anlage.parent %}
-            <a href="{% url 'compare_versions' anlage.pk %}" class="inline-block px-1 py-0.5 rounded bg-accent text-text text-sm hover:bg-accent-dark">Mit Vorgänger vergleichen</a>
+            {% url 'compare_versions' anlage.pk as compare_url %}
+            {% include 'partials/_button.html' with href=compare_url label='Mit Vorgänger vergleichen' variant='primary' classes='px-1 py-0.5 text-sm' %}
         {% endif %}
     </td>
     <td class="px-2 py-1 text-center">


### PR DESCRIPTION
## Summary
- replace manual buttons in `anlage_status.html` with centralized `_button.html` partial for consistent dark-mode text colors
- refactor `anlagen_row.html` buttons and compare link to use `_button.html`

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a59e23d8a4832b942998705dcdbe49