### PR TITLE
Erweitere Navigationstests und Sidebar-Doku

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Vor dem Einsatz der Managementbefehle muss zudem `pip install -r requirements.tx
 
 ## Sidebar-Struktur und Berechtigungssteuerung
 
-NOESIS stellt neben der Kachelnavigation auf dem Dashboard eine permanente Sidebar zur Verfügung. Die sichtbaren Bereiche und Kacheln werden durch den Kontextprozessor `core.context_processors.user_navigation` ermittelt. Dieser berücksichtigt individuelle und gruppenbasierte Zugriffe auf Bereiche sowie die Berechtigungen für einzelne Kacheln.
+Die Sidebar wird dynamisch aus den Modellen `Area` und `Tile` erzeugt – ein statisches `NAV_ITEMS`-Array ist nicht mehr nötig. Der Kontextprozessor `core.context_processors.user_navigation` stellt für den angemeldeten Benutzer alle freigeschalteten Bereiche samt zugehöriger Tiles bereit. Zugriffe können direkt oder über Gruppen vergeben werden und berücksichtigen sowohl `UserAreaAccess`/`GroupAreaAccess` als auch `UserTileAccess`/`GroupTileAccess`. Befindet sich ein Benutzer nur in genau einem Bereich, werden dessen Tiles ohne Bereichsüberschrift angezeigt. Der ergänzende Kontextprozessor `core.context_processors.is_admin` liefert ein Flag, mit dem Template-Logik Admin-Links ein- oder ausblenden kann.
 
 ### Bedienung und parallele Nutzung
 

--- a/core/tests/test_navigation.py
+++ b/core/tests/test_navigation.py
@@ -1,28 +1,117 @@
-"""Tests für die Navigationsberechtigungen."""
+"""Tests für die Sidebar-Navigation."""
 
-from django.contrib.auth.models import Permission, User
+from django.contrib.auth.models import Group, User
 from django.test import TestCase
 from django.urls import reverse
 
+from core.models import (
+    Area,
+    Tile,
+    UserAreaAccess,
+    UserTileAccess,
+)
 
-class NavigationPermissionsTests(TestCase):
-    """Überprüfung der Navigation abhängig von Benutzerrechten."""
+
+class NavigationSidebarTests(TestCase):
+    """Überprüfung der sichtbaren Bereiche, Tiles und Admin-Links."""
 
     def setUp(self) -> None:
-        """Initialisiert die benötigte Berechtigung."""
-        self.permission = Permission.objects.get(codename="view_bvproject")
+        """Legt Bereiche und Tiles für die Tests an."""
 
-    def test_navigation_without_permission(self) -> None:
-        """Ein Benutzer ohne Berechtigung sieht keinen Dashboard-Link."""
-        user = User.objects.create_user(username="alice", password="password")
-        self.client.login(username="alice", password="password")
-        response = self.client.get(reverse("home"))
-        self.assertNotContains(response, "Dashboard")
+        self.area_work = Area.objects.create(slug="work", name="Arbeitsbereich")
+        self.area_private = Area.objects.create(slug="personal", name="Privatbereich")
 
-    def test_navigation_with_permission(self) -> None:
-        """Ein Benutzer mit Berechtigung sieht den Dashboard-Link."""
-        user = User.objects.create_user(username="bob", password="password")
-        user.user_permissions.add(self.permission)
-        self.client.login(username="bob", password="password")
-        response = self.client.get(reverse("home"))
+        self.tile_dashboard = Tile.objects.create(
+            slug="dashboard", name="Dashboard", url_name="home"
+        )
+        self.tile_dashboard.areas.add(self.area_work)
+
+        self.tile_account = Tile.objects.create(
+            slug="account-tile", name="Privatkachel", url_name="account"
+        )
+        self.tile_account.areas.add(self.area_private)
+
+        self.tile_hidden = Tile.objects.create(
+            slug="hidden", name="Versteckt", url_name="home"
+        )
+        self.tile_hidden.areas.add(self.area_work)
+
+    def _grant_access(self, user: User, areas: list[Area], tiles: list[Tile]) -> None:
+        """Erteilt einem Benutzer Zugriff auf Bereiche und Tiles."""
+
+        for area in areas:
+            UserAreaAccess.objects.create(user=user, area=area)
+        for tile in tiles:
+            UserTileAccess.objects.create(user=user, tile=tile)
+
+    def test_sidebar_single_area_tiles_only(self) -> None:
+        """Bei genau einem Bereich werden nur die Tiles angezeigt."""
+
+        user = User.objects.create_user("alice", password="pw")
+        self._grant_access(user, [self.area_work], [self.tile_dashboard])
+        self.client.login(username="alice", password="pw")
+
+        response = self.client.get(reverse("account"))
+
         self.assertContains(response, "Dashboard")
+        self.assertNotContains(response, self.area_work.name)
+        self.assertNotContains(response, self.tile_account.name)
+        self.assertNotContains(response, self.tile_hidden.name)
+
+    def test_sidebar_multiple_areas(self) -> None:
+        """Mehrere Bereiche werden mit Überschriften dargestellt."""
+
+        user = User.objects.create_user("bob", password="pw")
+        self._grant_access(
+            user,
+            [self.area_work, self.area_private],
+            [self.tile_dashboard, self.tile_account],
+        )
+        self.client.login(username="bob", password="pw")
+
+        response = self.client.get(reverse("account"))
+
+        self.assertContains(response, self.area_work.name)
+        self.assertContains(response, self.area_private.name)
+        self.assertContains(response, "Dashboard")
+        self.assertContains(response, "Privatkachel")
+        self.assertNotContains(response, self.tile_hidden.name)
+
+    def test_no_admin_links_for_regular_user(self) -> None:
+        """Ohne Sonderrechte erscheinen keine Admin-Links."""
+
+        user = User.objects.create_user("carol", password="pw")
+        self._grant_access(user, [self.area_work], [self.tile_dashboard])
+        self.client.login(username="carol", password="pw")
+
+        response = self.client.get(reverse("account"))
+
+        self.assertNotContains(response, "Projekt-Admin")
+        self.assertNotContains(response, "System-Admin")
+
+    def test_project_admin_link_for_admin_group(self) -> None:
+        """Mitglied der Admin-Gruppe sieht Projekt-Admin-Link."""
+
+        admin_group = Group.objects.create(name="Admin")
+        user = User.objects.create_user("dave", password="pw")
+        user.groups.add(admin_group)
+        self._grant_access(user, [self.area_work], [self.tile_dashboard])
+        self.client.login(username="dave", password="pw")
+
+        response = self.client.get(reverse("account"))
+
+        self.assertContains(response, "Projekt-Admin")
+        self.assertNotContains(response, "System-Admin")
+
+    def test_system_admin_link_for_superuser(self) -> None:
+        """Superuser sieht Projekt- und System-Admin-Link."""
+
+        user = User.objects.create_superuser("eve", "eve@example.com", "pw")
+        self._grant_access(user, [self.area_work], [self.tile_dashboard])
+        self.client.login(username="eve", password="pw")
+
+        response = self.client.get(reverse("account"))
+
+        self.assertContains(response, "Projekt-Admin")
+        self.assertContains(response, "System-Admin")
+


### PR DESCRIPTION
## Zusammenfassung
- Dokumentation der Sidebar überarbeitet und neuen Kontextprozessor beschrieben
- Navigationstests für mehrere und einzelne Bereiche ergänzt
- Admin-Link-Anzeige in der Sidebar umfassend getestet

## Testanweisungen
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_navigation -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a7006b5b24832ba1496aa0f02dad73