### PR TITLE
fix: vereinheitlichte Buttonfarben

### DIFF
--- a/core/templatetags/ui_extras.py
+++ b/core/templatetags/ui_extras.py
@@ -5,7 +5,10 @@ register = template.Library()
 BTN_VARIANTS = {
 
     "primary": "bg-primary text-background dark:text-text-light hover:bg-primary-dark",
-    "secondary": "border border-primary text-primary bg-transparent hover:bg-primary-light",
+    "secondary": (
+        "border border-gray-500 text-gray-700 bg-transparent hover:bg-gray-200 "
+        "dark:border-gray-400 dark:text-text-light dark:hover:bg-gray-700"
+    ),
 
     "success": "bg-success text-text dark:text-text-light hover:bg-success-dark",
     "danger": "bg-error text-text dark:text-text-light hover:bg-error-dark",

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -26,7 +26,7 @@
     {% csrf_token %}
     <label for="status" class="font-semibold">Status:</label>
     {% include 'partials/_form_select.html' with name='status' id='status' options=status_choices value=projekt.status.key classes='' %}
-    {% include 'partials/_button.html' with type='submit' label='Aktualisieren' variant='primary' classes='' %}
+    {% include 'partials/_button.html' with type='submit' label='Aktualisieren' variant='primary' %}
 </form>
 <p class="mb-4">
     <a href="{% url 'projekt_gap_analysis' projekt.pk %}" class="text-primary underline">Gap-Analyse herunterladen</a>

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -9,7 +9,8 @@ const brandBlue = {
 export const btnVariants = {
 
   primary: 'bg-primary text-background dark:text-text-light hover:bg-primary-dark',
-  secondary: 'border border-primary text-primary bg-transparent hover:bg-primary-light',
+  secondary:
+    'border border-gray-500 text-gray-700 bg-transparent hover:bg-gray-200 dark:border-gray-400 dark:text-text-light dark:hover:bg-gray-700',
 
   success: 'bg-success text-text dark:text-text-light hover:bg-success-dark',
   danger: 'bg-error text-text dark:text-text-light hover:bg-error-dark',


### PR DESCRIPTION
## Summary
- ensure the status update and GAP-Bericht buttons share the same primary style
- use a neutral gray scheme for secondary buttons

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a5ca60bd88832ba9440f1811c62c83