### PR TITLE
fix: redirect non-htmx toggle for Anlage1 question review

### DIFF
--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -99,7 +99,16 @@ class ProjektFileJSONEditTests(NoesisTestCase):
     def test_question_review_saved(self):
         url = reverse("hx_toggle_anlage1_ok", args=[self.anlage1.pk, 1])
         resp = self.client.post(url)
+        self.assertRedirects(resp, reverse("projekt_detail", args=[self.projekt.pk]))
+        self.anlage1.refresh_from_db()
+        self.assertTrue(self.anlage1.question_review["1"]["ok"])
+        self.assertNotIn("note", self.anlage1.question_review["1"])
+
+    def test_question_review_saved_htmx(self):
+        url = reverse("hx_toggle_anlage1_ok", args=[self.anlage1.pk, 1])
+        resp = self.client.post(url, HTTP_HX_REQUEST="true")
         self.assertEqual(resp.status_code, 200)
+        self.assertTemplateUsed(resp, "partials/anlage1_negotiable.html")
         self.anlage1.refresh_from_db()
         self.assertTrue(self.anlage1.question_review["1"]["ok"])
         self.assertNotIn("note", self.anlage1.question_review["1"])

--- a/core/views.py
+++ b/core/views.py
@@ -5003,7 +5003,9 @@ def hx_toggle_anlage1_ok(request, pk: int, num: int):
     anlage.save(update_fields=["question_review"])
 
     context = {"anlage": anlage, "num": num, "is_ok": entry["ok"]}
-    return render(request, "partials/anlage1_negotiable.html", context)
+    if request.headers.get("HX-Request") or getattr(request, "htmx", False):
+        return render(request, "partials/anlage1_negotiable.html", context)
+    return redirect("projekt_detail", pk=anlage.project.pk)
 
 
 @login_required


### PR DESCRIPTION
## Summary
- Redirect to project detail when toggling Anlage1 question outside HTMX
- Verify redirect vs partial rendering for Anlage1 question review toggles

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_forms.ProjektFileJSONEditTests.test_question_review_saved`


------
https://chatgpt.com/codex/tasks/task_e_68a827ae4e34832ba6258ce92f57e4e9