### PR TITLE
Refine primary button styling

### DIFF
--- a/core/templatetags/ui_extras.py
+++ b/core/templatetags/ui_extras.py
@@ -3,7 +3,7 @@ from django import template
 register = template.Library()
 
 BTN_VARIANTS = {
-    "primary": "bg-primary text-text dark:text-text-light hover:bg-primary-dark",
+    "primary": "bg-primary text-background hover:bg-primary-dark",
     "secondary": "bg-background text-text dark:text-text-light hover:bg-background-dark",
     "success": "bg-success text-text dark:text-text-light hover:bg-success-dark",
     "danger": "bg-error text-text dark:text-text-light hover:bg-error-dark",

--- a/templates/partials/_button.html
+++ b/templates/partials/_button.html
@@ -1,8 +1,8 @@
 {% load ui_extras %}
 {% btn_classes variant as variant_classes %}
 {% if href %}
-<a href="{{ href }}" {% if id %}id="{{ id }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-4 py-2 rounded {{ variant_classes }} {{ classes|default:'' }}">{{ label }}</a>
+<a href="{{ href }}" {% if id %}id="{{ id }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-3 py-1 rounded {{ variant_classes }} {{ classes|default:'' }}">{{ label }}</a>
 {% else %}
-<button type="{{ type|default:'button' }}" {% if id %}id="{{ id }}"{% endif %} {% if name %}name="{{ name }}"{% endif %} {% if formaction %}formaction="{{ formaction }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {% if disabled %}disabled{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-4 py-2 rounded {{ variant_classes }} {{ classes|default:'' }}">{{ label }}</button>
+<button type="{{ type|default:'button' }}" {% if id %}id="{{ id }}"{% endif %} {% if name %}name="{{ name }}"{% endif %} {% if formaction %}formaction="{{ formaction }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {% if disabled %}disabled{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-3 py-1 rounded {{ variant_classes }} {{ classes|default:'' }}">{{ label }}</button>
 {% endif %}
 

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -7,7 +7,7 @@ const brandBlue = {
 };
 
 export const btnVariants = {
-  primary: 'bg-primary text-text dark:text-text-light hover:bg-primary-dark',
+  primary: 'bg-primary text-background hover:bg-primary-dark',
   secondary: 'bg-background text-text dark:text-text-light hover:bg-background-dark',
   success: 'bg-success text-text dark:text-text-light hover:bg-success-dark',
   danger: 'bg-error text-text dark:text-text-light hover:bg-error-dark',


### PR DESCRIPTION
## Summary
- reduce default button padding for a more compact layout
- update primary button variant to white text and adjust Tailwind config accordingly

## Testing
- `npm run build`
- `python manage.py makemigrations --check`
- `grep -o ".text-background{color:var(--color-background)" theme/static/css/dist/styles.css | head`
- `grep -o ".px-3{[^}]*}" theme/static/css/dist/styles.css | head`
- `grep -o ".py-1{[^}]*}" theme/static/css/dist/styles.css | head`


------
https://chatgpt.com/codex/tasks/task_e_68a5a73e66c4832b895746afebc4f868