### PR TITLE
feat: vereinheitlichte Grautöne

### DIFF
--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -10,11 +10,11 @@
             <p class="text-error mb-4">{% trans 'Bitte gültige Zugangsdaten eingeben.' %}</p>
         {% endif %}
         <div class="mb-4">
-            <label for="id_username" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{% trans 'Benutzername' %}</label>
+            <label for="id_username" class="block text-sm font-medium text-muted mb-1">{% trans 'Benutzername' %}</label>
              <input type="text" name="username" id="id_username" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" autofocus required>
         </div>
         <div class="mb-6">
-            <label for="id_password" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{% trans 'Passwort' %}</label>
+            <label for="id_password" class="block text-sm font-medium text-muted mb-1">{% trans 'Passwort' %}</label>
              <input type="password" name="password" id="id_password" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" required>
         </div>
         <input type="hidden" name="next" value="{{ next }}" />

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -15,11 +15,11 @@
     <input type="hidden" name="active_tab" id="active_tab" value="{{ active_tab }}">
     <input type="hidden" name="phrase_key" id="phrase_key" value="">
     <nav class="border-b border-gray-200 space-x-2 mb-4">
-        <button type="button" data-tab="table" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Tabellen-Parser</button>
-        <button type="button" data-tab="general" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Allgemein</button>
-        <button type="button" data-tab="rules" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Parser-Antwortregeln</button>
-        <button type="button" data-tab="rules2" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Regeln Fallback</button>
-        <button type="button" data-tab="a4" class="px-4 py-2 text-gray-600 dark:text-gray-300 bg-gray-200 border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Anlage 4 Parser</button>
+        <button type="button" data-tab="table" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Tabellen-Parser</button>
+        <button type="button" data-tab="general" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Allgemein</button>
+        <button type="button" data-tab="rules" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Parser-Antwortregeln</button>
+        <button type="button" data-tab="rules2" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Regeln Fallback</button>
+        <button type="button" data-tab="a4" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Anlage 4 Parser</button>
     </nav>
     <div id="tab-table" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Tabellen-Parser: Spaltenüberschriften (Alias)</h2>
@@ -62,7 +62,7 @@
                 {{ config_form.enforce_subquestion_override }}
                 {{ config_form.enforce_subquestion_override.label }}
             </label>
-            <p class="text-sm text-gray-600 dark:text-gray-300">
+            <p class="text-sm text-muted">
                 {{ config_form.enforce_subquestion_override.help_text }}
             </p>
             {{ config_form.enforce_subquestion_override.errors }}
@@ -136,11 +136,11 @@ function showTab(tab){
     document.getElementById('active_tab').value=tab;
     document.querySelectorAll('[data-tab]').forEach(btn=>{
         if(btn.dataset.tab===tab){
-            btn.classList.remove('bg-gray-200','text-gray-600','dark:text-gray-300','border-b-0');
+            btn.classList.remove('bg-muted','text-muted','border-b-0');
             btn.classList.add('bg-background','text-accent','font-semibold','border-b-transparent');
         }else{
             btn.classList.remove('bg-background','text-accent','font-semibold','border-b-transparent');
-            btn.classList.add('bg-gray-200','text-gray-600','dark:text-gray-300','border-b-0');
+            btn.classList.add('bg-muted','text-muted','border-b-0');
         }
     });
 }

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -44,7 +44,7 @@
         {% if a.analysis_json %}
         <tr class="border-b">
             <td colspan="3">
-                <div class="prose dark:prose-invert max-w-none bg-gray-100 p-2 rounded">
+                <div class="prose dark:prose-invert max-w-none bg-muted p-2 rounded">
                     {{ a.analysis_json|tojson|markdownify }}
                 </div>
                 <div class="mt-1 space-x-2">

--- a/templates/partials/_form_select.html
+++ b/templates/partials/_form_select.html
@@ -12,7 +12,7 @@
 </select>
 {% if not multiple %}
   <div class="pointer-events-none absolute inset-y-0 right-2 flex items-center">
-    <svg class="h-4 w-4 text-gray-500 dark:text-gray-300" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+    <svg class="h-4 w-4 text-muted" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       <path d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"/>
     </svg>
   </div>

--- a/templates/partials/_role_tile_form.html
+++ b/templates/partials/_role_tile_form.html
@@ -2,7 +2,7 @@
 <form method="post" class="space-y-4">
     {% csrf_token %}
     <input type="hidden" name="group_id" value="{{ selected_group.id }}">
