### PR TITLE
Filter navigation by permission and add tests

### DIFF
--- a/core/navigation.py
+++ b/core/navigation.py
@@ -21,6 +21,6 @@ NAV_ITEMS: List[NavItem] = [
     {
         "title": "Dashboard",
         "url": "home",
-        "perm": "app.view_model",
+        "perm": "core.view_bvproject",
     },
 ]

--- a/core/tests/test_navigation.py
+++ b/core/tests/test_navigation.py
@@ -1,0 +1,28 @@
+"""Tests für die Navigationsberechtigungen."""
+
+from django.contrib.auth.models import Permission, User
+from django.test import TestCase
+from django.urls import reverse
+
+
+class NavigationPermissionsTests(TestCase):
+    """Überprüfung der Navigation abhängig von Benutzerrechten."""
+
+    def setUp(self) -> None:
+        """Initialisiert die benötigte Berechtigung."""
+        self.permission = Permission.objects.get(codename="view_bvproject")
+
+    def test_navigation_without_permission(self) -> None:
+        """Ein Benutzer ohne Berechtigung sieht keinen Dashboard-Link."""
+        user = User.objects.create_user(username="alice", password="password")
+        self.client.login(username="alice", password="password")
+        response = self.client.get(reverse("home"))
+        self.assertNotContains(response, "Dashboard")
+
+    def test_navigation_with_permission(self) -> None:
+        """Ein Benutzer mit Berechtigung sieht den Dashboard-Link."""
+        user = User.objects.create_user(username="bob", password="password")
+        user.user_permissions.add(self.permission)
+        self.client.login(username="bob", password="password")
+        response = self.client.get(reverse("home"))
+        self.assertContains(response, "Dashboard")


### PR DESCRIPTION
## Summary
- restrict dashboard navigation entry to `core.view_bvproject`
- add tests verifying navigation visibility based on permissions

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_navigation`
- `python manage.py test` *(fails: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68a6c545b6e8832ba7ff9ba6d9e9c370