### PR TITLE
fix: improve dark mode form styling

### DIFF
--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -11,11 +11,11 @@
         {% endif %}
         <div class="mb-4">
             <label for="id_username" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{% trans 'Benutzername' %}</label>
-            <input type="text" name="username" id="id_username" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" autofocus required>
+             <input type="text" name="username" id="id_username" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" autofocus required>
         </div>
         <div class="mb-6">
             <label for="id_password" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{% trans 'Passwort' %}</label>
-            <input type="password" name="password" id="id_password" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" required>
+             <input type="password" name="password" id="id_password" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" required>
         </div>
         <input type="hidden" name="next" value="{{ next }}" />
         <button type="submit" class="w-full bg-accent hover:bg-accent-dark text-background font-semibold py-2 px-4 rounded">{% trans 'Anmelden' %}</button>

--- a/templates/admin_anlage1.html
+++ b/templates/admin_anlage1.html
@@ -33,18 +33,18 @@
                     <input type="checkbox" name="delete{{ q.id }}">
                 </td>
                 <td class="py-1">
-                    <textarea name="text{{ q.id }}" rows="2" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100">{{ q.text }}</textarea>
+                      <textarea name="text{{ q.id }}" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ q.text }}</textarea>
                 </td>
             </tr>
             <tr class="border-b align-top text-sm">
                 <td colspan="4" class="py-1">
                     {% for v in q.variants.all %}
                         <div class="flex items-center mb-1">
-                            <textarea name="variant{{ v.id }}" rows="1" class="border rounded p-2 flex-1 text-gray-900 dark:text-gray-100">{{ v.text }}</textarea>
+                              <textarea name="variant{{ v.id }}" rows="1" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 flex-1 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ v.text }}</textarea>
                             <label class="ml-2 text-sm"><input type="checkbox" name="delvar{{ v.id }}"> löschen</label>
                         </div>
                     {% endfor %}
-                    <textarea name="new_variant{{ q.id }}" rows="1" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100" placeholder="Neue Variante"></textarea>
+                      <textarea name="new_variant{{ q.id }}" rows="1" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" placeholder="Neue Variante"></textarea>
                 </td>
             </tr>
         {% endfor %}
@@ -58,7 +58,7 @@
             </td>
             <td class="py-1 text-center"></td>
             <td class="py-1">
-                <textarea name="new_text" rows="2" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100"></textarea>
+                  <textarea name="new_text" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800"></textarea>
             </td>
         </tr>
         </tbody>

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -42,13 +42,13 @@
             {% endfor %}
                 <tr class="border-b text-sm">
                     <td class="py-1">
-                        <select name="new_field" class="border rounded p-2 w-full">
+                          <select name="new_field" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">
                         {% for val, label in choices %}
                             <option value="{{ val }}">{{ label }}</option>
                         {% endfor %}
                         </select>
                     </td>
-                    <td class="py-1"><input type="text" name="new_text" class="border rounded p-2 w-full"></td>
+                      <td class="py-1"><input type="text" name="new_text" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800"></td>
                     <td></td>
                 </tr>
             </tbody>

--- a/templates/admin_anlage4_config.html
+++ b/templates/admin_anlage4_config.html
@@ -22,12 +22,12 @@
             <div id="ges-aliases-container">
                 {% for val in form.instance.gesellschaft_aliases %}
                 <div class="flex mb-2">
-                    <input type="text" name="gesellschaft_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="gesellschaft_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="gesellschaft_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="gesellschaft_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -43,12 +43,12 @@
             <div id="fb-aliases-container">
                 {% for val in form.instance.fachbereich_aliases %}
                 <div class="flex mb-2">
-                    <input type="text" name="fachbereich_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="fachbereich_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="fachbereich_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="fachbereich_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -59,12 +59,12 @@
             <div id="name-aliases-container">
                 {% for val in form.instance.name_aliases %}
                 <div class="flex mb-2">
-                    <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -75,12 +75,12 @@
             <div id="negative-inputs-container">
                 {% for pat in form.instance.negative_patterns %}
                 <div class="flex mb-2">
