### PR TITLE
Move sidebar toggle before header logo

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -30,16 +30,14 @@
 <body class="flex flex-col min-h-screen bg-background text-text dark:bg-background-dark dark:text-text-light">
     <header class="bg-header text-text-light border-b items-center">
         <div class="container mx-auto p-4 flex flex-col md:flex-row md:items-center md:justify-between">
-             <div class="flex items-center justify-between w-full md:w-auto">
-                 <div class="text-xl font-semibold">
-                     <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
-                 </div>
-                <div class="flex items-center space-x-2">
-                    <button id="sidebar-toggle" class="text-text-light" aria-label="Seitenleiste umschalten">
-                        <i class="fa-solid fa-table-columns"></i>
-                    </button>
+            <div class="flex items-center w-full md:w-auto space-x-4">
+                <button id="sidebar-toggle" class="text-text-light" aria-label="Seitenleiste umschalten">
+                    <i class="fa-solid fa-table-columns"></i>
+                </button>
+                <div class="text-xl font-semibold">
+                    <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
                 </div>
-             </div>
+            </div>
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- reposition sidebar toggle button before logo in header for desktop and mobile
- ensure toggle button stays visible across screen sizes with flexbox layout

## Testing
- `python3 manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a81e94bc18832bb41f2900cec417a9