-    <p class="text-gray-700 dark:text-gray-300">Wähle die sichtbaren Kacheln für diese Rolle aus.</p>
+    <p class="text-muted">Wähle die sichtbaren Kacheln für diese Rolle aus.</p>
     {% for area, items in tiles_by_area.items %}
         <h2 class="text-xl font-semibold mt-4">{{ area.name }}-Dashboard</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-2">

--- a/templates/partials/markdown_editor.html
+++ b/templates/partials/markdown_editor.html
@@ -3,7 +3,7 @@
   {% if label %}
   <label for="{{ id_prefix }}-textarea" class="font-semibold">{{ label }}</label>
   {% endif %}
-  <div id="{{ id_prefix }}-view" class="prose dark:prose-invert max-w-none bg-gray-100 p-2 rounded">{{ text|markdownify }}</div>
+  <div id="{{ id_prefix }}-view" class="prose dark:prose-invert max-w-none bg-muted p-2 rounded">{{ text|markdownify }}</div>
     <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
   <div class="flex space-x-2">
     {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-edit' label='Bearbeiten' variant='primary' %}

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -12,15 +12,15 @@
     data-func-id="{{ row.func_id }}" {% if row.sub %}data-sub-id="{{ row.sub_id }}"{% endif %}>
     <td class="border px-2 {% if row.sub %}pl-8{% endif %}">
         {% if not row.sub %}
-        <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
+        <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-muted hover:bg-muted" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-muted hover:bg-muted">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% else %}
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-muted hover:bg-muted">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% endif %}
         {% if row.source_text and row.source_text != 'N/A' %}
@@ -42,7 +42,7 @@
     {% endfor %}
     {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}
     <td class="border px-2 text-center action-column">
-        <button type="button" class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600"
+        <button type="button" class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-muted hover:bg-muted"
             data-state="robot" title="KI-Prüfung starten"
             data-project-file-id="{{ anlage.pk }}"
             data-function-id="{{ row.func_id }}"

--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -33,7 +33,7 @@
                         {{ row.entry.description|markdownify }}
                     </div>
                 {% elif row.entry and row.entry.is_known_by_llm is False %}
-                    <p class="text-sm text-gray-500 dark:text-gray-400">Die automatische Prüfung konnte diese Software nicht eindeutig identifizieren.</p>
+                    <p class="text-sm text-muted">Die automatische Prüfung konnte diese Software nicht eindeutig identifizieren.</p>
                 {% else %}
                 {% endif %}
             </div>

--- a/templates/partials/software_tab_gutachten.html
+++ b/templates/partials/software_tab_gutachten.html
@@ -31,7 +31,7 @@
                         {{ row.entry.gutachten.text|markdownify }}
                     </div>
                 {% elif row.entry %}
-                    <span class="text-sm text-gray-500 dark:text-gray-400">Noch kein Gutachten vorhanden</span>
+                    <span class="text-sm text-muted">Noch kein Gutachten vorhanden</span>
                 {% endif %}
             </div>
         </div>

--- a/templates/partials/supervision_group.html
+++ b/templates/partials/supervision_group.html
@@ -1,5 +1,5 @@
 <details class="border rounded" {% if group.function and group.function.has_discrepancy %}open{% endif %}>
-  <summary class="p-2 cursor-pointer {% if group.function and group.function.has_discrepancy %}bg-error-light{% else %}bg-gray-100{% endif %}">
+  <summary class="p-2 cursor-pointer {% if group.function and group.function.has_discrepancy %}bg-error-light{% else %}bg-muted{% endif %}">
     {% if group.function %}{{ group.function.name }}{% else %}{{ group.name }}{% endif %}
     {% if group.subrows %}<span class="ms-2">+</span>{% endif %}
   </summary>

--- a/templates/partials/supervision_row.html
+++ b/templates/partials/supervision_row.html
@@ -1,5 +1,5 @@
 <details class="border rounded" {% if row.has_discrepancy %}open{% endif %}>
-  <summary class="p-2 cursor-pointer {% if row.has_discrepancy %}bg-error-light{% else %}bg-gray-100{% endif %}">
+  <summary class="p-2 cursor-pointer {% if row.has_discrepancy %}bg-error-light{% else %}bg-muted{% endif %}">
     {{ row.name }}
     {% if row.has_discrepancy %}<span class="ms-2 text-error">⚠️</span>{% endif %}
   </summary>

