### PR TITLE
fix: return string for async task mock in HX status test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -598,7 +598,14 @@ class BVProjectFileTests(NoesisTestCase):
 
     def test_hx_anlage_status_ready(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        with patch("core.signals.start_analysis_for_file"):
+        # Der Signal-Handler `auto_start_analysis` speichert die
+        # R\xFCckgabe von `start_analysis_for_file` als Task-ID. Wenn der
+        # Mock kein einfaches String-Ergebnis liefert, w\xFCrde ein
+        # `FieldError` auftreten. Daher liefern wir explizit eine
+        # Zeichenkette zur\xFCck.
+        with patch(
+            "core.signals.start_analysis_for_file", return_value="mocked_task_id"
+        ):
             pf = BVProjectFile.objects.create(
                 project=projekt,
                 anlage_nr=2,


### PR DESCRIPTION
## Summary
- ensure `start_analysis_for_file` mock returns a string task id in HX status test
- prevent `FieldError` when saving the mocked task id

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_hx_anlage_status_ready -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a88f541d70832b860480a59e5c6225