### PR TITLE
feat: auslagerung der initialpruefung

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -259,6 +259,11 @@ urlpatterns = [
     path("work/projekte/", views.projekt_list, name="projekt_list"),
     path("work/projekte/neu/", views.projekt_create, name="projekt_create"),
     path("work/projekte/<int:pk>/", views.projekt_detail, name="projekt_detail"),
+    path(
+        "work/projekte/<int:pk>/initial-pruefung/",
+        views.projekt_initial_pruefung,
+        name="projekt_initial_pruefung",
+    ),
     path("work/projekte/<int:pk>/bearbeiten/", views.projekt_edit, name="projekt_edit"),
     path(
         "work/projekte/<int:pk>/context/",

--- a/core/views.py
+++ b/core/views.py
@@ -3008,6 +3008,10 @@ def projekt_detail(request, pk):
             checked += 1
         knowledge_rows.append({"name": name, "entry": entry})
 
+    first_gutachten = (
+        Gutachten.objects.filter(software_knowledge__project=projekt).first()
+    )
+
     # Letzte Aktivitäten aus Statusänderungen und Dateiuploads sammeln
     activities = []
     for h in projekt.status_history.order_by("-changed_at")[:5]:
@@ -3051,8 +3055,18 @@ def projekt_detail(request, pk):
         "software_list": software_list,
         "activities": activities,
         "can_gap_report": can_gap_report,
+        "first_gutachten": first_gutachten,
     }
     return render(request, "projekt_detail.html", context)
+
+
+@login_required
+def projekt_initial_pruefung(request, pk):
+    projekt = get_object_or_404(BVProject, pk=pk)
+    if not _user_can_edit_project(request.user, projekt):
+        return HttpResponseForbidden("Nicht berechtigt")
+    context = {"projekt": projekt}
+    return render(request, "projekt_initial_pruefung.html", context)
 
 
 @login_required

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -66,18 +66,15 @@
 
 
 <div class="card">
-<h2 class="text-xl font-semibold mb-4">Initial-Prüfung der Software-Komponenten</h2>
-<nav class="flex space-x-2 mb-4">
-  <button class="software-tab px-3 py-1 border-b-2 border-primary text-primary"
-          hx-get="{% url 'hx_project_software_tab' projekt.pk 'tech' %}"
-          hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
-          data-tab="tech">Technische Prüfung</button>
-  <button class="software-tab px-3 py-1 border-b-2 border-transparent text-gray-600 dark:text-gray-300"
-          hx-get="{% url 'hx_project_software_tab' projekt.pk 'gutachten' %}"
-          hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
-          data-tab="gutachten">Gutachten</button>
-</nav>
-<div id="software-tab-content" hx-get="{% url 'hx_project_software_tab' projekt.pk 'tech' %}" hx-trigger="load"></div>
+<h2 class="text-xl font-semibold mb-4">Prüfungen</h2>
+<div class="space-x-2">
+    {% url 'projekt_initial_pruefung' projekt.pk as init_url %}
+    {% include 'partials/_button.html' with href=init_url label='Initial-Pr\u00fcfung' variant='primary' %}
+    {% if first_gutachten %}
+        {% url 'gutachten_view' first_gutachten.id as gutachten_url %}
+        {% include 'partials/_button.html' with href=gutachten_url label='Gutachten anzeigen' variant='secondary' %}
+    {% endif %}
+</div>
 </div>
 </div>
 <div class="hidden lg:block lg:w-1/3 mt-4 lg:mt-0">

--- a/templates/projekt_initial_pruefung.html
+++ b/templates/projekt_initial_pruefung.html
@@ -1,0 +1,114 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load recording_extras %}
+{% block title %}Initial-Prüfung {{ projekt.title }}{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Initial-Prüfung der Software-Komponenten</h1>
+<div class="card">
+<nav class="flex space-x-2 mb-4">
+  <button class="software-tab px-3 py-1 border-b-2 border-primary text-primary"
+          hx-get="{% url 'hx_project_software_tab' projekt.pk 'tech' %}"
+          hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
+          data-tab="tech">Technische Prüfung</button>
+  <button class="software-tab px-3 py-1 border-b-2 border-transparent text-gray-600 dark:text-gray-300"
+          hx-get="{% url 'hx_project_software_tab' projekt.pk 'gutachten' %}"
+          hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
+          data-tab="gutachten">Gutachten</button>
+</nav>
+<div id="software-tab-content" hx-get="{% url 'hx_project_software_tab' projekt.pk 'tech' %}" hx-trigger="load"></div>
+</div>
+<script>
+function attachHandlers(){
+ document.querySelectorAll('.generate-gutachten-btn').forEach(button=>{
+   button.addEventListener('click',function(event){
+     event.preventDefault();
+     const knowledgeId=this.dataset.knowledgeId;
+     const url='{% url 'ajax_start_gutachten_generation' projekt.pk %}';
+     const body=new FormData();
+     body.append('knowledge_id',knowledgeId);
+     this.classList.add('disabled');
+     const status=document.getElementById('gutachten-status-'+knowledgeId);
+     showSpinner(this, 'Erstelle...');
+     fetch(url,{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body:body})
+       .then(r=>r.json()).then(data=>{
+         const tid=data.task_id;
+         const tmpl='{% url "ajax_check_task_status" "dummy" %}';
+         const iv=setInterval(()=>{
+           fetch(tmpl.replace('dummy',tid)).then(r=>r.json()).then(d=>{
+             if(d.status==='SUCCESS'){
+               clearInterval(iv);location.reload();
+             }else if(d.status==='FAIL'){
+               clearInterval(iv);
+               if(status){status.textContent='Fehler';}
+               hideSpinner(button);
+               button.classList.remove('disabled');
+             }
+           });
+         },3000);
+       }).catch(()=>{
+         if(status){status.textContent='Fehler';}
+         hideSpinner(button);
+         button.classList.remove('disabled');
+       });
+   });
+ });
+ document.querySelectorAll('.retry-check-btn, .start-initial-check-btn').forEach(btn=>{
+   btn.addEventListener('click',function(){
+     const knowledgeId=this.dataset.knowledgeId;
+     const body=new FormData();
+     body.append('knowledge_id',knowledgeId);
+     showSpinner(btn, 'Prüfung...');
+     fetch('{% url "ajax_rerun_initial_check" %}',{method:'POST',headers:{'X-CSRFToken':getCookie('csrftoken')},body:body})
+       .then(r=>r.json()).then(data=>{
+         const tid=data.task_id;
+         const tmpl='{% url "ajax_check_task_status" "dummy" %}';
+         const iv=setInterval(()=>{
+           fetch(tmpl.replace('dummy',tid)).then(r=>r.json()).then(d=>{
+             if(d.status==='SUCCESS'||d.status==='FAIL'){
+               clearInterval(iv);window.location.reload();
+             }
+           });
+         },3000);
+       }).catch(()=>{hideSpinner(btn);});
+   });
+ });
+ const start=document.getElementById('start-checks');
+ if(start){start.addEventListener('click',startChecks);}
+}
+function startChecks(){
+ const btn=document.getElementById('start-checks');
+ showSpinner(btn, 'Prüfung läuft...');
+ fetch('{% url 'ajax_start_initial_checks' projekt.pk %}',{
+   method:'POST',
+   headers:{'X-CSRFToken':getCookie('csrftoken')}
+ }).then(r=>r.json()).then(data=>{
+   const tasks=data.tasks||[];
+   const tmpl='{% url "ajax_check_task_status" "dummy" %}';
+   let done=0;
+   tasks.forEach(t=>{
+     const iv=setInterval(()=>{
+       fetch(tmpl.replace('dummy',t.task_id)).then(r=>r.json()).then(d=>{
+         if(d.status==='SUCCESS'||d.status==='FAIL'){
+            clearInterval(iv);done++;
+            if(done===tasks.length){window.location.reload();}
+         }
+       });
+     },3000);
+   });
+ }).catch(()=>{alert('Fehler beim Start'); hideSpinner(btn);});
+}
+document.addEventListener('DOMContentLoaded',attachHandlers);
+document.addEventListener('htmx:afterSwap',attachHandlers);
+document.addEventListener('htmx:beforeRequest',function(e){
+  const t=e.target;
+  if(t.classList.contains('software-tab')){
+    document.querySelectorAll('.software-tab').forEach(b=>{
+      b.classList.remove('border-primary','text-primary');
+      b.classList.add('border-transparent','text-gray-600','dark:text-gray-300');
+    });
+    t.classList.remove('border-transparent','text-gray-600','dark:text-gray-300');
+    t.classList.add('border-primary','text-primary');
+  }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create dedicated view and url for initial project checks
- move technical check and gutachten tabs into new template
- link initial check and existing gutachten view from project detail

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_selenium` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68a5dbffb008832ba14982f6fd44b795