### PR TITLE
feat: dynamische system admin navigation

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -88,15 +88,19 @@ def admin_navigation(request: HttpRequest) -> dict[str, list[AdminSection]]:
         )
 
     if request.user.is_superuser:
-        navigation.append(
-            {
-                "name": "System-Admin",
-                "tiles": [
-                    {"name": "Benutzer", "url_name": "admin:auth_user_changelist"},
-                    {"name": "Gruppen", "url_name": "admin:auth_group_changelist"},
-                ],
-            }
-        )
+        from django.contrib.admin import site as admin_site
+
+        system_tiles: list[AdminLink] = []
+        for app in admin_site.get_app_list(request):
+            for model in app["models"]:
+                system_tiles.append(
+                    {
+                        "name": model["name"],
+                        "url_name": f"admin:{app['app_label']}_{model['object_name'].lower()}_changelist",
+                    }
+                )
+
+        navigation.append({"name": "System-Admin", "tiles": system_tiles})
 
     return {"admin_navigation": navigation}
 

--- a/core/tests/test_navigation.py
+++ b/core/tests/test_navigation.py
@@ -114,4 +114,6 @@ class NavigationSidebarTests(TestCase):
 
         self.assertContains(response, "Projekt-Admin")
         self.assertContains(response, "System-Admin")
+        self.assertContains(response, reverse("admin:auth_user_changelist"))
+        self.assertContains(response, reverse("admin:auth_group_changelist"))
 


### PR DESCRIPTION
## Summary
- generiere System-Admin-Navigation dynamisch aus registrierten Admin-Modellen
- erweitere Test um Überprüfung der generierten Links

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fail: ModuleNotFoundError: No module named 'selenium'; IntegrityError; KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_68a70b126ca8832bb75cfa71a01ed6d2