### PR TITLE
fix: style EasyMDE editor for dark mode

### DIFF
--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -45,4 +45,25 @@
   .active-nav-link {
     @apply bg-accent text-text-light font-semibold;
   }
+
+  /* Dark-Mode-Stile für den EasyMDE-Markdown-Editor */
+  .dark .CodeMirror,
+  .dark .CodeMirror-scroll {
+    @apply bg-background-dark text-text-light;
+  }
+  .dark .CodeMirror {
+    @apply border border-gray-700;
+  }
+  .dark .editor-toolbar {
+    @apply bg-background-dark text-text-light border border-gray-700;
+  }
+  .dark .editor-toolbar button {
+    @apply text-text-light;
+  }
+  .dark .editor-toolbar button:hover {
+    @apply bg-gray-700;
+  }
+  .dark .editor-statusbar {
+    @apply bg-background-dark text-text-light border-t border-gray-700;
+  }
 }


### PR DESCRIPTION
## Summary
- style EasyMDE markdown editor for dark mode

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a791c83140832bb0b114e17f30a1b7