### PR TITLE
feat: add sidebar toggle with off-canvas

### DIFF
--- a/static/js/sidebar.js
+++ b/static/js/sidebar.js
@@ -1,0 +1,56 @@
+/**
+ * JS für Seitenleisten-Toggle mit mobilem Off-Canvas.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+    const sidebar = document.getElementById('sidebar');
+    const toggleBtn = document.getElementById('sidebar-toggle');
+    const overlay = document.getElementById('sidebar-overlay');
+    const storageKey = 'sidebar-open';
+
+    if (!sidebar) {
+        return;
+    }
+
+    const setSidebar = (open) => {
+        if (open) {
+            sidebar.classList.add('translate-x-0');
+            sidebar.classList.remove('-translate-x-full', 'md:-translate-x-full');
+            if (overlay) {
+                overlay.classList.add('sidebar-overlay-active');
+            }
+        } else {
+            sidebar.classList.remove('translate-x-0');
+            sidebar.classList.add('-translate-x-full', 'md:-translate-x-full');
+            if (overlay) {
+                overlay.classList.remove('sidebar-overlay-active');
+            }
+        }
+        try {
+            localStorage.setItem(storageKey, open ? '1' : '0');
+        } catch (e) {
+            // localStorage ist möglicherweise nicht verfügbar
+        }
+    };
+
+    let open = window.innerWidth >= 768;
+    try {
+        const stored = localStorage.getItem(storageKey);
+        if (stored !== null) {
+            open = stored === '1';
+        }
+    } catch (e) {
+        // localStorage ist möglicherweise nicht verfügbar
+    }
+    setSidebar(open);
+
+    if (toggleBtn) {
+        toggleBtn.addEventListener('click', () => {
+            const isClosed = sidebar.classList.contains('-translate-x-full');
+            setSidebar(isClosed);
+        });
+    }
+
+    if (overlay) {
+        overlay.addEventListener('click', () => setSidebar(false));
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,14 +30,19 @@
 <body class="flex flex-col min-h-screen bg-background text-text dark:bg-background-dark dark:text-text-light">
     <header class="bg-header text-text-light border-b items-center">
         <div class="container mx-auto p-4 flex flex-col md:flex-row md:items-center md:justify-between">
-            <div class="flex items-center justify-between w-full md:w-auto">
-                <div class="text-xl font-semibold">
-                    <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
-                </div>
-                <button id="menu-toggle" class="md:hidden text-text-light" aria-label="Menü umschalten">
-                    <i class="fa-solid fa-bars"></i>
-                </button>
-            </div>
+             <div class="flex items-center justify-between w-full md:w-auto">
+                 <div class="text-xl font-semibold">
+                     <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
+                 </div>
+                 <div class="flex items-center space-x-2">
+                     <button id="menu-toggle" class="md:hidden text-text-light" aria-label="Menü umschalten">
+                         <i class="fa-solid fa-bars"></i>
+                     </button>
+                     <button id="sidebar-toggle" class="text-text-light" aria-label="Seitenleiste umschalten">
+                         <i class="fa-solid fa-table-columns"></i>
+                     </button>
+                 </div>
+             </div>
             <nav id="nav-menu" class="hidden flex-col md:flex md:flex-row md:items-center text-text-light space-y-2 md:space-y-0 md:space-x-4 mt-2 md:mt-0">
                 <a href="{{ request.META.HTTP_REFERER|default:'#' }}" onclick="history.back(); return false;" class="md:mr-2 hover:underline hover:text-accent-light">&larr; Zurück</a>
                 <a href="/" class="hover:underline hover:text-accent-light">Startseite</a>
@@ -65,11 +70,12 @@
         </div>
     </header>
 
-    <div class="flex flex-1">
-        <aside class="hidden md:block md:w-64 bg-background border-r text-text dark:bg-background-dark dark:text-text-light">
-            {% include 'partials/_sidebar.html' %}
-        </aside>
-        <main class="flex-1 container mx-auto p-4">
+     <div class="flex flex-1">
+         <aside id="sidebar" class="sidebar">
+             {% include 'partials/_sidebar.html' %}
+         </aside>
+         <div id="sidebar-overlay" class="sidebar-overlay md:hidden"></div>
+         <main class="flex-1 container mx-auto p-4">
             {% if messages %}
             <div class="mb-4 space-y-2">
                 {% for message in messages %}
@@ -86,9 +92,10 @@
     <footer class="bg-background text-text text-center py-4 dark:bg-background-dark dark:text-text-light">
         <p>&copy; 2025 Frank Vendolsky</p>
     </footer>
-    <script src="{% static 'js/utils.js' %}"></script>
-    <script src="{% static 'js/theme_toggle.js' %}"></script>
-    <script src="{% static 'js/menu_toggle.js' %}"></script>
-    {% block extra_js %}{% endblock %}
+     <script src="{% static 'js/utils.js' %}"></script>
+     <script src="{% static 'js/theme_toggle.js' %}"></script>
+     <script src="{% static 'js/menu_toggle.js' %}"></script>
+     <script src="{% static 'js/sidebar.js' %}"></script>
+     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -31,6 +31,18 @@ html.dark {
   --color-text: var(--color-text-light);
 }
 
+@layer components {
+  .sidebar {
+    @apply fixed inset-y-0 left-0 z-40 w-64 transform transition-transform -translate-x-full md:relative md:translate-x-0 md:transform-none bg-background border-r text-text dark:bg-background-dark dark:text-text-light;
+  }
+  .sidebar-overlay {
+    @apply fixed inset-0 bg-black/50 z-30 hidden;
+  }
+  .sidebar-overlay-active {
+    @apply block;
+  }
+}
+
 /**
   * A catch-all path to Django template files, JavaScript, and Python files
   * that contain Tailwind CSS classes and will be scanned by Tailwind to generate the final CSS file.


### PR DESCRIPTION
## Summary
- add JS-based sidebar toggle with off-canvas behavior and persisted state
- integrate sidebar toggle into base template and add Tailwind component styles

## Testing
- `python manage.py makemigrations --check`
- `cd theme/static_src && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6c53c736c832b94cba35458057858