--- a/templates/personal.html
+++ b/templates/personal.html
@@ -20,7 +20,7 @@
         {% endif %}
         <div class="p-4 bg-background">
             <h3 class="text-lg font-semibold mb-2">{{ tile.name }}</h3>
-            <p class="text-gray-600 dark:text-gray-300">{{ tile.description }}</p>
+            <p class="text-muted">{{ tile.description }}</p>
         </div>
     </a>
     {% endfor %}

--- a/templates/projekt_cockpit.html
+++ b/templates/projekt_cockpit.html
@@ -1,4 +1,4 @@
-<div class="bg-gray-100 dark:bg-gray-800 p-4 rounded">
+<div class="bg-muted p-4 rounded">
   <h3 class="font-semibold mb-2">Projektinfo</h3>
   <p><strong>Erstellt am:</strong> {{ projekt.created_at|date:"d.m.Y" }}</p>
   <p class="mt-1"><strong>Software:</strong> {{ projekt.software_string }}</p>

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -43,7 +43,7 @@
 <h2 class="text-xl font-semibold mb-4">Anlagen</h2>
 <nav class="flex space-x-2 mb-4" id="anlage-tabs-nav">
   {% for nr in anlage_numbers %}
-  <button class="anlage-tab px-3 py-1 border-b-2 {% if forloop.first %}border-primary text-primary{% else %}border-transparent text-gray-600 dark:text-gray-300{% endif %}"
+  <button class="anlage-tab px-3 py-1 border-b-2 {% if forloop.first %}border-primary text-primary{% else %}border-transparent text-muted{% endif %}"
           hx-get="{% url 'hx_project_anlage_tab' projekt.pk nr %}"
           hx-target="#anlage-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-nr="{{ nr }}">
