### PR TITLE
fix: use LLMConfig singleton in admin model test

### DIFF
--- a/core/tests/test_admin_views.py
+++ b/core/tests/test_admin_views.py
@@ -149,12 +149,12 @@ class AdminModelsViewTests(NoesisTestCase):
         self.user = User.objects.create_user("amodel", password="pass")
         self.user.groups.add(admin_group)
         self.client.login(username="amodel", password="pass")
-        self.cfg = LLMConfig.objects.create(
-            default_model="a",
-            gutachten_model="a",
-            anlagen_model="a",
-            available_models=["a", "b"],
-        )
+        self.cfg = LLMConfig.get_instance()
+        self.cfg.default_model = "a"
+        self.cfg.gutachten_model = "a"
+        self.cfg.anlagen_model = "a"
+        self.cfg.available_models = ["a", "b"]
+        self.cfg.save()
 
     def test_update_models(self):
         url = reverse("admin_models")


### PR DESCRIPTION
## Summary
- ensure AdminModelsViewTests uses the shared LLMConfig singleton and sets initial values

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_admin_views.AdminModelsViewTests.test_update_models -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a8913756b0832b86eabf6e1a2bd3b8