### PR TITLE
fix: aktualisierte tests für anlage 3 analyse

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -777,13 +777,15 @@ def analyse_anlage3(file_id: int, model_name: str | None = None) -> dict:
         anlage3_logger.debug("Seitenzahl der Datei: %s", pages)
 
         if pages <= 1:
-            data = {"task": "analyse_anlage3", "auto_ok": True, "pages": pages}
+            data = {
+                "task": "analyse_anlage3",
+                "result": {"status": "auto_ok", "pages": pages},
+            }
             verhandlungsfaehig = True
         else:
             data = {
                 "task": "analyse_anlage3",
-                "manual_required": True,
-                "pages": pages,
+                "result": {"status": "manual_required", "pages": pages},
             }
             verhandlungsfaehig = False
 

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2154,11 +2154,13 @@ class LLMTasksTests(NoesisTestCase):
 
         pf = projekt.anlagen.get(anlage_nr=3)
         data = analyse_anlage3(pf.pk)
-        file_obj = pf
-        self.assertTrue(data["auto_ok"])  # pages <= 1
-        self.assertEqual(file_obj.analysis_json["auto_ok"], True)
-        if hasattr(file_obj, "verhandlungsfaehig"):
-            self.assertTrue(file_obj.verhandlungsfaehig)
+        pf.refresh_from_db()
+        result = data.get("result", {})
+        self.assertEqual(result.get("status"), "auto_ok")
+        self.assertEqual(result.get("pages"), 1)
+        self.assertEqual(pf.analysis_json.get("result", {}).get("status"), "auto_ok")
+        if hasattr(pf, "verhandlungsfaehig"):
+            self.assertTrue(pf.verhandlungsfaehig)
 
     def test_analyse_anlage3_manual_required(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -2181,11 +2183,13 @@ class LLMTasksTests(NoesisTestCase):
 
         pf = projekt.anlagen.get(anlage_nr=3)
         data = analyse_anlage3(pf.pk)
-        file_obj = pf
-        self.assertTrue(data["manual_required"])  # pages > 1
-        self.assertEqual(file_obj.analysis_json["manual_required"], True)
-        if hasattr(file_obj, "verhandlungsfaehig"):
-            self.assertFalse(file_obj.verhandlungsfaehig)
+        pf.refresh_from_db()
+        result = data.get("result", {})
+        self.assertEqual(result.get("status"), "manual_required")
+        self.assertEqual(result.get("pages"), 2)
+        self.assertEqual(pf.analysis_json.get("result", {}).get("status"), "manual_required")
+        if hasattr(pf, "verhandlungsfaehig"):
+            self.assertFalse(pf.verhandlungsfaehig)
 
     def test_analyse_anlage3_pdf_auto_ok(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -2206,9 +2210,11 @@ class LLMTasksTests(NoesisTestCase):
 
         pf = projekt.anlagen.get(anlage_nr=3)
         data = analyse_anlage3(pf.pk)
-        file_obj = pf
-        self.assertTrue(data["auto_ok"])  # pages <= 1
-        self.assertEqual(file_obj.analysis_json["auto_ok"], True)
+        pf.refresh_from_db()
+        result = data.get("result", {})
+        self.assertEqual(result.get("status"), "auto_ok")
+        self.assertEqual(result.get("pages"), 1)
+        self.assertEqual(pf.analysis_json.get("result", {}).get("status"), "auto_ok")
 
     def test_analyse_anlage3_pdf_manual_required(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -2230,9 +2236,11 @@ class LLMTasksTests(NoesisTestCase):
 
         pf = projekt.anlagen.get(anlage_nr=3)
         data = analyse_anlage3(pf.pk)
-        file_obj = pf
-        self.assertTrue(data["manual_required"])  # pages > 1
-        self.assertEqual(file_obj.analysis_json["manual_required"], True)
+        pf.refresh_from_db()
+        result = data.get("result", {})
+        self.assertEqual(result.get("status"), "manual_required")
+        self.assertEqual(result.get("pages"), 2)
+        self.assertEqual(pf.analysis_json.get("result", {}).get("status"), "manual_required")
 
     def test_analyse_anlage3_multiple_files(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -2804,7 +2812,7 @@ class ProjektFileDeleteResultTests(NoesisTestCase):
             anlage_nr=3,
             upload=SimpleUploadedFile("d.txt", b"data"),
             text_content="Text",
-            analysis_json={"auto_ok": True},
+            analysis_json={"result": {"status": "auto_ok"}},
             manual_analysis_json={"functions": {}},
             verification_json={"functions": {}},
             manual_reviewed=True,

--- a/core/views.py
+++ b/core/views.py
@@ -912,7 +912,8 @@ def get_cockpit_context(projekt: BVProject) -> dict[str, Any]:
             }
         )
         data = f.analysis_json if isinstance(f.analysis_json, dict) else {}
-        if data.get("manual_required"):
+        status = data.get("result", {}).get("status")
+        if status == "manual_required":
             next_steps.append(f"Anlage {f.anlage_nr}: manuelle Prüfung notwendig")
         elif f.processing_status != BVProjectFile.COMPLETE:
             next_steps.append(f"Anlage {f.anlage_nr}: Analyse starten")


### PR DESCRIPTION
## Summary
- refactor analyse_anlage3 to return nested result with status and page count
- adjust views to read new analysis structure
- update Anlage 3 tests to validate nested result

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.LLMTasksTests.test_analyse_anlage3_auto_ok core.tests.test_general.LLMTasksTests.test_analyse_anlage3_manual_required core.tests.test_general.LLMTasksTests.test_analyse_anlage3_pdf_auto_ok core.tests.test_general.LLMTasksTests.test_analyse_anlage3_pdf_manual_required core.tests.test_general.ProjektFileDeleteResultTests.test_delete_resets_fields -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a88e9446d4832b896caec75a41be55