### PR TITLE
fix: allow optional manual comment in project file form

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -211,6 +211,7 @@ class BVProjectFileForm(forms.ModelForm):
             "upload",
             "parser_mode",
             "parser_order",
+            "manual_comment",
         ]
         labels = {
             "upload": "Datei",
@@ -238,6 +239,7 @@ class BVProjectFileForm(forms.ModelForm):
     def __init__(self, *args, anlage_nr=None, **kwargs):
         self.anlage_nr = anlage_nr
         super().__init__(*args, **kwargs)
+        self.fields["manual_comment"].required = False
         if self.anlage_nr is None:
             self.anlage_nr = getattr(self.instance, "anlage_nr", None)
         nr = self.anlage_nr
@@ -273,6 +275,8 @@ class BVProjectFileForm(forms.ModelForm):
 
     def save(self, commit: bool = True) -> BVProjectFile:
         obj = super().save(commit=False)
+        if self.anlage_nr is not None:
+            obj.anlage_nr = self.anlage_nr
         if "parser_mode" in self.cleaned_data:
             obj.parser_mode = self.cleaned_data.get("parser_mode") or ""
         if "parser_order" in self.cleaned_data:

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -275,4 +275,14 @@ class BVProjectFileFormTests(NoesisTestCase):
         obj = form.save(commit=False)
         self.assertEqual(obj.anlage_nr, 2)
 
+    def test_manual_comment_is_optional(self):
+        form = BVProjectFileForm(
+            {"manual_comment": "Hinweis"},
+            {"upload": SimpleUploadedFile("Anlage_1.docx", b"d")},
+            anlage_nr=1,
+        )
+        self.assertTrue(form.is_valid())
+        obj = form.save(commit=False)
+        self.assertEqual(obj.manual_comment, "Hinweis")
+
 


### PR DESCRIPTION
## Summary
- allow BVProjectFileForm to accept `manual_comment`
- ensure form saves selected Anlage number
- add regression test for manual comment handling

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_forms.BVProjectFileFormTests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a84bc6cfe4832b968b6858d614f3ba