### PR TITLE
feat: verbessern Sidebar-Navigation

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,6 +1,7 @@
 """Kontextprozessoren für die Django-Templates."""
 
 from typing import TypedDict
+from types import SimpleNamespace
 
 from django.db.models import Q
 from django.http import HttpRequest
@@ -46,6 +47,26 @@ def user_navigation(request: HttpRequest) -> dict[str, list[NavSection]]:
     for area in areas:
         tiles = get_user_tiles(request.user, area.slug)
         navigation.append({"area": area, "tiles": tiles})
+
+    # Admin-Bereiche integrieren
+    if request.user.is_staff or request.user.groups.filter(name__iexact="admin").exists():
+        project_admin_area = SimpleNamespace(name="Projekt-Admin", slug="projekt-admin")
+        project_admin_tiles = [
+            SimpleNamespace(name="Projekt-Liste", url_name="admin_projects"),
+            SimpleNamespace(name="Status-Definitionen", url_name="admin_project_statuses"),
+            SimpleNamespace(name="LLM-Rollen", url_name="admin_llm_roles"),
+            SimpleNamespace(name="Benutzer verwalten", url_name="admin_user_list"),
+            SimpleNamespace(name="Konfiguration", url_name="config_transfer"),
+        ]
+        navigation.append({"area": project_admin_area, "tiles": project_admin_tiles})
+
+    if request.user.is_superuser:
+        system_admin_area = SimpleNamespace(name="System-Admin", slug="system-admin")
+        system_admin_tiles = [
+            SimpleNamespace(name="Django Admin", url_name="admin:index"),
+            SimpleNamespace(name="Benutzer verwalten", url_name="admin:auth_user_changelist"),
+        ]
+        navigation.append({"area": system_admin_area, "tiles": system_admin_tiles})
 
     return {"user_navigation": navigation}
 

--- a/static/js/sidebar.js
+++ b/static/js/sidebar.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const toggleBtn = document.getElementById('sidebar-toggle');
     const overlay = document.getElementById('sidebar-overlay');
     const storageKey = 'sidebar-open';
