### PR TITLE
feat: add stale processing cleanup command

### DIFF
--- a/core/management/commands/fail_stale_processing.py
+++ b/core/management/commands/fail_stale_processing.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from core.models import BVProjectFile
+
+
+class Command(BaseCommand):
+    """Setzt alte PROCESSING-Einträge auf FAILED."""
+
+    help = "Markiert veraltete Prozess-Einträge als fehlgeschlagen."
+
+    def add_arguments(self, parser) -> None:  # pragma: no cover - argparse trivial
+        parser.add_argument(
+            "--minutes",
+            type=int,
+            default=60,
+            help="Timeout in Minuten",
+        )
+
+    def handle(self, minutes: int, **options) -> None:
+        """Führt die Aktualisierung der veralteten Einträge durch."""
+
+        cutoff = timezone.now() - timedelta(minutes=minutes)
+        stale_qs = BVProjectFile.objects.filter(
+            processing_status=BVProjectFile.PROCESSING,
+            created_at__lt=cutoff,
+        )
+        updated = stale_qs.update(processing_status=BVProjectFile.FAILED)
+        self.stdout.write(f"{updated} Einträge aktualisiert.")

--- a/core/tests/test_fail_stale_processing.py
+++ b/core/tests/test_fail_stale_processing.py
@@ -1,0 +1,29 @@
+from datetime import timedelta
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+from core.models import BVProject, BVProjectFile, ProjectStatus
+
+
+class FailStaleProcessingCommandTests(TestCase):
+    """Tests für den fail_stale_processing-Command."""
+
+    def test_marks_old_entries_failed(self) -> None:
+        status = ProjectStatus.objects.create(name="Init", key="init")
+        projekt = BVProject.objects.create(title="Test", status=status)
+        upload = SimpleUploadedFile("test.txt", b"x")
+        pf = BVProjectFile.objects.create(
+            project=projekt,
+            anlage_nr=1,
+            upload=upload,
+            processing_status=BVProjectFile.PROCESSING,
+        )
+        BVProjectFile.objects.filter(pk=pf.pk).update(
+            created_at=timezone.now() - timedelta(minutes=120)
+        )
+        call_command("fail_stale_processing", minutes=60)
+        pf.refresh_from_db()
+        self.assertEqual(pf.processing_status, BVProjectFile.FAILED)

--- a/core/utils.py
+++ b/core/utils.py
@@ -104,8 +104,7 @@ def start_analysis_for_file(file_id: int) -> str | None:
 @transaction.atomic
 def update_file_status(file_id: int, status: str) -> None:
     """Aktualisiert den Verarbeitungsstatus einer Projektdatei."""
-
-    pf = BVProjectFile.objects.get(pk=file_id)
+    pf = BVProjectFile.objects.select_for_update().get(pk=file_id)
     pf.processing_status = status
     pf.save(update_fields=["processing_status"])
 


### PR DESCRIPTION
## Summary
- add management command to mark outdated PROCESSING entries as FAILED
- lock file status updates with `select_for_update` to prevent parallel changes
- cover the new command with tests

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python manage.py test core.tests.test_fail_stale_processing`


------
https://chatgpt.com/codex/tasks/task_e_68a603b8e010832b91e1f97e67d0699f