### PR TITLE
fix: derive attachment number from filename on upload

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -5191,9 +5191,13 @@ def hx_project_file_upload(request, pk: int):
         except ValueError:
             anlage_nr = None
 
+    data = request.POST.copy()
+    if anlage_nr is not None and not data.get("anlage_nr"):
+        data["anlage_nr"] = str(anlage_nr)
+
     # ``request.FILES`` kann bei ``multiple``-Uploads eine Liste enthalten.
     # Das Formular erwartet jedoch genau eine Datei.
-    form = BVProjectFileForm(request.POST, {"upload": upload}, anlage_nr=anlage_nr)
+    form = BVProjectFileForm(data, {"upload": upload}, anlage_nr=anlage_nr)
 
     if form.is_valid() and anlage_nr:
         saved_file = _save_project_file(projekt, form=form)


### PR DESCRIPTION
## Summary
- ensure `hx_project_file_upload` injects derived `anlage_nr` into POST data before validation
- test upload without `anlage_nr` in form uses filename

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ProjektFileUploadTests.test_upload_without_anlage_nr_uses_filename -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a863d06364832b8149c6703073c498