### PR TITLE
fix: speichere analyse-task-id nach upload

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -51,5 +51,8 @@ def auto_start_analysis(sender, instance: BVProjectFile, created: bool, **kwargs
     if not created:
         return
 
-    start_analysis_for_file(instance.pk)
+    task_id = start_analysis_for_file(instance.pk)
+    if task_id:
+        instance.verification_task_id = task_id
+        instance.save(update_fields=["verification_task_id"])
 

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -459,6 +459,21 @@ class BVProjectFileTests(NoesisTestCase):
             projekt.delete()
             self.assertFalse(os.path.exists(file_path))
 
+    def test_auto_start_analysis_saves_task_id(self):
+        """Die Analyse-ID wird nach dem Upload gespeichert."""
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        with patch(
+            "core.signals.start_analysis_for_file", return_value="tid"
+        ) as mock_start:
+            pf = BVProjectFile.objects.create(
+                project=projekt,
+                anlage_nr=1,
+                upload=SimpleUploadedFile("a.txt", b"data"),
+            )
+        mock_start.assert_called_with(pf.pk)
+        pf.refresh_from_db()
+        self.assertEqual(pf.verification_task_id, "tid")
+
     def test_json_form_shows_analysis_field_for_anlage3(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         pf = BVProjectFile.objects.create(


### PR DESCRIPTION
## Zusammenfassung
- speichere die Task-ID der automatischen Analyse im Projektfile
- teste, dass die Signalbehandlung die Task-ID korrekt setzt

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_auto_start_analysis_saves_task_id -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68a84bc7a308832b9d64b489af5bf350