### PR TITLE
fix: patch freitext parser correctly in anlage2 reset test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -4639,7 +4639,7 @@ class Anlage2ResetTests(NoesisTestCase):
                 "core.llm_tasks.parse_anlage2_table",
                 return_value=[{"funktion": "Login"}],
             ),
-            patch("core.llm_tasks.parse_anlage2_text", return_value=[]),
+            patch("core.text_parser.parse_anlage2_text", return_value=[]),
         ):
             run_anlage2_analysis(pf)
         results = AnlagenFunktionsMetadaten.objects.filter(


### PR DESCRIPTION
## Summary
- fix test `test_run_anlage2_analysis_resets_results` to patch `parse_anlage2_text` from `core.text_parser` instead of `core.llm_tasks`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.Anlage2ResetTests.test_run_anlage2_analysis_resets_results -v 2` *(fails: AssertionError 2 != 1)*


------
https://chatgpt.com/codex/tasks/task_e_68a87b655fbc832ba2270308e894a42e