### PR TITLE
feat: redesign software tabs for mobile usability

### DIFF
--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -1,28 +1,33 @@
 {% load recording_extras %}
-<div class="overflow-x-auto">
-<table id="knowledge-table" class="mb-4 w-full text-left">
-    <thead>
-        <tr class="bg-background dark:bg-background-dark">
-            <th class="px-2 py-1 bg-background dark:bg-background-dark">Software</th>
-            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Bekannt?</th>
-            <th class="px-2 py-1 bg-background dark:bg-background-dark">Beschreibung</th>
-            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Aktionen</th>
-        </tr>
-    </thead>
-    <tbody>
+<div class="space-y-4">
     {% for row in knowledge_rows %}
-        <tr class="border-t" data-id="{{ row.entry.id|default:'' }}">
-            <td class="px-2 py-1">{{ row.name }}</td>
-            <td class="px-2 py-1 text-center">
-                {% if row.entry and row.entry.is_known_by_llm is True %}
-                    {% include 'partials/status_badge.html' with status_key='ja' label='✓ Bekannt' %}
-                {% elif row.entry and row.entry.is_known_by_llm is False %}
-                    {% include 'partials/status_badge.html' with status_key='nein' label='✗ Nicht bekannt' %}
-                {% else %}
-                    {% include 'partials/status_badge.html' with status_key='unbekannt' label='? Ungeprüft' %}
-                {% endif %}
-            </td>
-            <td class="px-2 py-1">
+        <div class="card p-4" data-id="{{ row.entry.id|default:'' }}">
+            <div class="flex justify-between items-start mb-2">
+                <div>
+                    <h3 class="font-semibold">{{ row.name }}</h3>
+                    <div>
+                        {% if row.entry and row.entry.is_known_by_llm is True %}
+                            {% include 'partials/status_badge.html' with status_key='ja' label='✓ Bekannt' %}
+                        {% elif row.entry and row.entry.is_known_by_llm is False %}
+                            {% include 'partials/status_badge.html' with status_key='nein' label='✗ Nicht bekannt' %}
+                        {% else %}
+                            {% include 'partials/status_badge.html' with status_key='unbekannt' label='? Ungeprüft' %}
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="space-x-2">
+                    {% if row.entry and row.entry.is_known_by_llm is True %}
+                        <a href="{% url 'edit_knowledge_description' row.entry.id %}" class="btn-action">Bearbeiten</a>
+                        <a href="{% url 'download_knowledge_as_word' row.entry.id %}" class="btn-action">Export</a>
+                        <a href="{% url 'delete_knowledge_entry' row.entry.id %}" class="btn-action-delete">Löschen</a>
+                    {% elif row.entry and row.entry.is_known_by_llm is False %}
+                        <button type="button" class="btn btn-warning btn-sm retry-check-btn" data-knowledge-id="{{ row.entry.id }}">Erneut prüfen</button>
+                    {% else %}
+                        <button type="button" class="btn btn-primary btn-sm start-initial-check-btn" data-knowledge-id="{{ row.entry.id|default:'' }}">Prüfung starten</button>
+                    {% endif %}
+                </div>
+            </div>
+            <div>
                 {% if row.entry and row.entry.is_known_by_llm is True %}
                     <div class="prose dark:prose-invert max-w-none">
                         {{ row.entry.description|markdownify }}
@@ -31,21 +36,9 @@
                     <p class="text-sm text-gray-500 dark:text-gray-400">Die automatische Prüfung konnte diese Software nicht eindeutig identifizieren.</p>
                 {% else %}
                 {% endif %}
-            </td>
-            <td class="px-2 py-1 text-center space-x-2">
-            {% if row.entry and row.entry.is_known_by_llm is True %}
-                <a href="{% url 'edit_knowledge_description' row.entry.id %}" class="btn-action">Bearbeiten</a>
-                <a href="{% url 'download_knowledge_as_word' row.entry.id %}" class="btn-action">Export</a>
-                <a href="{% url 'delete_knowledge_entry' row.entry.id %}" class="btn-action-delete">Löschen</a>
-            {% elif row.entry and row.entry.is_known_by_llm is False %}
-                <button type="button" class="btn btn-warning btn-sm retry-check-btn" data-knowledge-id="{{ row.entry.id }}">Erneut prüfen</button>
-            {% else %}
-                <button type="button" class="btn btn-primary btn-sm start-initial-check-btn" data-knowledge-id="{{ row.entry.id|default:'' }}">Prüfung starten</button>
-            {% endif %}
-            </td>
-        </tr>
+            </div>
+        </div>
     {% endfor %}
