### PR TITLE
fix: unify buttons via shared partial

### DIFF
--- a/core/templates/core/anlage3_rule_confirm_delete.html
+++ b/core/templates/core/anlage3_rule_confirm_delete.html
@@ -5,7 +5,8 @@
 <p>Möchten Sie die Regel für '{{ object.get_field_name_display }}' wirklich löschen?</p>
 <form method="post" class="mt-4 space-x-2">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Bestätigen</button>
-    <a href="{% url 'anlage3_rule_list' %}" class="px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
+    {% include 'partials/_button.html' with type='submit' label='Bestätigen' variant='danger' %}
+    {% url 'anlage3_rule_list' as cancel_url %}
+    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' %}
 </form>
 {% endblock %}

--- a/core/templates/core/supervisionnote_confirm_delete.html
+++ b/core/templates/core/supervisionnote_confirm_delete.html
@@ -5,7 +5,8 @@
 <p>Möchten Sie die Notiz '{{ object.note_text }}' wirklich löschen?</p>
 <form method="post" class="mt-4 space-x-2">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Bestätigen</button>
-    <a href="{% url 'supervisionnote_list' %}" class="px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
+    {% include 'partials/_button.html' with type='submit' label='Bestätigen' variant='danger' %}
+    {% url 'supervisionnote_list' as cancel_url %}
+    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' %}
 </form>
 {% endblock %}

--- a/core/templates/core/zweckkategoriea_confirm_delete.html
+++ b/core/templates/core/zweckkategoriea_confirm_delete.html
@@ -5,7 +5,8 @@
 <p>Möchten Sie den Zweck '{{ object.beschreibung }}' wirklich löschen?</p>
 <form method="post" class="mt-4 space-x-2">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Bestätigen</button>
-    <a href="{% url 'zweckkategoriea_list' %}" class="px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
+    {% include 'partials/_button.html' with type='submit' label='Bestätigen' variant='danger' %}
+    {% url 'zweckkategoriea_list' as cancel_url %}
+    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' %}
 </form>
 {% endblock %}

--- a/core/templates/widgets/actions_json_widget.html
+++ b/core/templates/widgets/actions_json_widget.html
@@ -1,6 +1,6 @@
 <div id="{{ widget.attrs.id }}_container"></div>
 <input type="hidden" name="{{ widget.name }}" id="{{ widget.attrs.id }}" value="{{ widget.value }}">
