### PR TITLE
Fix user area export in permissions view

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -2226,7 +2226,11 @@ def admin_edit_user_permissions(request, user_id):
 @admin_required
 def admin_export_users_permissions(request):
     """Exportiert Benutzer, Gruppen und Tile-Zuordnungen als JSON."""
-    users = User.objects.all().prefetch_related("groups", "tiles").order_by("username")
+    users = (
+        User.objects.all()
+        .prefetch_related("groups", "tiles", "userareaaccess_set__area")
+        .order_by("username")
+    )
     data = []
     for user in users:
         group_tiles = Tile.objects.filter(groups__in=user.groups.all()).values_list(
@@ -2236,7 +2240,10 @@ def admin_export_users_permissions(request):
             "slug", flat=True
         )
         tiles = set(user.tiles.values_list("url_name", flat=True)) | set(group_tiles)
-        areas = set(user.areas.values_list("slug", flat=True)) | set(group_areas)
+        user_areas = Area.objects.filter(userareaaccess__user=user).values_list(
+            "slug", flat=True
+        )
+        areas = set(user_areas) | set(group_areas)
         data.append(
             {
                 "username": user.username,


### PR DESCRIPTION
## Summary
- resolve AttributeError in admin_export_users_permissions by joining Area through UserAreaAccess

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.UserImportExportTests.test_export_json -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68a887fe2cfc832bbe277ab69054739d