@@ -96,7 +96,7 @@ function renderLLM(data){
    </div>`;
  }else if(data.ist_llm_geprueft && data.llm_validated){
   sec.innerHTML=`<button id="toggle" class="bg-success text-background px-4 py-2 rounded mb-2">Antwort ein-/ausblenden</button>
-  <div id="output" class="prose dark:prose-invert max-w-none bg-gray-100 p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
+  <div id="output" class="prose dark:prose-invert max-w-none bg-muted p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
  }
  if(data.llm_initial_output){
   sec.innerHTML += `<button id="recheck" class="bg-primary text-background px-4 py-2 rounded mt-2">Erneut prüfen</button>`;
@@ -243,17 +243,17 @@ document.addEventListener('htmx:beforeRequest',function(e){
   if(t.classList.contains('anlage-tab')){
     document.querySelectorAll('.anlage-tab').forEach(b=>{
       b.classList.remove('border-primary','text-primary');
-      b.classList.add('border-transparent','text-gray-600','dark:text-gray-300');
+      b.classList.add('border-transparent','text-muted');
     });
-    t.classList.remove('border-transparent','text-gray-600','dark:text-gray-300');
+    t.classList.remove('border-transparent','text-muted');
     t.classList.add('border-primary','text-primary');
   }
   if(t.classList.contains('software-tab')){
     document.querySelectorAll('.software-tab').forEach(b=>{
       b.classList.remove('border-primary','text-primary');
-      b.classList.add('border-transparent','text-gray-600','dark:text-gray-300');
+      b.classList.add('border-transparent','text-muted');
     });
-    t.classList.remove('border-transparent','text-gray-600','dark:text-gray-300');
+    t.classList.remove('border-transparent','text-muted');
     t.classList.add('border-primary','text-primary');
   }
 });

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -60,11 +60,11 @@
                 data-func-id="{{ row.func_id }}" {% if row.sub %}data-sub-id="{{ row.sub_id }}"{% endif %}>
                 <td class="border px-2 {% if row.sub %}pl-8{% endif %}">
                     {% if not row.sub %}
-                    <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
+                    <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-muted hover:bg-muted" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-muted hover:bg-muted">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
@@ -72,7 +72,7 @@
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-muted hover:bg-muted">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
@@ -98,7 +98,7 @@
                 <td class="border px-2 text-center action-column hidden">
                     {% if allow_ai_check %}
                     <button type="button"
-                        class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600"
+                        class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-muted hover:bg-muted"
                         data-state="robot" data-popover-content="KI-Prüfung starten"
                         data-project-file-id="{{ anlage.pk }}"
                         data-function-id="{{ row.func_id }}"

--- a/templates/projekt_initial_pruefung.html
+++ b/templates/projekt_initial_pruefung.html
@@ -10,7 +10,7 @@
           hx-get="{% url 'hx_project_software_tab' projekt.pk 'tech' %}"
           hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-tab="tech">Technische Prüfung</button>
-  <button class="software-tab px-3 py-1 border-b-2 border-transparent text-gray-600 dark:text-gray-300"
+  <button class="software-tab px-3 py-1 border-b-2 border-transparent text-muted"
           hx-get="{% url 'hx_project_software_tab' projekt.pk 'gutachten' %}"
           hx-target="#software-tab-content" hx-swap="innerHTML" hx-push-url="false"
           data-tab="gutachten">Gutachten</button>
@@ -104,9 +104,9 @@ document.addEventListener('htmx:beforeRequest',function(e){
   if(t.classList.contains('software-tab')){
     document.querySelectorAll('.software-tab').forEach(b=>{
       b.classList.remove('border-primary','text-primary');
-      b.classList.add('border-transparent','text-gray-600','dark:text-gray-300');
+      b.classList.add('border-transparent','text-muted');
     });
-    t.classList.remove('border-transparent','text-gray-600','dark:text-gray-300');
+    t.classList.remove('border-transparent','text-muted');
     t.classList.add('border-primary','text-primary');
   }
 });

--- a/templates/talkdiary_detail.html
+++ b/templates/talkdiary_detail.html
@@ -3,7 +3,7 @@
 {% block title %}Transcript{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">{{ recording.audio_file.name|basename }}</h1>
-<p class="text-sm text-gray-600 dark:text-gray-300 mb-4">{{ recording.created_at|date:'d.m.Y H:i' }} - {{ recording.bereich }}</p>
+<p class="text-sm text-muted mb-4">{{ recording.created_at|date:'d.m.Y H:i' }} - {{ recording.bereich }}</p>
 <audio controls src="{{ recording.audio_file.url }}" class="mb-4 w-full"></audio>
 <div class="prose dark:prose-invert max-w-none">
     {{ transcript_text|markdownify }}

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -12,7 +12,7 @@
         <button type="submit" class="bg-error text-background px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
       </form>
     </h2>
-    <pre class="whitespace-pre-wrap border p-2 bg-gray-100">{{ file.manual_analysis_json|default:file.analysis_json|tojson }}</pre>
+    <pre class="whitespace-pre-wrap border p-2 bg-muted">{{ file.manual_analysis_json|default:file.analysis_json|tojson }}</pre>
   </div>
   {% if parent %}
   <div>
@@ -23,7 +23,7 @@
         <button type="submit" class="bg-error text-background px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
       </form>
     </h2>
-    <pre class="whitespace-pre-wrap border p-2 bg-gray-100">{{ parent.manual_analysis_json|default:parent.analysis_json|tojson }}</pre>
+    <pre class="whitespace-pre-wrap border p-2 bg-muted">{{ parent.manual_analysis_json|default:parent.analysis_json|tojson }}</pre>
   </div>
   {% endif %}
 </div>

--- a/theme/static_src/src/styles.css
+++ b/theme/static_src/src/styles.css
@@ -22,6 +22,7 @@
   --color-error-dark: #be123c;
   --color-warning: #facc15;
   --color-warning-dark: #eab308;
+  --color-muted: #475569;
 }
 
 @import "./components.css";
@@ -29,6 +30,7 @@
 html.dark {
   --color-background: var(--color-background-dark);
   --color-text: var(--color-text-light);
+  --color-muted: #cbd5e1;
 }
 
 /**

--- a/theme/static_src/tailwind.config.js
+++ b/theme/static_src/tailwind.config.js
@@ -61,6 +61,7 @@ export default {
           DEFAULT: '#facc15',
           dark: '#eab308',
         },
+        muted: 'var(--color-muted)',
         gray: {
           50: '#f8fafc',
           100: '#f1f5f9',


### PR DESCRIPTION
## Zusammenfassung
- neue CSS-Variable `--color-muted` samt Dark‑Mode-Wert eingeführt
- Tailwind-Konfiguration um `text-muted`/`bg-muted` erweitert
- Templates auf die neuen Utilities umgestellt

## Testing
- `npm --prefix theme/static_src run build`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a871acf630832bb3bca424b4153724