### PR TITLE
Add arrow icon to status dropdown

### DIFF
--- a/templates/partials/_form_select.html
+++ b/templates/partials/_form_select.html
@@ -1,6 +1,7 @@
+{% if not multiple %}<div class="relative">{% endif %}
 <select name="{{ name }}"
         id="{{ id|default:name }}"
-        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 {{ classes|default:'' }}"
+        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 {{ classes|default:'' }}{% if not multiple %} appearance-none pr-8{% endif %}"
         {% if multiple %}multiple{% endif %}>
   {% if include_blank %}<option value="">{{ include_blank }}</option>{% endif %}
   {% for option in options %}
@@ -9,4 +10,12 @@
     {% endwith %}
   {% endfor %}
 </select>
+{% if not multiple %}
+  <div class="pointer-events-none absolute inset-y-0 right-2 flex items-center">
+    <svg class="h-4 w-4 text-gray-500 dark:text-gray-300" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"/>
+    </svg>
+  </div>
+</div>
+{% endif %}
 


### PR DESCRIPTION
## Summary
- add custom SVG arrow to the generic select template so status dropdowns display an arrow

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68a5ca8c7120832ba1cfb9c9bbb19311