### PR TITLE
fix: add markdown editor to Anlage 5 review

### DIFF
--- a/templates/projekt_file_anlage5_review.html
+++ b/templates/projekt_file_anlage5_review.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load static %}
 {% block title %}Anlage 5 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 5 Zwecke prüfen</h1>
@@ -15,4 +16,15 @@
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
     {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' %}
 </form>
+{% endblock %}
+{% block extra_js %}
+<script src="{% static 'js/markdown_editor.js' %}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const el = document.getElementById('id_sonstige');
+    if (el) {
+        initMarkdownEditor(el.id);
+    }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure Anlage 5 review page loads `markdown_editor.js` and initializes the editor for the comment field

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_forms.ProjektFileJSONEditTests.test_edit_page_has_mde -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a84a164dac832b90d6c7f056e100a4