-                    <input type="text" name="negative_patterns" value="{{ pat }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="negative_patterns" value="{{ pat }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="negative_patterns" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="negative_patterns" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -94,12 +94,12 @@
             <div id="column-inputs-container">
                 {% for col in form.instance.table_columns %}
                 <div class="flex mb-2">
-                    <input type="text" name="table_columns" value="{{ col }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="table_columns" value="{{ col }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
-                    <input type="text" name="table_columns" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                      <input type="text" name="table_columns" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                     <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
                 </div>
             </div>
@@ -125,7 +125,7 @@
                 const input = document.createElement('input');
                 input.type = 'text';
                 input.name = name;
-                input.className = 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow';
+                input.className = 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow';
                 const del = document.createElement('button');
                 del.type = 'button';
                 del.textContent = 'x';

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -35,7 +35,7 @@
                     <form method="post" class="space-y-2">
                         {% csrf_token %}
                         <input type="hidden" name="pk" value="{{ p.id }}">
-                        <select name="role" class="border rounded p-2 w-full">
+                          <select name="role" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">
                             <option value="" {% if not p.role %}selected{% endif %}>Standard</option>
                             {% for r in roles %}
                                 <option value="{{ r.id }}" {% if p.role_id == r.id %}selected{% endif %}>{{ r.name }}</option>
@@ -55,7 +55,7 @@
                         </label>
                 </td>
                 <td class="py-1">
-                        <textarea name="text" rows="4" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100">{{ p.text }}</textarea>
+                          <textarea name="text" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ p.text }}</textarea>
                         <button name="action" value="save" class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>
@@ -78,7 +78,7 @@
                     <form method="post" class="space-y-2">
                         {% csrf_token %}
                         <input type="hidden" name="action" value="save_a4_config">
-                        <textarea name="prompt_template" rows="4" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100">{{ a4_config.prompt_template }}</textarea>
+                          <textarea name="prompt_template" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ a4_config.prompt_template }}</textarea>
                         <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>
@@ -90,7 +90,7 @@
                         {% csrf_token %}
                         <input type="hidden" name="action" value="save_a4_parser_prompts">
                         <input type="hidden" name="field" value="prompt_plausibility">
-                        <textarea name="prompt_text" rows="4" class="border rounded p-2 w-full text-gray-900 dark:text-gray-100">{{ a4_parser.prompt_plausibility }}</textarea>
+                          <textarea name="prompt_text" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ a4_parser.prompt_plausibility }}</textarea>
                         <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>

--- a/templates/admin_roles.html
+++ b/templates/admin_roles.html
@@ -4,7 +4,7 @@
 <h1 class="text-2xl font-semibold mb-4">Rollen & Kacheln</h1>
 <div class="mb-4">
     <label for="group-select" class="mr-2">Rolle:</label>