+    const accordionKey = 'sidebar-active-accordion';
 
     if (!sidebar) {
         return;
@@ -54,6 +55,63 @@ document.addEventListener('DOMContentLoaded', () => {
         overlay.addEventListener('click', () => setSidebar(false));
     }
 
+    const openAccordion = (id, store = true) => {
+        const btn = sidebar.querySelector(`.sidebar-accordion-btn[data-accordion-target="${id}"]`);
+        const target = document.getElementById(id);
+        if (!btn || !target) {
+            return;
+        }
+        target.classList.remove('hidden');
+        const icon = btn.querySelector('i');
+        if (icon) {
+            icon.classList.add('rotate-180');
+        }
+        if (store) {
+            try {
+                localStorage.setItem(accordionKey, id);
+            } catch (e) {
+                // localStorage ist möglicherweise nicht verfügbar
+            }
+        }
+    };
+
+    const closeAccordion = (id) => {
+        const btn = sidebar.querySelector(`.sidebar-accordion-btn[data-accordion-target="${id}"]`);
+        const target = document.getElementById(id);
+        if (!btn || !target) {
+            return;
+        }
+        target.classList.add('hidden');
+        const icon = btn.querySelector('i');
+        if (icon) {
+            icon.classList.remove('rotate-180');
+        }
+        try {
+            localStorage.removeItem(accordionKey);
+        } catch (e) {
+            // localStorage ist möglicherweise nicht verfügbar
+        }
+    };
+
+    let activeAcc = null;
+    try {
+        activeAcc = localStorage.getItem(accordionKey);
+    } catch (e) {
+        // localStorage ist möglicherweise nicht verfügbar
+    }
+
+    if (activeAcc) {
+        openAccordion(activeAcc, false);
+    } else {
+        const activeLink = sidebar.querySelector('.active-nav-link');
+        if (activeLink) {
+            const parent = activeLink.closest('ul');
+            if (parent && parent.id) {
+                openAccordion(parent.id);
+            }
+        }
+    }
+
     const accordionButtons = sidebar.querySelectorAll('.sidebar-accordion-btn');
     accordionButtons.forEach((btn) => {
         const targetId = btn.getAttribute('data-accordion-target');
@@ -62,10 +120,25 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         btn.addEventListener('click', () => {
-            target.classList.toggle('hidden');
-            const icon = btn.querySelector('i');
-            if (icon) {
-                icon.classList.toggle('rotate-180');
+            const isHidden = target.classList.contains('hidden');
+            if (isHidden) {
+                openAccordion(targetId);
+            } else {
+                closeAccordion(targetId);
+            }
+        });
+    });
+
+    const navLinks = sidebar.querySelectorAll('nav a');
+    navLinks.forEach((link) => {
+        link.addEventListener('click', () => {
+            const parent = link.closest('ul');
+            if (parent && parent.id) {
+                try {
+                    localStorage.setItem(accordionKey, parent.id);
+                } catch (e) {
+                    // localStorage ist möglicherweise nicht verfügbar
+                }
             }
         });
     });

--- a/templates/partials/_sidebar.html
+++ b/templates/partials/_sidebar.html
@@ -23,7 +23,7 @@
         <ul class="space-y-2">
             {% for tile in user_navigation.0.tiles %}
             <li>
-                <a href="{% url tile.url_name %}" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light {% if request.resolver_match.url_name == tile.url_name %}bg-accent text-text-light font-semibold{% endif %}">
+                <a href="{% url tile.url_name %}" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light {% if request.resolver_match.view_name == tile.url_name %}active-nav-link{% endif %}">
                     {{ tile.name }}
                 </a>
             </li>
@@ -32,14 +32,14 @@
         {% else %}
         {% for section in user_navigation %}
         <div class="mb-2">
-            <button class="w-full flex items-center justify-between px-4 py-2 font-semibold rounded hover:bg-accent hover:text-text-light sidebar-accordion-btn" data-accordion-target="nav-{{ forloop.counter }}">
+            <button class="w-full flex items-center justify-between px-4 py-2 font-semibold rounded hover:bg-accent hover:text-text-light sidebar-accordion-btn" data-accordion-target="nav-{{ section.area.slug }}" data-accordion-id="{{ section.area.slug }}">
                 <span>{{ section.area.name }}</span>
                 <i class="fa-solid fa-chevron-down transition-transform"></i>
             </button>
-            <ul id="nav-{{ forloop.counter }}" class="mt-1 pl-2 space-y-1 hidden">
+            <ul id="nav-{{ section.area.slug }}" class="mt-1 pl-2 space-y-1 hidden">
                 {% for tile in section.tiles %}
                 <li>
-                    <a href="{% url tile.url_name %}" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light {% if request.resolver_match.url_name == tile.url_name %}bg-accent text-text-light font-semibold{% endif %}">
+                    <a href="{% url tile.url_name %}" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light {% if request.resolver_match.view_name == tile.url_name %}active-nav-link{% endif %}">
                         {{ tile.name }}
                     </a>
                 </li>
@@ -49,26 +49,6 @@
         {% endfor %}
         {% endif %}
     </nav>
-
-    <!-- Admin-Links -->
-    <div class="p-4 border-t border-gray-200 dark:border-gray-700">
-        <ul class="space-y-2">
-            {% if user.is_staff or is_admin %}
-            <li>
-                <a href="/projects-admin/" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light">
-                    Projekt-Admin
-                </a>
-            </li>
-            {% endif %}
-            {% if user.is_superuser %}
-            <li>
-                <a href="/admin/" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light">
-                    System-Admin
-                </a>
-            </li>
-            {% endif %}
-        </ul>
-    </div>
 
     <!-- Unterer Bereich mit Zurück-Link und Theme-Schalter -->
     <div class="mt-auto p-4 border-t border-gray-200 dark:border-gray-700">

--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -41,6 +41,9 @@ html.dark {
   .sidebar-overlay-active {
     @apply block;
   }
+  .active-nav-link {
+    @apply bg-accent text-text-light font-semibold;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- erweitere Kontextprozessor um komplette Admin-Navigation
- hebe aktive Sidebar-Links hervor und speichere Akkordeon-Zustand
- ergänze CSS-Klasse und JS für persistente Sidebar

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fail: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68a7009b0b34832ba672b1ff6b52471a