### PR TITLE
fix: ensure reliable EasyMDE dark mode

### DIFF
--- a/static/js/markdown_editor.js
+++ b/static/js/markdown_editor.js
@@ -13,7 +13,12 @@ function loadEasyMDE() {
                 link.rel = 'stylesheet';
                 link.href = 'https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css';
                 link.id = cssId;
-                document.head.appendChild(link);
+                const firstStylesheet = document.head.querySelector('link[rel="stylesheet"]');
+                if (firstStylesheet) {
+                    document.head.insertBefore(link, firstStylesheet);
+                } else {
+                    document.head.appendChild(link);
+                }
             }
             const script = document.createElement('script');
             script.src = 'https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js';

--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -47,23 +47,23 @@
   }
 
   /* Dark-Mode-Stile für den EasyMDE-Markdown-Editor */
-  .dark .CodeMirror,
-  .dark .CodeMirror-scroll {
+  .dark .EasyMDEContainer .CodeMirror,
+  .dark .EasyMDEContainer .CodeMirror-scroll {
     @apply bg-background-dark text-text-light;
   }
-  .dark .CodeMirror {
+  .dark .EasyMDEContainer .CodeMirror {
     @apply border border-gray-700;
   }
-  .dark .editor-toolbar {
+  .dark .EasyMDEContainer .editor-toolbar {
     @apply bg-background-dark text-text-light border border-gray-700;
   }
-  .dark .editor-toolbar button {
+  .dark .EasyMDEContainer .editor-toolbar button {
     @apply text-text-light;
   }
-  .dark .editor-toolbar button:hover {
+  .dark .EasyMDEContainer .editor-toolbar button:hover {
     @apply bg-gray-700;
   }
-  .dark .editor-statusbar {
+  .dark .EasyMDEContainer .editor-statusbar {
     @apply bg-background-dark text-text-light border-t border-gray-700;
   }
 }


### PR DESCRIPTION
## Summary
- Ensure EasyMDE stylesheet loads before app styles to avoid overriding dark mode tweaks
- Increase specificity of EasyMDE dark-mode rules for consistent styling

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a80fe4a054832ba0685b95c6159170