-<button type="button" class="btn btn-sm btn-secondary mt-1" id="{{ widget.attrs.id }}_add">+ Aktion</button>
+{% include 'partials/_button.html' with type='button' id=widget.attrs.id|add:'_add' label='+ Aktion' variant='secondary' classes='text-sm px-2 py-1 mt-1' %}
 <script>
 (function(){
   const container=document.getElementById('{{ widget.attrs.id }}_container');

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -4,8 +4,10 @@
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Konfiguration</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_anlage2_config_export' %}" class="px-4 py-2 bg-gray-300 rounded">Exportieren</a>
-    <a href="{% url 'admin_anlage2_config_import' %}" class="px-4 py-2 bg-gray-300 rounded">Importieren</a>
+    {% url 'admin_anlage2_config_export' as export_url %}
+    {% url 'admin_anlage2_config_import' as import_url %}
+    {% include 'partials/_button.html' with href=export_url label='Exportieren' variant='secondary' %}
+    {% include 'partials/_button.html' with href=import_url label='Importieren' variant='secondary' %}
 </div>
 <form method="post" class="space-y-4">
     {% csrf_token %}
@@ -88,7 +90,7 @@
         </div>
         <div class="mt-2 space-x-2">
             <!-- HTMX-Funktion vorübergehend deaktiviert -->
-            <button type="button" class="px-3 py-1 bg-gray-300 rounded" disabled>Neue Regel hinzufügen</button>
+            {% include 'partials/_button.html' with type='button' label='Neue Regel hinzufügen' variant='disabled' classes='px-3 py-1' disabled=True %}
             <button type="submit" name="action" value="save_rules" class="px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
         </div>
     </div>

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -20,25 +20,29 @@
             <td class="px-2 py-1 text-center">
                 <form method="post" action="{% url 'projekt_file_check_view' a.pk %}?llm=1">
                     {% csrf_token %}
-                    <button class="bg-primary text-background px-2 py-1 rounded">LLM-Prüfung</button>
+                    {% include 'partials/_button.html' with type='submit' label='LLM-Prüfung' variant='primary' classes='px-2 py-1' %}
                 </form>
             </td>
             <td class="px-2 py-1 text-center">
                 <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
                     {% csrf_token %}
                     <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-success text-background{% else %}bg-gray-300{% endif %}">
-                        {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
-                    </button>
+                    {% if a.manual_reviewed %}
+                        {% include 'partials/_button.html' with type='submit' label='✓' variant='success' classes='px-2 py-1 text-background' %}
+                    {% else %}
+                        {% include 'partials/_button.html' with type='submit' label='✗' variant='secondary' classes='px-2 py-1' %}
+                    {% endif %}
                 </form>
             </td>
             <td class="px-2 py-1 text-center space-x-1">
-                <a href="{% url 'projekt_file_edit_json' a.pk %}" class="bg-primary text-background px-2 py-1 rounded">Analyse bearbeiten</a>
-                <form method="post" action="{% url 'projekt_file_delete_result' a.pk %}" class="inline">
+                {% url 'projekt_file_edit_json' a.pk as edit_url %}
+                {% url 'projekt_file_delete_result' a.pk as delete_url %}
+                {% include 'partials/_button.html' with href=edit_url label='Analyse bearbeiten' variant='primary' classes='px-2 py-1' %}
+                <form method="post" action="{{ delete_url }}" class="inline">
                     {% csrf_token %}
-                    <button class="bg-error text-background px-2 py-1 rounded" onclick="return confirm('Ergebnis wirklich löschen?')">Ergebnis löschen</button>
+                    {% include 'partials/_button.html' with type='submit' label='Ergebnis löschen' variant='danger' classes='px-2 py-1' onclick="return confirm('Ergebnis wirklich löschen?')" %}
                 </form>
-                <a href="{{ a.upload.url }}" class="bg-accent text-background px-2 py-1 rounded">Download</a>
+                {% include 'partials/_button.html' with href=a.upload.url label='Download' variant='secondary' classes='px-2 py-1' %}
             </td>
         </tr>
         {% if a.analysis_json %}
@@ -48,7 +52,8 @@
                     {{ a.analysis_json|tojson|markdownify }}
                 </div>
                 <div class="mt-1 space-x-2">
-                    <a href="{% url 'projekt_file_edit_json' a.pk %}" class="btn-action">Bearbeiten</a>
+                    {% url 'projekt_file_edit_json' a.pk as edit_url %}
+                    {% include 'partials/_button.html' with href=edit_url label='Bearbeiten' variant='primary' classes='text-sm px-2 py-1' %}
                     <a href="{{ a.upload.url }}" class="text-accent-dark dark:text-accent-light underline">Download</a>
                 </div>
             </td>
@@ -60,5 +65,6 @@
     </tbody>
 </table>
 </div>
-<a href="{% url 'projekt_detail' projekt.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück</a>
+{% url 'projekt_detail' projekt.pk as project_detail_url %}
+{% include 'partials/_button.html' with href=project_detail_url label='Zurück' variant='secondary' %}
 {% endblock %}

--- a/templates/parser_rules/rule_confirm_delete.html
+++ b/templates/parser_rules/rule_confirm_delete.html
@@ -5,7 +5,8 @@
 <p>Möchten Sie die Regel "{{ object.regel_name }}" wirklich löschen?</p>
 <form method="post">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-error text-background rounded">Löschen</button>
-    <a href="{% url 'parser_rule_list' %}" class="ml-2 px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
+    {% include 'partials/_button.html' with type='submit' label='Löschen' variant='danger' %}
+    {% url 'parser_rule_list' as cancel_url %}
+    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' classes='ml-2' %}
 </form>
 {% endblock %}

--- a/templates/partials/_response_rule_row_simple.html
+++ b/templates/partials/_response_rule_row_simple.html
@@ -24,7 +24,7 @@
                 </div>
             {% endfor %}
             {{ af.non_form_errors }}
-            <button type="submit" name="action" value="add_action_row" class="px-2 py-1 bg-gray-300 rounded">+</button>
+            {% include 'partials/_button.html' with type='submit' name='action' label='+' variant='secondary' classes='px-2 py-1' attrs='value="add_action_row"' %}
             <input type="hidden" name="action_prefix" value="{{ af.prefix }}">
         {% endwith %}
     </td>

--- a/templates/partials/anlage1_note.html
+++ b/templates/partials/anlage1_note.html
@@ -5,10 +5,9 @@
         hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML" class="space-y-2">
     <textarea name="text" rows="3" class="w-full border rounded p-2">{{ text }}</textarea>
     <div class="space-x-2">
-      <button type="submit" class="bg-accent text-background px-2 py-1 rounded">Speichern</button>
-      <button type="button" class="bg-gray-300 text-text px-2 py-1 rounded"
-              hx-get="{% url 'hx_anlage1_note' anlage.pk num field %}"
-              hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML">Abbrechen</button>
+      {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-2 py-1' %}
+      {% url 'hx_anlage1_note' anlage.pk num field as cancel_url %}
+      {% include 'partials/_button.html' with type='button' label='Abbrechen' variant='secondary' classes='px-2 py-1' attrs='hx-get="'|add:cancel_url|add:'" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' %}
     </div>
   </form>
 {% else %}

--- a/templates/partials/anlagen_tab.html
+++ b/templates/partials/anlagen_tab.html
@@ -25,11 +25,11 @@
 {% if page_obj %}
 <div class="flex justify-between items-center">
     {% if page_obj.has_previous %}
-        <a hx-get="{{ base_url }}?page={{ page_obj.previous_page_number }}" hx-target="#anlage-tab-content" class="px-2 py-1 bg-gray-300 rounded">«</a>
+        {% include 'partials/_button.html' with label='«' variant='secondary' classes='px-2 py-1' attrs='hx-get="'|add:base_url|add:'?page='|add:page_obj.previous_page_number|add:'" hx-target="#anlage-tab-content"' %}
     {% endif %}
     <span>Seite {{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
     {% if page_obj.has_next %}
-        <a hx-get="{{ base_url }}?page={{ page_obj.next_page_number }}" hx-target="#anlage-tab-content" class="px-2 py-1 bg-gray-300 rounded">»</a>
+        {% include 'partials/_button.html' with label='»' variant='secondary' classes='px-2 py-1' attrs='hx-get="'|add:base_url|add:'?page='|add:page_obj.next_page_number|add:'" hx-target="#anlage-tab-content"' %}
     {% endif %}
 </div>
 {% endif %}

--- a/templates/partials/markdown_editor.html
+++ b/templates/partials/markdown_editor.html
@@ -6,8 +6,8 @@
   <div id="{{ id_prefix }}-view" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
   <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border rounded p-2">{{ text }}</textarea>
   <div class="flex space-x-2">
-    <button type="button" id="{{ id_prefix }}-edit" class="bg-accent text-background px-4 py-2 rounded">Bearbeiten</button>
-    <button type="submit" id="{{ id_prefix }}-save" class="hidden bg-accent text-background px-4 py-2 rounded">Speichern</button>
-    <button type="button" id="{{ id_prefix }}-cancel" class="hidden bg-gray-300 text-text px-4 py-2 rounded">Abbrechen</button>
+    {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-edit' label='Bearbeiten' variant='primary' %}
+    {% include 'partials/_button.html' with type='submit' id=id_prefix|add:'-save' label='Speichern' variant='primary' classes='hidden' %}
+    {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-cancel' label='Abbrechen' variant='secondary' classes='hidden' %}
   </div>
 </div>

--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -34,13 +34,16 @@
             </td>
             <td class="px-2 py-1 text-center space-x-2">
             {% if row.entry and row.entry.is_known_by_llm is True %}
-                <a href="{% url 'edit_knowledge_description' row.entry.id %}" class="btn-action">Bearbeiten</a>
-                <a href="{% url 'download_knowledge_as_word' row.entry.id %}" class="btn-action">Export</a>
-                <a href="{% url 'delete_knowledge_entry' row.entry.id %}" class="btn-action-delete">Löschen</a>
+                {% url 'edit_knowledge_description' row.entry.id as edit_url %}
+                {% url 'download_knowledge_as_word' row.entry.id as export_url %}
+                {% url 'delete_knowledge_entry' row.entry.id as delete_url %}
+                {% include 'partials/_button.html' with href=edit_url label='Bearbeiten' variant='primary' classes='text-sm px-2 py-1' %}
+                {% include 'partials/_button.html' with href=export_url label='Export' variant='primary' classes='text-sm px-2 py-1' %}
+                {% include 'partials/_button.html' with href=delete_url label='Löschen' variant='danger' classes='text-sm px-2 py-1' %}
             {% elif row.entry and row.entry.is_known_by_llm is False %}
-                <button type="button" class="btn btn-warning btn-sm retry-check-btn" data-knowledge-id="{{ row.entry.id }}">Erneut prüfen</button>
+                {% include 'partials/_button.html' with type='button' label='Erneut prüfen' variant='primary' classes='text-sm px-2 py-1 retry-check-btn' attrs='data-knowledge-id="'|add:row.entry.id|add:'"' %}
             {% else %}
-                <button type="button" class="btn btn-primary btn-sm start-initial-check-btn" data-knowledge-id="{{ row.entry.id|default:'' }}">Prüfung starten</button>
+                {% include 'partials/_button.html' with type='button' label='Prüfung starten' variant='primary' classes='text-sm px-2 py-1 start-initial-check-btn' attrs='data-knowledge-id="'|add:row.entry.id|add:'"' %}
             {% endif %}
             </td>
         </tr>
@@ -48,4 +51,4 @@
     </tbody>
 </table>
 </div>
-<button id="start-checks" class="bg-success text-background px-4 py-2 rounded">Prüfung starten</button>
+{% include 'partials/_button.html' with id='start-checks' label='Prüfung starten' variant='success' classes='text-background' %}

--- a/templates/partials/software_tab_gutachten.html
+++ b/templates/partials/software_tab_gutachten.html
@@ -24,10 +24,12 @@
             <td class="px-2 py-1 text-center space-x-2">
             {% if row.entry %}
                 {% if row.entry.gutachten %}
-                    <a href="{% url 'gutachten_edit' row.entry.gutachten.id %}" class="btn-action">Bearbeiten</a>
-                    <a href="{% url 'gutachten_download' row.entry.gutachten.id %}" class="btn-action">Download</a>
+                    {% url 'gutachten_edit' row.entry.gutachten.id as edit_url %}
+                    {% url 'gutachten_download' row.entry.gutachten.id as dl_url %}
+                    {% include 'partials/_button.html' with href=edit_url label='Bearbeiten' variant='primary' classes='text-sm px-2 py-1' %}
+                    {% include 'partials/_button.html' with href=dl_url label='Download' variant='primary' classes='text-sm px-2 py-1' %}
                 {% else %}
-                    <button class="btn btn-sm btn-primary generate-gutachten-btn" data-knowledge-id="{{ row.entry.id }}">Gutachten erstellen</button>
+                    {% include 'partials/_button.html' with type='button' label='Gutachten erstellen' variant='primary' classes='text-sm px-2 py-1 generate-gutachten-btn' attrs='data-knowledge-id="'|add:row.entry.id|add:'"' %}
                 {% endif %}
                 <span class="gutachten-status-spinner ms-2" id="gutachten-status-{{ row.entry.id }}"></span>
             {% endif %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -119,8 +119,8 @@
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <div class="space-x-2 mt-2">
-        <button type="reset" id="reset-fields" class="bg-gray-300 text-text px-4 py-2 rounded">Reset</button>
-        <button type="button" id="btn-reset-all-reviews" class="bg-gray-300 text-text px-4 py-2 rounded">Alle Bewertungen zurücksetzen</button>
+        {% include 'partials/_button.html' with type='reset' id='reset-fields' label='Reset' variant='secondary' classes='text-text' %}
+        {% include 'partials/_button.html' with type='button' id='btn-reset-all-reviews' label='Alle Bewertungen zurücksetzen' variant='secondary' classes='text-text' %}
     </div>
 </form>
 <details>

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -65,6 +65,7 @@
 </div>
 {% endif %}
 <div class="mt-4">
-  <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück zum Projekt</a>
+  {% url 'projekt_detail' file.project.pk as project_url %}
+  {% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' %}
 </div>
 {% endblock %}

--- a/templates/version_compare_anlage1.html
+++ b/templates/version_compare_anlage1.html
@@ -80,6 +80,7 @@
 </table>
 </div>
 <div class="mt-4">
-  <a href="{% url 'projekt_detail' file.project.pk %}" class="bg-gray-300 text-text px-4 py-2 rounded">Zurück zum Projekt</a>
+  {% url 'projekt_detail' file.project.pk as project_url %}
+  {% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace manual buttons with `partials/_button.html`
- map actions to primary, secondary or danger variants
- remove legacy `btn` and gray button classes

## Testing
- `python manage.py makemigrations --check`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68a5a74ab6d4832ba5935d648fae3dfc