-    <select id="group-select" class="border rounded p-1">
+      <select id="group-select" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-1 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">
         <option value="">Rolle wählen</option>
         {% for g in groups %}
             <option value="{{ g.id }}" {% if selected_group and g.id == selected_group.id %}selected{% endif %}>{{ g.name }}</option>

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -15,12 +15,12 @@
         <div id="alias-container">
             {% for val in aliases %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                  <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                 <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
             {% endfor %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                  <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                 <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
         </div>
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const input = document.createElement('input');
         input.type = 'text';
         input.name = 'name_aliases';
-        input.className = 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow';
+          input.className = 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow';
         const del = document.createElement('button');
         del.type = 'button';
         del.textContent = 'x';

--- a/templates/anlage2/subquestion_form.html
+++ b/templates/anlage2/subquestion_form.html
@@ -15,12 +15,12 @@
         <div id="alias-container">
             {% for val in aliases %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                  <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                 <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
             {% endfor %}
             <div class="flex mb-2">
-                <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
+                  <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
                 <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
             </div>
         </div>
@@ -40,7 +40,7 @@
             const input = document.createElement('input');
             input.type = 'text';
             input.name = 'name_aliases';
-            input.className = 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow';
+              input.className = 'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow';
             const del = document.createElement('button');
             del.type = 'button';
             del.textContent = 'x';

--- a/templates/edit_ki_justification.html
+++ b/templates/edit_ki_justification.html
@@ -4,7 +4,7 @@
 <h1 class="text-2xl font-semibold mb-4">KI-Begründung bearbeiten</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
-    <textarea name="ki_begruendung" rows="5" class="w-full border rounded p-2">{{ ki_begruendung }}</textarea>
+      <textarea name="ki_begruendung" rows="5" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ ki_begruendung }}</textarea>
     {% if object_type == 'function' %}
     <input type="hidden" name="function" value="{{ object.id }}">
     {% else %}

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -12,7 +12,7 @@
 {% if projekt.gutachten_function_note %}
 <div class="mt-4">
     <label class="font-semibold">LLM-Vorschlag:</label>
-    <textarea class="border rounded w-full p-2" rows="6" readonly>{{ projekt.gutachten_function_note }}</textarea>
+      <textarea class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" rows="6" readonly>{{ projekt.gutachten_function_note }}</textarea>
 </div>
 {% endif %}
 <form id="llm-check-form" class="mt-4">

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,11 +12,11 @@
         {% endif %}
         <div class="mb-4">
             <label for="id_username" class="block text-sm font-medium text-text mb-1">Benutzername</label>
-            <input type="text" name="username" id="id_username" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" autofocus required>
+             <input type="text" name="username" id="id_username" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" autofocus required>
         </div>
         <div class="mb-6">
             <label for="id_password" class="block text-sm font-medium text-text mb-1">Passwort</label>
-            <input type="password" name="password" id="id_password" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" required>
+             <input type="password" name="password" id="id_password" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" required>
         </div>
         <button type="submit" class="w-full bg-accent hover:bg-accent-dark text-background font-semibold py-2 px-4 rounded">Anmelden</button>
     </form>

--- a/templates/partials/_form_input.html
+++ b/templates/partials/_form_input.html
@@ -2,7 +2,7 @@
        name="{{ name }}"
        id="{{ id|default:name }}"
        value="{{ value|default:'' }}"
-       class="{{ base_classes|default:'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800' }} {{ classes|default:'' }}"
+       class="{{ base_classes|default:'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800' }} {{ classes|default:'' }}"
        {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
        {% if required %}required{% endif %}
        {% if checked %}checked{% endif %}>

--- a/templates/partials/_form_select.html
+++ b/templates/partials/_form_select.html
@@ -1,7 +1,7 @@
 {% if not multiple %}<div class="relative">{% endif %}
 <select name="{{ name }}"
         id="{{ id|default:name }}"
-        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 {{ classes|default:'' }}{% if not multiple %} appearance-none pr-8{% endif %}"
+        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 {{ classes|default:'' }}{% if not multiple %} appearance-none pr-8{% endif %}"
         {% if multiple %}multiple{% endif %}>
   {% if include_blank %}<option value="">{{ include_blank }}</option>{% endif %}
   {% for option in options %}

--- a/templates/partials/anlage1_note.html
+++ b/templates/partials/anlage1_note.html
@@ -4,7 +4,7 @@
   <form hx-post="{% url 'hx_anlage1_note' anlage.pk num field %}"
         hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML" class="space-y-2">
     {% url 'hx_anlage1_note' anlage.pk num field as abbrechen_url %}
-    <textarea name="text" rows="3" class="w-full border rounded p-2">{{ text }}</textarea>
+      <textarea name="text" rows="3" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
     <div class="space-x-2">
       {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-2 py-1 rounded' %}
       {% include 'partials/_button.html' with type='button' label='Abbrechen' variant='secondary' classes='px-2 py-1 rounded' attrs='hx-get="'|add:abbrechen_url|add:'" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' %}

--- a/templates/partials/anlagen_assign_row.html
+++ b/templates/partials/anlagen_assign_row.html
@@ -4,7 +4,7 @@
             {% csrf_token %}
             <input type="hidden" name="temp_id" value="{{ temp_id }}">
             <span>Zu welcher Anlage gehört '{{ filename }}'?</span>
-            <select name="anlage_nr" class="border rounded p-1 mx-2">
+              <select name="anlage_nr" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-1 mx-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">
                 {% for n in numbers %}
                 <option value="{{ n }}">{{ n }}</option>
                 {% endfor %}

--- a/templates/partials/markdown_editor.html
+++ b/templates/partials/markdown_editor.html
@@ -4,7 +4,7 @@
   <label for="{{ id_prefix }}-textarea" class="font-semibold">{{ label }}</label>
   {% endif %}
   <div id="{{ id_prefix }}-view" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
-  <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border rounded p-2">{{ text }}</textarea>
+    <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
   <div class="flex space-x-2">
     {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-edit' label='Bearbeiten' variant='primary' %}
     {% include 'partials/_button.html' with type='submit' id=id_prefix|add:'-save' label='Speichern' variant='primary' classes='hidden' %}

--- a/templates/partials/supervision_row_content.html
+++ b/templates/partials/supervision_row_content.html
@@ -33,7 +33,7 @@
       {% endfor %}
     </div>
     <form hx-post="{% url 'hx_supervision_save_notes' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="space-y-2">
-      <textarea name="notes" rows="2" class="border rounded w-full p-2">{{ row.notes }}</textarea>
+        <textarea name="notes" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ row.notes }}</textarea>
       <div class="space-x-2">
         <button type="submit" class="bg-accent text-text px-2 py-1 rounded">Speichern</button>
         <button type="button"

--- a/templates/partials/version_switcher.html
+++ b/templates/partials/version_switcher.html
@@ -1,7 +1,7 @@
 {% if versions|length > 1 %}
 <div class="mb-4">
   <label for="version-select" class="font-semibold mr-2">Version:</label>
-  <select id="version-select" class="border rounded p-1">
+    <select id="version-select" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-1 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">
     {% for v in versions %}
       <option value="{{ v.version }}" {% if v.version == current_version %}selected{% endif %}>Version {{ v.version }}</option>
     {% endfor %}

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -104,10 +104,10 @@ function renderLLM(data){
  if(!data.ist_llm_geprueft && !data.llm_initial_output){
    sec.innerHTML=`<button id="run" class="bg-success text-background px-4 py-2 rounded">LLM-Check starten</button>`;
  }else if(data.ist_llm_geprueft && !data.llm_validated){
-   sec.innerHTML=`<div class="text-error mb-2">LLM-Check unvollständig oder technisch fehlerhaft.</div>
-   <textarea id="edit" class="border rounded w-full p-2 mb-2">${data.llm_initial_output||''}</textarea>
-   <input id="context" type="text" placeholder="Weiterer Kontext" class="border rounded w-full p-2 mb-2 hidden">
-   <div class="space-x-2">
+    sec.innerHTML=`<div class="text-error mb-2">LLM-Check unvollständig oder technisch fehlerhaft.</div>
+    <textarea id="edit" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 mb-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">${data.llm_initial_output||''}</textarea>
+    <input id="context" type="text" placeholder="Weiterer Kontext" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 mb-2 hidden focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">
+    <div class="space-x-2">
      <button id="edit-btn" class="bg-primary text-background px-4 py-2 rounded">Antwort bearbeiten & erneut prüfen</button>
      <button id="ctx-btn" class="bg-primary text-background px-4 py-2 rounded">Zusätzlichen Kontext & erneut prüfen</button>
    </div>`;

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -4,7 +4,7 @@
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
-    <textarea name="prompt" rows="15" class="w-full border rounded p-2">{{ prompt }}</textarea>
+      <textarea name="prompt" rows="15" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ prompt }}</textarea>
     <div>
         <label for="model_category" class="font-semibold">LLM-Modell:</label>
         {% for key, data in categories.items %}


### PR DESCRIPTION
## Summary
- add dark mode text styling to shared form input and select partials
- update manually styled inputs, selects and textareas for proper contrast

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a5e427f2e8832b9558b1ee6005d840