### PR TITLE
fix: align actions on version comparison page

### DIFF
--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -65,7 +65,17 @@
 </div>
 {% endif %}
 {% url 'projekt_detail' file.project.pk as project_url %}
+<div class="mt-4 flex justify-center gap-2">
+  <form method="post" action="{% url 'compare_versions' file.pk %}" class="inline">
+    {% csrf_token %}
+    {% include 'partials/_button.html' with type='submit' label='Mit Vorgänger vergleichen' variant='primary' classes='whitespace-nowrap' %}
+  </form>
+  <form method="post" action="{% url 'trigger_file_analysis' file.pk %}" class="inline">
+    {% csrf_token %}
+    {% include 'partials/_button.html' with type='submit' label='Erneut analysieren' variant='primary' classes='whitespace-nowrap' %}
+  </form>
+</div>
 <div class="mt-4">
-{% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' %}
+  {% include 'partials/_button.html' with href=project_url label='Zurück zum Projekt' variant='secondary' %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Align comparison and reanalysis actions horizontally on the version comparison view

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a61ef0bd4c832b805d9529fef6e636