### PR TITLE
fix: highlight report download links

### DIFF
--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -29,9 +29,13 @@
     {% include 'partials/_button.html' with type='submit' label='Aktualisieren' variant='primary' classes='' %}
 </form>
 <p class="mb-4">
-    <a href="{% url 'projekt_gap_analysis' projekt.pk %}" class="text-primary underline">Gap-Analyse herunterladen</a>
+    <a href="{% url 'projekt_gap_analysis' projekt.pk %}" class="text-primary underline font-semibold inline-flex items-center">
+        <span class="mr-1">&#x2B07;</span>Gap-Analyse herunterladen
+    </a>
     |
-    <a href="{% url 'projekt_management_summary' projekt.pk %}" class="text-primary underline">Management Summary herunterladen</a>
+    <a href="{% url 'projekt_management_summary' projekt.pk %}" class="text-primary underline font-semibold inline-flex items-center">
+        <span class="mr-1">&#x2B07;</span>Management Summary herunterladen
+    </a>
 </p>
 <p class="mb-4">
     {% if can_gap_report %}


### PR DESCRIPTION
## Summary
- improve visibility of Gap-Analyse and Management Summary download links by adding arrow icons and bolder styling

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ca7e5c3c832bacbd82a16819a893