### PR TITLE
fix: korrigiere Testfall für projekt_file_check_view

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2890,7 +2890,7 @@ class ProjektFileCheckResultTests(NoesisTestCase):
         self.assertRedirects(
             resp, reverse("projekt_file_edit_json", args=[self.file.pk])
         )
-        mock_func.assert_called_with(self.projekt.pk, model_name=None)
+        mock_func.assert_called_with(self.file.pk, model_name=None)
 
     def test_anlage2_uses_parser_by_default(self):
         url = reverse("projekt_file_check_view", args=[self.file2.pk])


### PR DESCRIPTION
## Zusammenfassung
- Stelle sicher, dass `check_anlage1` im Test mit der ID der Anlagendatei aufgerufen wird.

## Testing
- `python manage.py makemigrations --check`
- `pre-commit run --files core/tests/test_general.py`
- `python manage.py test core.tests.test_general.ProjektFileCheckResultTests.test_post_triggers_check_and_redirects -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a8669aa560832bb52788370328cfe3