### PR TITLE
fix: invert prose typography in dark mode

### DIFF
--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -44,7 +44,7 @@
         {% if a.analysis_json %}
         <tr class="border-b">
             <td colspan="3">
-                <div class="prose max-w-none bg-gray-100 p-2 rounded">
+                <div class="prose dark:prose-invert max-w-none bg-gray-100 p-2 rounded">
                     {{ a.analysis_json|tojson|markdownify }}
                 </div>
                 <div class="mt-1 space-x-2">

--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -3,7 +3,7 @@
 {% block title %}Gutachten anzeigen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>
-<div class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
+<div class="prose dark:prose-invert max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
 <p class="mt-4">
     <a href="{% url 'gutachten_edit' gutachten.id %}" class="text-accent-dark dark:text-accent-light underline">Bearbeiten</a>
     |

--- a/templates/partials/anlage1_note.html
+++ b/templates/partials/anlage1_note.html
@@ -11,7 +11,7 @@
     </div>
   </form>
 {% else %}
-  <div class="prose max-w-none">{{ text|markdownify }}</div>
+  <div class="prose dark:prose-invert max-w-none">{{ text|markdownify }}</div>
   {% url 'hx_anlage1_note' anlage.pk num field as edit_url %}
   {% include 'partials/_button.html' with type='button' label='Bearbeiten' variant='secondary' classes='mt-1 px-2 py-1 rounded' attrs='hx-get="'|add:edit_url|add:'?edit=1" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' %}
 {% endif %}

--- a/templates/partials/markdown_editor.html
+++ b/templates/partials/markdown_editor.html
@@ -3,7 +3,7 @@
   {% if label %}
   <label for="{{ id_prefix }}-textarea" class="font-semibold">{{ label }}</label>
   {% endif %}
-  <div id="{{ id_prefix }}-view" class="prose max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
+  <div id="{{ id_prefix }}-view" class="prose dark:prose-invert max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
     <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
   <div class="flex space-x-2">
     {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-edit' label='Bearbeiten' variant='primary' %}

--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -24,7 +24,7 @@
             </td>
             <td class="px-2 py-1">
                 {% if row.entry and row.entry.is_known_by_llm is True %}
-                    <div class="prose max-w-none">
+                    <div class="prose dark:prose-invert max-w-none">
                         {{ row.entry.description|markdownify }}
                     </div>
                 {% elif row.entry and row.entry.is_known_by_llm is False %}

--- a/templates/partials/software_tab_gutachten.html
+++ b/templates/partials/software_tab_gutachten.html
@@ -14,7 +14,7 @@
             <td class="px-2 py-1">{{ row.name }}</td>
             <td class="px-2 py-1">
             {% if row.entry and row.entry.gutachten %}
-                <div class="prose max-w-none">
+                <div class="prose dark:prose-invert max-w-none">
                     {{ row.entry.gutachten.text|markdownify }}
                 </div>
             {% elif row.entry %}

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -103,7 +103,7 @@ function renderLLM(data){
    </div>`;
  }else if(data.ist_llm_geprueft && data.llm_validated){
   sec.innerHTML=`<button id="toggle" class="bg-success text-background px-4 py-2 rounded mb-2">Antwort ein-/ausblenden</button>
-  <div id="output" class="prose max-w-none bg-gray-100 p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
+  <div id="output" class="prose dark:prose-invert max-w-none bg-gray-100 p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
  }
  if(data.llm_initial_output){
   sec.innerHTML += `<button id="recheck" class="bg-primary text-background px-4 py-2 rounded mt-2">Erneut prüfen</button>`;

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -7,7 +7,7 @@
     {% for q in qa %}
     <div class="p-4 border rounded space-y-2">
         <div class="font-semibold">{{ q.num }}. {{ q.question }}</div>
-        <div class="prose max-w-none">{{ q.answer|markdownify }}</div>
+        <div class="prose dark:prose-invert max-w-none">{{ q.answer|markdownify }}</div>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
                 <h3 class="text-sm font-semibold">Interne Arbeitsanmerkung</h3>

--- a/templates/talkdiary_detail.html
+++ b/templates/talkdiary_detail.html
@@ -5,7 +5,7 @@
 <h1 class="text-2xl font-semibold mb-4">{{ recording.audio_file.name|basename }}</h1>
 <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">{{ recording.created_at|date:'d.m.Y H:i' }} - {{ recording.bereich }}</p>
 <audio controls src="{{ recording.audio_file.url }}" class="mb-4 w-full"></audio>
-<div class="prose max-w-none">
+<div class="prose dark:prose-invert max-w-none">
     {{ transcript_text|markdownify }}
 </div>
 {% endblock %}

--- a/theme/static_src/package.json
+++ b/theme/static_src/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.1.11",
+    "@tailwindcss/typography": "^0.5.16",
     "autoprefixer": "^10.4.21",
     "cross-env": "^7.0.3",
     "pa11y": "^9.0.0",

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -1,4 +1,5 @@
 import forms from '@tailwindcss/forms';
+import typography from '@tailwindcss/typography';
 
 const brandBlue = {
   DEFAULT: '#2563eb',
@@ -83,8 +84,27 @@ export default {
         '3xl': ['1.875rem', { lineHeight: '2.25rem' }],
         '4xl': ['2.25rem', { lineHeight: '2.5rem' }],
       },
+      typography: ({ theme }) => ({
+        DEFAULT: {
+          css: {
+            '--tw-prose-body': theme('colors.text.DEFAULT'),
+            '--tw-prose-headings': theme('colors.text.DEFAULT'),
+            '--tw-prose-links': theme('colors.accent.DEFAULT'),
+            '--tw-prose-bold': theme('colors.text.DEFAULT'),
+          },
+        },
+        invert: {
+          css: {
+            '--tw-prose-body': theme('colors.text.light'),
+            '--tw-prose-headings': theme('colors.text.light'),
+            '--tw-prose-links': theme('colors.accent.light'),
+            '--tw-prose-bold': theme('colors.text.light'),
+            '--tw-prose-counters': theme('colors.text.light'),
+            '--tw-prose-bullets': theme('colors.text.light'),
+          },
+        },
+      }),
     },
   },
-  plugins: [forms],
+  plugins: [forms, typography],
 };
-


### PR DESCRIPTION
## Summary
- extend Tailwind config with typography plugin and dark mode colors
- enable dark mode reading by applying `dark:prose-invert` on all prose blocks

## Testing
- `python manage.py makemigrations --check`
- `npm run build:tailwind`


------
https://chatgpt.com/codex/tasks/task_e_68a6166588c8832bb357b74219680450