### PR TITLE
fix: update compare version test highlight class

### DIFF
--- a/core/tests/test_compare_versions.py
+++ b/core/tests/test_compare_versions.py
@@ -26,7 +26,7 @@ class CompareVersionsAnlage1Tests(NoesisTestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Hinweis: H")
-        self.assertContains(resp, "bg-yellow-100")
+        self.assertContains(resp, "bg-warning/20")
         self.client.post(url, {"action": "negotiate"})
         current.refresh_from_db()
         self.assertTrue(current.verhandlungsfaehig)


### PR DESCRIPTION
## Summary
- align compare versions test with current highlight class

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_compare_versions.CompareVersionsAnlage1Tests.test_gap_and_diff_display -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a8230635f0832b8d61704717a7f6ad