### PR TITLE
feat: outline secondary button variant

### DIFF
--- a/core/templatetags/ui_extras.py
+++ b/core/templatetags/ui_extras.py
@@ -4,7 +4,7 @@ register = template.Library()
 
 BTN_VARIANTS = {
     "primary": "bg-primary text-text dark:text-text-light hover:bg-primary-dark",
-    "secondary": "bg-background text-text dark:text-text-light hover:bg-background-dark",
+    "secondary": "border border-primary text-primary bg-transparent hover:bg-primary-light",
     "success": "bg-success text-text dark:text-text-light hover:bg-success-dark",
     "danger": "bg-error text-text dark:text-text-light hover:bg-error-dark",
     "danger-light": "bg-error-light text-error-dark dark:text-error-dark hover:bg-error-lighter",

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -3,9 +3,11 @@
 {% block title %}Anlage 2 Konfiguration{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Konfiguration</h1>
+{% url 'admin_anlage2_config_export' as export_url %}
+{% url 'admin_anlage2_config_import' as import_url %}
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_anlage2_config_export' %}" class="px-4 py-2 bg-gray-300 rounded">Exportieren</a>
-    <a href="{% url 'admin_anlage2_config_import' %}" class="px-4 py-2 bg-gray-300 rounded">Importieren</a>
+    {% include 'partials/_button.html' with href=export_url label='Exportieren' variant='secondary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with href=import_url label='Importieren' variant='secondary' classes='px-4 py-2 rounded' %}
 </div>
 <form method="post" class="space-y-4">
     {% csrf_token %}
@@ -88,7 +90,7 @@
         </div>
         <div class="mt-2 space-x-2">
             <!-- HTMX-Funktion vorübergehend deaktiviert -->
-            <button type="button" class="px-3 py-1 bg-gray-300 rounded" disabled>Neue Regel hinzufügen</button>
+            {% include 'partials/_button.html' with type='button' label='Neue Regel hinzufügen' variant='secondary' classes='px-3 py-1 rounded' disabled=True %}
             <button type="submit" name="action" value="save_rules" class="px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
         </div>
     </div>

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -60,5 +60,6 @@
     </tbody>
 </table>
 </div>
-<a href="{% url 'projekt_detail' projekt.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück</a>
+{% url 'projekt_detail' projekt.pk as back_url %}
+{% include 'partials/_button.html' with href=back_url label='Zurück' variant='secondary' classes='px-4 py-2 rounded' %}
 {% endblock %}

--- a/templates/parser_rules/rule_confirm_delete.html
+++ b/templates/parser_rules/rule_confirm_delete.html
@@ -6,6 +6,7 @@
 <form method="post">
     {% csrf_token %}
     <button type="submit" class="px-4 py-2 bg-error text-background rounded">Löschen</button>
-    <a href="{% url 'parser_rule_list' %}" class="ml-2 px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
+    {% url 'parser_rule_list' as cancel_url %}
+    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' classes='ml-2 px-4 py-2 rounded' %}
 </form>
 {% endblock %}

--- a/templates/partials/_response_rule_row_simple.html
+++ b/templates/partials/_response_rule_row_simple.html
@@ -24,7 +24,7 @@
                 </div>
             {% endfor %}
             {{ af.non_form_errors }}
-            <button type="submit" name="action" value="add_action_row" class="px-2 py-1 bg-gray-300 rounded">+</button>
+            {% include 'partials/_button.html' with type='submit' name='action' value='add_action_row' label='+' variant='secondary' classes='px-2 py-1 rounded' %}
             <input type="hidden" name="action_prefix" value="{{ af.prefix }}">
         {% endwith %}
     </td>

--- a/templates/partials/anlage1_note.html
+++ b/templates/partials/anlage1_note.html
@@ -3,18 +3,16 @@
 {% if editing %}
   <form hx-post="{% url 'hx_anlage1_note' anlage.pk num field %}"
         hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML" class="space-y-2">
+    {% url 'hx_anlage1_note' anlage.pk num field as abbrechen_url %}
     <textarea name="text" rows="3" class="w-full border rounded p-2">{{ text }}</textarea>
     <div class="space-x-2">
-      <button type="submit" class="bg-accent text-background px-2 py-1 rounded">Speichern</button>
-      <button type="button" class="bg-gray-300 text-text px-2 py-1 rounded"
-              hx-get="{% url 'hx_anlage1_note' anlage.pk num field %}"
-              hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML">Abbrechen</button>
+      {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-2 py-1 rounded' %}
+      {% include 'partials/_button.html' with type='button' label='Abbrechen' variant='secondary' classes='px-2 py-1 rounded' attrs='hx-get="'|add:abbrechen_url|add:'" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' %}
     </div>
   </form>
 {% else %}
   <div class="prose max-w-none">{{ text|markdownify }}</div>
-  <button type="button" class="mt-1 bg-gray-200 px-2 py-1 rounded"
-          hx-get="{% url 'hx_anlage1_note' anlage.pk num field %}?edit=1"
-          hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML">Bearbeiten</button>
+  {% url 'hx_anlage1_note' anlage.pk num field as edit_url %}
+  {% include 'partials/_button.html' with type='button' label='Bearbeiten' variant='secondary' classes='mt-1 px-2 py-1 rounded' attrs='hx-get="'|add:edit_url|add:'?edit=1" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' %}
 {% endif %}
 </div>

--- a/templates/partials/anlagen_tab.html
+++ b/templates/partials/anlagen_tab.html
@@ -25,13 +25,13 @@
 {% if page_obj %}
 <div class="flex justify-between items-center">
     {% if page_obj.has_previous %}
-        <a hx-get="{{ base_url }}?page={{ page_obj.previous_page_number }}" hx-target="#anlage-tab-content" class="px-2 py-1 bg-gray-300 rounded">«</a>
+        {% include 'partials/_button.html' with type='button' label='«' variant='secondary' classes='px-2 py-1 rounded' attrs='hx-get="'|add:base_url|add:'?page='|add:page_obj.previous_page_number|add:'" hx-target="#anlage-tab-content"' %}
     {% endif %}
     <span>Seite {{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
     {% if page_obj.has_next %}
-        <a hx-get="{{ base_url }}?page={{ page_obj.next_page_number }}" hx-target="#anlage-tab-content" class="px-2 py-1 bg-gray-300 rounded">»</a>
+        {% include 'partials/_button.html' with type='button' label='»' variant='secondary' classes='px-2 py-1 rounded' attrs='hx-get="'|add:base_url|add:'?page='|add:page_obj.next_page_number|add:'" hx-target="#anlage-tab-content"' %}
     {% endif %}
-</div>
+    </div>
 {% endif %}
 </div>
 

--- a/templates/partials/markdown_editor.html
+++ b/templates/partials/markdown_editor.html
@@ -6,8 +6,8 @@
   <div id="{{ id_prefix }}-view" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
   <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border rounded p-2">{{ text }}</textarea>
   <div class="flex space-x-2">
-    <button type="button" id="{{ id_prefix }}-edit" class="bg-accent text-background px-4 py-2 rounded">Bearbeiten</button>
-    <button type="submit" id="{{ id_prefix }}-save" class="hidden bg-accent text-background px-4 py-2 rounded">Speichern</button>
-    <button type="button" id="{{ id_prefix }}-cancel" class="hidden bg-gray-300 text-text px-4 py-2 rounded">Abbrechen</button>
+    {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-edit' label='Bearbeiten' variant='primary' classes='px-4 py-2' %}
+    {% include 'partials/_button.html' with type='submit' id=id_prefix|add:'-save' label='Speichern' variant='primary' classes='hidden px-4 py-2' %}
+    {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-cancel' label='Abbrechen' variant='secondary' classes='hidden px-4 py-2' %}
   </div>
 </div>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -119,8 +119,8 @@
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <div class="space-x-2 mt-2">
-        <button type="reset" id="reset-fields" class="bg-gray-300 text-text px-4 py-2 rounded">Reset</button>
-        <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-text px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>
+        {% include 'partials/_button.html' with type='reset' id='reset-fields' label='Reset' variant='secondary' classes='px-4 py-2 rounded' %}
+        {% include 'partials/_button.html' with type='button' id='btn-reset-all-reviews' label='Alle Bewertungen zurücksetzen' variant='secondary' classes='px-4 py-2 rounded' %}
     </div>
 </form>
 <details>

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -64,7 +64,8 @@
 </table>
 </div>
 {% endif %}
+{% url 'projekt_detail' file.project.pk as project_url %}
 <div class="mt-4">
-  <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück zum Projekt</a>
+  {% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' classes='px-4 py-2 rounded' %}
 </div>
 {% endblock %}

--- a/templates/version_compare_anlage1.html
+++ b/templates/version_compare_anlage1.html
@@ -79,7 +79,8 @@
   </tbody>
 </table>
 </div>
+{% url 'projekt_detail' file.project.pk as project_url %}
 <div class="mt-4">
-  <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück zum Projekt</a>
+  {% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' classes='px-4 py-2 rounded' %}
 </div>
 {% endblock %}

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -8,7 +8,7 @@ const brandBlue = {
 
 export const btnVariants = {
   primary: 'bg-primary text-text dark:text-text-light hover:bg-primary-dark',
-  secondary: 'bg-background text-text dark:text-text-light hover:bg-background-dark',
+  secondary: 'border border-primary text-primary bg-transparent hover:bg-primary-light dark:border-primary-light dark:text-primary-light dark:hover:bg-primary-dark',
   success: 'bg-success text-text dark:text-text-light hover:bg-success-dark',
   danger: 'bg-error text-text dark:text-text-light hover:bg-error-dark',
   'danger-light': 'bg-error-light text-error-dark dark:text-error-dark hover:bg-error-lighter',


### PR DESCRIPTION
## Summary
- style secondary button as outline with primary border
- compile Tailwind assets for new button style
- use secondary button variant for low priority actions

## Testing
- `npm run build`
- `python manage.py makemigrations --check`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68a5a744b2e8832bbdfc6ee32b0c1221