### PR TITLE
fix: style markdown editor for dark mode

### DIFF
--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -45,4 +45,19 @@
   .active-nav-link {
     @apply bg-accent text-text-light font-semibold;
   }
+
+  .dark .CodeMirror,
+  .dark .editor-toolbar,
+  .dark .editor-statusbar {
+    @apply bg-background-dark text-text-light border border-gray-700;
+  }
+
+  .dark .editor-toolbar button {
+    @apply text-text-light;
+  }
+
+  .dark .editor-toolbar button:hover,
+  .dark .editor-toolbar button.active {
+    @apply bg-gray-700 text-text-light;
+  }
 }


### PR DESCRIPTION
## Summary
- style EasyMDE editor for dark mode using Tailwind theme colors

## Testing
- `python manage.py makemigrations --check`
- `npm --prefix theme/static_src run build:tailwind`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a791c83140832bb0b114e17f30a1b7