### PR TITLE
feat: introduce secondary button style

### DIFF
--- a/core/templates/core/anlage3_rule_confirm_delete.html
+++ b/core/templates/core/anlage3_rule_confirm_delete.html
@@ -5,7 +5,8 @@
 <p>Möchten Sie die Regel für '{{ object.get_field_name_display }}' wirklich löschen?</p>
 <form method="post" class="mt-4 space-x-2">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Bestätigen</button>
-    <a href="{% url 'anlage3_rule_list' %}" class="px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
+    {% include 'partials/_button.html' with type='submit' label='Bestätigen' variant='danger' %}
+    {% url 'anlage3_rule_list' as cancel_url %}
+    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' %}
 </form>
 {% endblock %}

--- a/core/templates/core/supervisionnote_confirm_delete.html
+++ b/core/templates/core/supervisionnote_confirm_delete.html
@@ -5,7 +5,8 @@
 <p>Möchten Sie die Notiz '{{ object.note_text }}' wirklich löschen?</p>
 <form method="post" class="mt-4 space-x-2">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Bestätigen</button>
-    <a href="{% url 'supervisionnote_list' %}" class="px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
+    {% include 'partials/_button.html' with type='submit' label='Bestätigen' variant='danger' %}
+    {% url 'supervisionnote_list' as cancel_url %}
+    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' %}
 </form>
 {% endblock %}

--- a/core/templates/core/zweckkategoriea_confirm_delete.html
+++ b/core/templates/core/zweckkategoriea_confirm_delete.html
@@ -5,7 +5,8 @@
 <p>Möchten Sie den Zweck '{{ object.beschreibung }}' wirklich löschen?</p>
 <form method="post" class="mt-4 space-x-2">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Bestätigen</button>
-    <a href="{% url 'zweckkategoriea_list' %}" class="px-4 py-2 bg-gray-300 rounded">Abbrechen</a>
+    {% include 'partials/_button.html' with type='submit' label='Bestätigen' variant='danger' %}
+    {% url 'zweckkategoriea_list' as cancel_url %}
+    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' %}
 </form>
 {% endblock %}