-    </tbody>
-</table>
 </div>
 <button id="start-checks" class="bg-success text-background px-4 py-2 rounded">Prüfung starten</button>
+

--- a/templates/partials/software_tab_gutachten.html
+++ b/templates/partials/software_tab_gutachten.html
@@ -1,39 +1,40 @@
 {% load recording_extras %}
-<div class="overflow-x-auto">
-<table class="mb-4 w-full text-left">
-    <thead>
-        <tr class="bg-background dark:bg-background-dark">
-            <th class="px-2 py-1 bg-background dark:bg-background-dark">Software</th>
-            <th class="px-2 py-1 bg-background dark:bg-background-dark">Gutachten</th>
-            <th class="px-2 py-1 text-center bg-background dark:bg-background-dark">Aktionen</th>
-        </tr>
-    </thead>
-    <tbody>
+<div class="space-y-4">
     {% for row in knowledge_rows %}
-        <tr class="border-t align-top">
-            <td class="px-2 py-1">{{ row.name }}</td>
-            <td class="px-2 py-1">
-            {% if row.entry and row.entry.gutachten %}
-                <div class="prose dark:prose-invert max-w-none">
-                    {{ row.entry.gutachten.text|markdownify }}
+        <div class="card p-4">
+            <div class="flex justify-between items-start mb-2">
+                <div>
+                    <h3 class="font-semibold">{{ row.name }}</h3>
+                    <div>
+                        {% if row.entry and row.entry.gutachten %}
+                            {% include 'partials/status_badge.html' with status_key='ja' label='✓ Gutachten vorhanden' %}
+                        {% else %}
+                            {% include 'partials/status_badge.html' with status_key='nein' label='✗ Kein Gutachten' %}
+                        {% endif %}
+                    </div>
                 </div>
-            {% elif row.entry %}
-                <span class="text-sm text-gray-500 dark:text-gray-400">Noch kein Gutachten vorhanden</span>
-            {% endif %}
-            </td>
-            <td class="px-2 py-1 text-center space-x-2">
-            {% if row.entry %}
-                {% if row.entry.gutachten %}
-                    <a href="{% url 'gutachten_edit' row.entry.gutachten.id %}" class="btn-action">Bearbeiten</a>
-                    <a href="{% url 'gutachten_download' row.entry.gutachten.id %}" class="btn-action">Download</a>
-                {% else %}
-                    <button class="btn btn-sm btn-primary generate-gutachten-btn" data-knowledge-id="{{ row.entry.id }}">Gutachten erstellen</button>
+                <div class="space-x-2">
+                    {% if row.entry %}
+                        {% if row.entry.gutachten %}
+                            <a href="{% url 'gutachten_edit' row.entry.gutachten.id %}" class="btn-action">Bearbeiten</a>
+                            <a href="{% url 'gutachten_download' row.entry.gutachten.id %}" class="btn-action">Download</a>
+                        {% else %}
+                            <button class="btn btn-sm btn-primary generate-gutachten-btn" data-knowledge-id="{{ row.entry.id }}">Gutachten erstellen</button>
+                        {% endif %}
+                        <span class="gutachten-status-spinner ms-2" id="gutachten-status-{{ row.entry.id }}"></span>
+                    {% endif %}
+                </div>
+            </div>
+            <div>
+                {% if row.entry and row.entry.gutachten %}
+                    <div class="prose dark:prose-invert max-w-none">
+                        {{ row.entry.gutachten.text|markdownify }}
+                    </div>
+                {% elif row.entry %}
+                    <span class="text-sm text-gray-500 dark:text-gray-400">Noch kein Gutachten vorhanden</span>
                 {% endif %}
-                <span class="gutachten-status-spinner ms-2" id="gutachten-status-{{ row.entry.id }}"></span>
-            {% endif %}
-            </td>
-        </tr>
+            </div>
+        </div>
     {% endfor %}
-    </tbody>
-</table>
 </div>
+


### PR DESCRIPTION
## Summary
- display technical check results in cards instead of a table
- show gutachten information in card layout without table

## Testing
- `python3 manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a6b9b1a47c832bb635da680f4d6e68