### PR TITLE
fix: verwende dateiname bei fehlender anlagen-nummer

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -5191,7 +5191,9 @@ def hx_project_file_upload(request, pk: int):
         except ValueError:
             anlage_nr = None
 
-    form = BVProjectFileForm(request.POST, request.FILES, anlage_nr=anlage_nr)
+    # ``request.FILES`` kann bei ``multiple``-Uploads eine Liste enthalten.
+    # Das Formular erwartet jedoch genau eine Datei.
+    form = BVProjectFileForm(request.POST, {"upload": upload}, anlage_nr=anlage_nr)
 
     if form.is_valid() and anlage_nr:
         saved_file = _save_project_file(projekt, form=form)


### PR DESCRIPTION
## Zusammenfassung
- Verhindert Validierungsfehler beim Einzel-Upload, indem die Datei direkt an das Formular übergeben wird
- Damit wird die Anlagen-Nummer aus dem Dateinamen korrekt erkannt

## Test
- `python manage.py makemigrations --check`
- `DJANGO_SETTINGS_MODULE=noesis.settings pytest core/tests/test_general.py -k test_upload_uses_filename_when_no_anlage_nr -q` *(scheiterte: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_68a84f21481c832b86cc1d6693539270