--- a/core/templatetags/ui_extras.py
+++ b/core/templatetags/ui_extras.py
@@ -4,8 +4,8 @@ register = template.Library()
 
 BTN_VARIANTS = {
 
-    "primary": "bg-primary text-background hover:bg-primary-dark",
-    "secondary": "bg-background text-text dark:text-text-light hover:bg-background-dark",
+    "primary": "bg-primary text-background dark:text-text-light hover:bg-primary-dark",
+    "secondary": "border border-primary text-primary bg-transparent hover:bg-primary-light",
 
     "success": "bg-success text-text dark:text-text-light hover:bg-success-dark",
     "danger": "bg-error text-text dark:text-text-light hover:bg-error-dark",

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -6,8 +6,8 @@
 {% url 'admin_anlage2_config_export' as export_url %}
 {% url 'admin_anlage2_config_import' as import_url %}
 <div class="mb-4 space-x-2">
-    {% include 'partials/_button.html' with href=export_url label='Exportieren' variant='secondary' classes='px-4 py-2 rounded' %}
-    {% include 'partials/_button.html' with href=import_url label='Importieren' variant='secondary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with href=export_url label='Exportieren' variant='secondary' %}
+    {% include 'partials/_button.html' with href=import_url label='Importieren' variant='secondary' %}
 </div>
 <form method="post" class="space-y-4">
     {% csrf_token %}

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -61,5 +61,5 @@
 </table>
 </div>
 {% url 'projekt_detail' projekt.pk as back_url %}
-{% include 'partials/_button.html' with href=back_url label='Zurück' variant='secondary' classes='px-4 py-2 rounded' %}
+{% include 'partials/_button.html' with href=back_url label='Zurück' variant='secondary' %}
 {% endblock %}

--- a/templates/edit_project_context.html
+++ b/templates/edit_project_context.html
@@ -6,6 +6,6 @@
     {% csrf_token %}
     {{ form.project_prompt.label_tag }}
     {{ form.project_prompt }}
-    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' %}
 </form>
 {% endblock %}

--- a/templates/gap_notes_form.html
+++ b/templates/gap_notes_form.html
@@ -6,10 +6,10 @@
 <div class="space-x-2 mt-4">
     {% if project_file %}
     {% url 'projekt_file_edit_json' project_file.pk as back_url %}
-    {% include 'partials/_button.html' with href=back_url label='Zurück' variant='secondary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with href=back_url label='Zurück' variant='secondary' %}
     {% else %}
     {% url 'projekt_detail' result.project.pk as back_url %}
-    {% include 'partials/_button.html' with href=back_url label='Zurück' variant='secondary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with href=back_url label='Zurück' variant='secondary' %}
     {% endif %}
 </div>
 {% endblock %}

--- a/templates/parser_rules/rule_confirm_delete.html
+++ b/templates/parser_rules/rule_confirm_delete.html
@@ -5,8 +5,8 @@
 <p>Möchten Sie die Regel "{{ object.regel_name }}" wirklich löschen?</p>
 <form method="post">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-error text-background rounded">Löschen</button>
+    {% include 'partials/_button.html' with type='submit' label='Löschen' variant='danger' %}
     {% url 'parser_rule_list' as cancel_url %}
-    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' classes='ml-2 px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with href=cancel_url label='Abbrechen' variant='secondary' classes='ml-2' %}
 </form>
 {% endblock %}

--- a/templates/partials/markdown_editor.html
+++ b/templates/partials/markdown_editor.html
@@ -6,8 +6,8 @@
   <div id="{{ id_prefix }}-view" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
   <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border rounded p-2">{{ text }}</textarea>
   <div class="flex space-x-2">
-    {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-edit' label='Bearbeiten' variant='primary' classes='px-4 py-2' %}
-    {% include 'partials/_button.html' with type='submit' id=id_prefix|add:'-save' label='Speichern' variant='primary' classes='hidden px-4 py-2' %}
-    {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-cancel' label='Abbrechen' variant='secondary' classes='hidden px-4 py-2' %}
+    {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-edit' label='Bearbeiten' variant='primary' %}
+    {% include 'partials/_button.html' with type='submit' id=id_prefix|add:'-save' label='Speichern' variant='primary' classes='hidden' %}
+    {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-cancel' label='Abbrechen' variant='secondary' classes='hidden' %}
   </div>
 </div>

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -112,15 +112,15 @@
     </table>
     <div class="mb-2">
         {% if allow_ai_check %}
-        {% include 'partials/_button.html' with type='button' id='btn-verify-all' label='Alle Funktionen prüfen 🤖' variant='success' classes='px-2 py-1 rounded' attrs='data-project-id="'|add:anlage.project.pk|add:'"' %}
+        {% include 'partials/_button.html' with type='button' id='btn-verify-all' label='Alle Funktionen prüfen 🤖' variant='success' attrs='data-project-id="'|add:anlage.project.pk|add:'"' %}
         {% endif %}
         <a href="{% url 'projekt_file_parse_anlage2' anlage.pk %}" class="bg-accent text-background px-2 py-1 rounded ml-4">Parser-Analyse starten</a>
     </div>
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     <div class="space-x-2 mt-2">
-        {% include 'partials/_button.html' with type='reset' id='reset-fields' label='Reset' variant='secondary' classes='px-4 py-2 rounded' %}
-        {% include 'partials/_button.html' with type='button' id='btn-reset-all-reviews' label='Alle Bewertungen zurücksetzen' variant='secondary' classes='px-4 py-2 rounded' %}
+        {% include 'partials/_button.html' with type='reset' id='reset-fields' label='Reset' variant='secondary' %}
+        {% include 'partials/_button.html' with type='button' id='btn-reset-all-reviews' label='Alle Bewertungen zurücksetzen' variant='secondary' %}
     </div>
 </form>
 <details>

--- a/templates/projekt_file_anlage3_review.html
+++ b/templates/projekt_file_anlage3_review.html
@@ -7,6 +7,6 @@
     {% csrf_token %}
     {{ form.as_p }}
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage4_review.html
+++ b/templates/projekt_file_anlage4_review.html
@@ -46,6 +46,6 @@
     </table>
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage5_review.html
+++ b/templates/projekt_file_anlage5_review.html
@@ -13,6 +13,6 @@
         {{ form.sonstige }}
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_anlage6_review.html
+++ b/templates/projekt_file_anlage6_review.html
@@ -19,6 +19,6 @@
         {{ form.verhandlungsfaehig.errors }}
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
-    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' %}
 </form>
 {% endblock %}

--- a/templates/projekt_file_check_result.html
+++ b/templates/projekt_file_check_result.html
@@ -10,9 +10,9 @@
             {{ data.label }}
         </label>
     {% endfor %}
-    {% include 'partials/_button.html' with type='submit' label='Neu prüfen' variant='primary' classes='px-4 py-2 rounded ml-2' %}
+    {% include 'partials/_button.html' with type='submit' label='Neu prüfen' variant='primary' classes='ml-2' %}
     {% if anlage.anlage_nr == 2 %}
-    {% include 'partials/_button.html' with type='submit' name='llm' value='1' label='LLM-Check' variant='primary' classes='px-4 py-2 rounded ml-2' %}
+    {% include 'partials/_button.html' with type='submit' name='llm' value='1' label='LLM-Check' variant='primary' classes='ml-2' %}
     {% endif %}
 </form>
 <form method="post" class="space-y-4">
@@ -33,10 +33,10 @@
     </div>
     {% endif %}
     <div class="space-x-2">
-        {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded' %}
+        {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' %}
         {% url 'projekt_detail' anlage.project.pk as detail_url %}
-        {% include 'partials/_button.html' with href=detail_url label='Zurück' variant='secondary' classes='px-4 py-2 rounded' %}
-        {% include 'partials/_button.html' with type='button' id='copy-email' label='E-Mail kopieren' variant='success' classes='px-4 py-2 rounded' %}
+        {% include 'partials/_button.html' with href=detail_url label='Zurück' variant='secondary' %}
+        {% include 'partials/_button.html' with type='button' id='copy-email' label='E-Mail kopieren' variant='success' %}
     </div>
 </form>
 <script>

--- a/templates/projekt_file_form.html
+++ b/templates/projekt_file_form.html
@@ -41,7 +41,7 @@
     {{ form.verhandlungsfaehig }} {{ form.verhandlungsfaehig.label_tag }}
     {{ form.verhandlungsfaehig.errors }}
 </div>
-{% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-4 py-2 rounded mt-4' %}
+{% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='mt-4' %}
 </form>
 {% endblock %}
 

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -14,7 +14,7 @@
             </label>
         {% endfor %}
     </div>
-    {% include 'partials/_button.html' with type='submit' label='LLM starten' variant='primary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='LLM starten' variant='primary' %}
 </form>
 {% if projekt.gutachten_file %}
 <p class="mt-4">

--- a/templates/projekt_upload.html
+++ b/templates/projekt_upload.html
@@ -8,6 +8,6 @@
     {{ form.docx_file.label_tag }}<br>
     {{ form.docx_file }}
     {{ form.docx_file.errors }}
-    {% include 'partials/_button.html' with type='submit' label='Upload' variant='primary' classes='px-4 py-2 rounded' %}
+    {% include 'partials/_button.html' with type='submit' label='Upload' variant='primary' %}
 </form>
 {% endblock %}

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -66,6 +66,6 @@
 {% endif %}
 {% url 'projekt_detail' file.project.pk as project_url %}
 <div class="mt-4">
-  {% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' classes='px-4 py-2 rounded' %}
+{% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' %}
 </div>
 {% endblock %}

--- a/templates/version_compare_anlage1.html
+++ b/templates/version_compare_anlage1.html
@@ -81,6 +81,6 @@
 </div>
 {% url 'projekt_detail' file.project.pk as project_url %}
 <div class="mt-4">
-  {% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' classes='px-4 py-2 rounded' %}
+  {% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' %}
 </div>
 {% endblock %}

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -8,8 +8,8 @@ const brandBlue = {
 
 export const btnVariants = {
 
-  primary: 'bg-primary text-background hover:bg-primary-dark',
-  secondary: 'bg-background text-text dark:text-text-light hover:bg-background-dark',
+  primary: 'bg-primary text-background dark:text-text-light hover:bg-primary-dark',
+  secondary: 'border border-primary text-primary bg-transparent hover:bg-primary-light',
 
   success: 'bg-success text-text dark:text-text-light hover:bg-success-dark',
   danger: 'bg-error text-text dark:text-text-light hover:bg-error-dark',


### PR DESCRIPTION
## Summary
- add dark-mode aware primary button contrast and new outlined secondary variant
- apply new secondary style across confirmation and review templates
- drop custom padding overrides to ensure consistent button sizing

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a5bb460a84832b89627842b5d16a52