### PR TITLE
fix: style gutachten view layout and buttons

### DIFF
--- a/templates/gutachten_view.html
+++ b/templates/gutachten_view.html
@@ -3,29 +3,30 @@
 {% block title %}Gutachten anzeigen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>
-<div class="prose dark:prose-invert max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
-<p class="mt-4">
-    <a href="{% url 'gutachten_edit' gutachten.id %}" class="text-accent-dark dark:text-accent-light underline">Bearbeiten</a>
-    |
-    <a href="{% url 'gutachten_download' gutachten.id %}" class="text-accent-dark dark:text-accent-light underline">Download</a>
-</p>
-{% if projekt.gutachten_function_note %}
-<div class="mt-4">
-    <label class="font-semibold">LLM-Vorschlag:</label>
-      <textarea class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" rows="6" readonly>{{ projekt.gutachten_function_note }}</textarea>
+<div class="card">
+    <div class="prose dark:prose-invert max-w-none">{{ text|markdownify }}</div>
+    <div class="mt-4 flex space-x-2">
+        <a href="{% url 'gutachten_edit' gutachten.id %}" class="btn-action">Bearbeiten</a>
+        <a href="{% url 'gutachten_download' gutachten.id %}" class="btn-action">Download</a>
+    </div>
+    {% if projekt.gutachten_function_note %}
+    <div class="mt-4">
+        <label class="font-semibold">LLM-Vorschlag:</label>
+          <textarea class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" rows="6" readonly>{{ projekt.gutachten_function_note }}</textarea>
+    </div>
+    {% endif %}
+    <form id="llm-check-form" class="mt-4">
+        {% csrf_token %}
+        <label class="font-semibold">LLM-Modell:</label>
+        {% for key, data in categories.items %}
+            <label class="ml-2">
+                <input type="radio" name="model_category" value="{{ key }}" {% if key == category %}checked{% endif %}>
+                {{ data.label }}
+            </label>
+        {% endfor %}
+        <button type="button" id="llm-check-btn" class="btn btn-primary ml-2">LLM-Funktionscheck</button>
+    </form>
 </div>
-{% endif %}
-<form id="llm-check-form" class="mt-4">
-    {% csrf_token %}
-    <label class="font-semibold">LLM-Modell:</label>
-    {% for key, data in categories.items %}
-        <label class="ml-2">
-            <input type="radio" name="model_category" value="{{ key }}" {% if key == category %}checked{% endif %}>
-            {{ data.label }}
-        </label>
-    {% endfor %}
-    <button type="button" id="llm-check-btn" class="bg-primary text-background px-4 py-2 rounded ml-2">LLM-Funktionscheck</button>
-</form>
 <script>
 document.getElementById('llm-check-btn').addEventListener('click',function(){
     const btn=this;


### PR DESCRIPTION
## Summary
- wrap gutachten content and actions in a `card` container
- switch Bearbeiten/Download links to `btn-action`
- unify LLM-Funktionscheck button styling with `btn btn-primary`

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a61be94768832ba8f72973f3ae6a55