### PR TITLE
feat: vereinheitliche Sidebar-Steuerung

### DIFF
--- a/static/js/sidebar.js
+++ b/static/js/sidebar.js
@@ -3,7 +3,7 @@
  */
 document.addEventListener('DOMContentLoaded', () => {
     const sidebar = document.getElementById('sidebar');
-    const toggleBtn = document.getElementById('sidebar-toggle');
+    const toggleBtn = document.getElementById('menu-toggle');
     const overlay = document.getElementById('sidebar-overlay');
     const storageKey = 'sidebar-open';
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,43 +30,16 @@
 <body class="flex flex-col min-h-screen bg-background text-text dark:bg-background-dark dark:text-text-light">
     <header class="bg-header text-text-light border-b items-center">
         <div class="container mx-auto p-4 flex flex-col md:flex-row md:items-center md:justify-between">
-             <div class="flex items-center justify-between w-full md:w-auto">
-                 <div class="text-xl font-semibold">
-                     <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
-                 </div>
-                 <div class="flex items-center space-x-2">
-                     <button id="menu-toggle" class="md:hidden text-text-light" aria-label="Menü umschalten">
-                         <i class="fa-solid fa-bars"></i>
-                     </button>
-                     <button id="sidebar-toggle" class="text-text-light" aria-label="Seitenleiste umschalten">
-                         <i class="fa-solid fa-table-columns"></i>
-                     </button>
-                 </div>
-             </div>
-            <nav id="nav-menu" class="hidden flex-col md:flex md:flex-row md:items-center text-text-light space-y-2 md:space-y-0 md:space-x-4 mt-2 md:mt-0">
-                <a href="{{ request.META.HTTP_REFERER|default:'#' }}" onclick="history.back(); return false;" class="md:mr-2 hover:underline hover:text-accent-light">&larr; Zurück</a>
-                <a href="/" class="hover:underline hover:text-accent-light">Startseite</a>
-                {% if user.is_authenticated %}
-                    <a href="/account/" class="hover:underline hover:text-accent-light">Mein Konto</a>
-                    {% if user.is_superuser or is_admin %}
-                        <a href="/projects-admin/" class="hover:underline hover:text-accent-light">Projekt-Admin</a>
-                    {% endif %}
-                    {% if user.is_staff %}
-                        <a href="/admin/" class="hover:underline hover:text-accent-light">System-Admin</a>
-                    {% endif %}
-
-                    <form action="{% url 'logout' %}" method="post" class="md:inline">
-                        {% csrf_token %}
-                        {% include 'partials/_button.html' with type='submit' label='Abmelden' variant='secondary' classes='bg-transparent hover:bg-transparent text-text-light hover:text-accent-light hover:underline px-0 py-0' %}
-                    </form>
-
-                {% else %}
-                    <a href="/login/" class="hover:underline hover:text-accent-light">Anmelden</a>
-                {% endif %}
-                <button id="theme-toggle" class="md:ml-2 text-text-light hover:text-accent-light" aria-label="Farbschema umschalten">
-                    <i class="fa-solid fa-moon"></i>
-                </button>
-            </nav>
+            <div class="flex items-center justify-between w-full md:w-auto">
+                <div class="text-xl font-semibold">
+                    <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
+                </div>
+                <div class="flex items-center space-x-2">
+                    <button id="menu-toggle" class="text-text-light" aria-label="Seitenleiste umschalten">
+                        <i class="fa-solid fa-bars"></i>
+                    </button>
+                </div>
+            </div>
         </div>
     </header>
 
@@ -94,7 +67,6 @@
     </footer>
      <script src="{% static 'js/utils.js' %}"></script>
      <script src="{% static 'js/theme_toggle.js' %}"></script>
-     <script src="{% static 'js/menu_toggle.js' %}"></script>
      <script src="{% static 'js/sidebar.js' %}"></script>
      {% block extra_js %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- remove top navigation and rely on sidebar
- introduce single burger button with id `menu-toggle`
- hook sidebar logic to new button and drop unused menu_toggle script

## Testing
- `python manage.py makemigrations --check`
- `DJANGO_SETTINGS_MODULE=noesis.settings pytest` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cc27b03c832bb56f572faa87be43