### PR TITLE
fix: vereinheitliche Button-Elemente in Software-Tabs

### DIFF
--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -17,9 +17,9 @@
                 </div>
                 <div class="space-x-2">
                     {% if row.entry and row.entry.is_known_by_llm is True %}
-                        <a href="{% url 'edit_knowledge_description' row.entry.id %}" class="btn-action">Bearbeiten</a>
-                        <a href="{% url 'download_knowledge_as_word' row.entry.id %}" class="btn-action">Export</a>
-                        <a href="{% url 'delete_knowledge_entry' row.entry.id %}" class="btn-action-delete">Löschen</a>
+                        <a href="{% url 'edit_knowledge_description' row.entry.id %}" class="btn btn-primary btn-sm">Bearbeiten</a>
+                        <a href="{% url 'download_knowledge_as_word' row.entry.id %}" class="btn btn-secondary btn-sm">Export</a>
+                        <a href="{% url 'delete_knowledge_entry' row.entry.id %}" class="btn btn-error btn-sm">Löschen</a>
                     {% elif row.entry and row.entry.is_known_by_llm is False %}
                         <button type="button" class="btn btn-warning btn-sm retry-check-btn" data-knowledge-id="{{ row.entry.id }}">Erneut prüfen</button>
                     {% else %}
@@ -40,5 +40,5 @@
         </div>
     {% endfor %}
 </div>
-<button id="start-checks" class="bg-success text-background px-4 py-2 rounded">Prüfung starten</button>
+<button id="start-checks" type="button" class="bg-success text-background px-4 py-2 rounded">Prüfung starten</button>
 

--- a/templates/partials/software_tab_gutachten.html
+++ b/templates/partials/software_tab_gutachten.html
@@ -16,10 +16,10 @@
                 <div class="space-x-2">
                     {% if row.entry %}
                         {% if row.entry.gutachten %}
-                            <a href="{% url 'gutachten_edit' row.entry.gutachten.id %}" class="btn-action">Bearbeiten</a>
-                            <a href="{% url 'gutachten_download' row.entry.gutachten.id %}" class="btn-action">Download</a>
+                            <a href="{% url 'gutachten_edit' row.entry.gutachten.id %}" class="btn btn-primary btn-sm">Bearbeiten</a>
+                            <a href="{% url 'gutachten_download' row.entry.gutachten.id %}" class="btn btn-secondary btn-sm">Download</a>
                         {% else %}
-                            <button class="btn btn-sm btn-primary generate-gutachten-btn" data-knowledge-id="{{ row.entry.id }}">Gutachten erstellen</button>
+                            <button type="button" class="btn btn-sm btn-primary generate-gutachten-btn" data-knowledge-id="{{ row.entry.id }}">Gutachten erstellen</button>
                         {% endif %}
                         <span class="gutachten-status-spinner ms-2" id="gutachten-status-{{ row.entry.id }}"></span>
                     {% endif %}


### PR DESCRIPTION
## Summary
- Vereinheitliche Button-Styling zwischen Links und Schaltflächen in den Software-Tabs
- Ergänze fehlende `type="button"` Attribute für JS-gesteuerte Aktionen

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a6c0a610e0832b83d8470d1a1cdaef