### PR TITLE
fix: handle HTMX header more strictly

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -5003,7 +5003,7 @@ def hx_toggle_anlage1_ok(request, pk: int, num: int):
     anlage.save(update_fields=["question_review"])
 
     context = {"anlage": anlage, "num": num, "is_ok": entry["ok"]}
-    if request.headers.get("HX-Request") or getattr(request, "htmx", False):
+    if request.headers.get("HX-Request", "").lower() == "true":
         return render(request, "partials/anlage1_negotiable.html", context)
     return redirect("projekt_detail", pk=anlage.project.pk)
 


### PR DESCRIPTION
## Summary
- ensure `hx_toggle_anlage1_ok` only treats `HX-Request: true` as HTMX

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_forms.ProjektFileJSONEditTests.test_question_review_saved`


------
https://chatgpt.com/codex/tasks/task_e_68a849fa2d54832bbac57ef183784389