### PR TITLE
Remove obsolete async reanalysis test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -3288,19 +3288,6 @@ class ModelSelectionTests(NoesisTestCase):
         self.assertEqual(pf.verification_task_id, "tid")
         self.assertEqual(pf.processing_status, BVProjectFile.PROCESSING)
 
-    def test_prompt_save_triggers_async_check(self):
-        url = reverse("edit_project_context", args=[self.projekt.pk])
-        with patch("core.models.async_task") as mock_task:
-            resp = self.client.post(url, {"project_prompt": "Test"})
-        self.assertRedirects(
-            resp,
-            reverse("projekt_detail", args=[self.projekt.pk]),
-        )
-        mock_task.assert_called_with(
-            "core.llm_tasks.run_conditional_anlage2_check",
-            self.pf2.pk,
-        )
-
 
 class FunctionImportExportTests(NoesisTestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- remove outdated test `test_prompt_save_triggers_async_check` from `ModelSelectionTests`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.ModelSelectionTests` *(fails: expected call not found in `test_file_check_uses_category`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8704a53f0832bb47edb265940d994