### PR TITLE
fix: use valid Anlage2Function in tests

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -521,7 +521,7 @@ class BVProjectFileTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"x"),
             verification_task_id="tid",
         )
-        Anlage2Function.objects.get(name="Login")
+        Anlage2Function.objects.get(name="Anmelden")
         with (
             patch("core.llm_tasks.query_llm", return_value="{}"),
             patch("core.llm_tasks.async_task") as mock_async,
@@ -848,7 +848,7 @@ class ProjektFileUploadTests(NoesisTestCase):
         table = doc.add_table(rows=2, cols=2)
         table.cell(0, 0).text = "Funktion"
         table.cell(0, 1).text = "Technisch vorhanden"
-        table.cell(1, 0).text = "Login"
+        table.cell(1, 0).text = "Anmelden"
         table.cell(1, 1).text = "Ja"
         tmp = NamedTemporaryFile(delete=False, suffix=".docx")
         doc.save(tmp.name)
@@ -857,7 +857,7 @@ class ProjektFileUploadTests(NoesisTestCase):
             upload = SimpleUploadedFile("Anlage_2.docx", fh.read())
         Path(tmp.name).unlink(missing_ok=True)
 
-        Anlage2Function.objects.get(name="Login")
+        Anlage2Function.objects.get(name="Anmelden")
 
         url = reverse("hx_project_file_upload", args=[self.projekt.pk])
         mock_async = Mock(side_effect=["tid1", "tid2"])
@@ -891,7 +891,7 @@ class ProjektFileUploadTests(NoesisTestCase):
         )
 
     def test_second_anlage2_version_skips_ai_check(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         first = BVProjectFile.objects.create(
             project=self.projekt,
             anlage_nr=2,
@@ -1238,7 +1238,7 @@ class BVProjectModelTests(NoesisTestCase):
 class AnlagenFunktionsMetadatenModelTests(NoesisTestCase):
     def test_manual_result_field(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         pf = BVProjectFile.objects.create(
             project=projekt,
             anlage_nr=2,
@@ -1535,7 +1535,7 @@ class LLMTasksTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Anlagetext",
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         llm_reply = json.dumps({"technisch_verfuegbar": True})
         with patch("core.llm_tasks.query_llm", return_value=llm_reply) as mock_q:
             data = check_anlage2(projekt.pk)
@@ -1557,7 +1557,7 @@ class LLMTasksTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("a.txt", b"data"),
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         llm_reply = json.dumps({"technisch_verfuegbar": True})
         with (
             patch("core.llm_tasks.query_llm", return_value=llm_reply),
@@ -1586,13 +1586,13 @@ class LLMTasksTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Testinhalt Anlage2",
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         llm_reply = json.dumps({"technisch_verfuegbar": False})
         with patch("core.llm_tasks.query_llm", return_value=llm_reply) as mock_q:
             data = check_anlage2(projekt.pk)
         self.assertIn("Testinhalt Anlage2", mock_q.call_args_list[0].args[0].text)
         file_obj = projekt.anlagen.get(anlage_nr=2)
-        self.assertEqual(data["functions"][0]["funktion"], "Login")
+        self.assertEqual(data["functions"][0]["funktion"], "Anmelden")
 
     def test_check_anlage2_prompt_contains_text(self):
         """Der Prompt enth\u00e4lt den gesamten Anlagentext."""
@@ -1603,14 +1603,14 @@ class LLMTasksTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"data"),
             text_content="Testinhalt Anlage2",
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         llm_reply = json.dumps({"technisch_verfuegbar": False})
         with patch("core.llm_tasks.query_llm", return_value=llm_reply) as mock_q:
             data = check_anlage2(projekt.pk)
         prompt = mock_q.call_args_list[0].args[0].text
         self.assertIn("Testinhalt Anlage2", prompt)
         file_obj = projekt.anlagen.get(anlage_nr=2)
-        self.assertEqual(data["functions"][0]["funktion"], "Login")
+        self.assertEqual(data["functions"][0]["funktion"], "Anmelden")
 
     def test_check_anlage2_parser(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -1621,7 +1621,7 @@ class LLMTasksTests(NoesisTestCase):
         table.cell(0, 2).text = "Einsatz bei Telefónica"
         table.cell(0, 3).text = "Zur LV-Kontrolle"
         table.cell(0, 4).text = "KI-Beteiligung"
-        table.cell(1, 0).text = "Login"
+        table.cell(1, 0).text = "Anmelden"
         table.cell(1, 1).text = "Ja"
         table.cell(1, 2).text = "Nein"
         table.cell(1, 3).text = "Nein"
@@ -1638,7 +1638,7 @@ class LLMTasksTests(NoesisTestCase):
             upload=upload,
             text_content="ignored",
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
 
         with patch("core.llm_tasks.query_llm") as mock_q:
             data = check_anlage2(projekt.pk)
@@ -1647,7 +1647,7 @@ class LLMTasksTests(NoesisTestCase):
             "task": "check_anlage2",
             "functions": [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "ki_beteiligung": {"value": True, "note": None},
                     "source": "parser",
@@ -1668,7 +1668,7 @@ class LLMTasksTests(NoesisTestCase):
         table.cell(0, 2).text = "Einsatz bei Telefónica"
         table.cell(0, 3).text = "Zur LV-Kontrolle"
         table.cell(0, 4).text = "KI-Beteiligung"
-        table.cell(1, 0).text = "Login"
+        table.cell(1, 0).text = "Anmelden"
         table.cell(1, 1).text = "Ja"
         table.cell(1, 2).text = "Nein"
         table.cell(1, 3).text = "Nein"
@@ -1683,9 +1683,9 @@ class LLMTasksTests(NoesisTestCase):
             project=projekt,
             anlage_nr=2,
             upload=upload,
-            text_content="Login: tv: ja; tel: nein; lv: nein; ki: ja",
+            text_content="Anmelden: tv: ja; tel: nein; lv: nein; ki: ja",
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         cfg = Anlage2Config.get_instance()
         cfg.parser_mode = "table_only"
         cfg.parser_order = ["table"]
@@ -1703,7 +1703,7 @@ class LLMTasksTests(NoesisTestCase):
         result = run_anlage2_analysis(pf)
         expected = [
             {
-                "funktion": "Login",
+                "funktion": "Anmelden",
                 "technisch_verfuegbar": {"value": True, "note": None},
                 "einsatz_telefonica": {"value": False, "note": None},
                 "zur_lv_kontrolle": {"value": False, "note": None},
@@ -1719,7 +1719,7 @@ class LLMTasksTests(NoesisTestCase):
         self.assertTrue(fe.technisch_verfuegbar)
 
         login_entry = next(
-            f for f in pf.analysis_json["functions"] if f["funktion"] == "Login"
+            f for f in pf.analysis_json["functions"] if f["funktion"] == "Anmelden"
         )
         self.assertTrue(login_entry["technisch_verfuegbar"]["value"])
         self.assertFalse(login_entry["einsatz_telefonica"]["value"])
@@ -1727,11 +1727,11 @@ class LLMTasksTests(NoesisTestCase):
         self.assertTrue(login_entry["ki_beteiligung"]["value"])
 
         self.assertIsInstance(result, list)
-        self.assertTrue(any(r["funktion"] == "Login" for r in result))
+        self.assertTrue(any(r["funktion"] == "Anmelden" for r in result))
 
     def test_run_anlage2_analysis_sets_negotiable_on_match(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        content = "Login: tv: ja; tel: nein; lv: nein; ki: ja"
+        content = "Anmelden: tv: ja; tel: nein; lv: nein; ki: ja"
         upload = SimpleUploadedFile("b.txt", b"x")
         pf = BVProjectFile.objects.create(
             project=projekt,
@@ -1739,7 +1739,7 @@ class LLMTasksTests(NoesisTestCase):
             upload=upload,
             text_content=content,
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         cfg = Anlage2Config.get_instance()
         cfg.text_technisch_verfuegbar_true = ["ja"]
         cfg.save()
@@ -1922,7 +1922,7 @@ class LLMTasksTests(NoesisTestCase):
         cfg.parser_mode = "auto"
         cfg.parser_order = ["table", "exact"]
         cfg.save()
-        table_result = [{"funktion": "Login"}]
+        table_result = [{"funktion": "Anmelden"}]
         with (
             patch("core.parsers.parse_anlage2_table", return_value=table_result),
             patch(
@@ -1945,13 +1945,13 @@ class LLMTasksTests(NoesisTestCase):
         cfg.parser_order = ["exact", "table"]
         cfg.save()
         with (
-            patch("core.parsers.parse_anlage2_table", return_value=[{"funktion": "Login"}]) as m_table,
+            patch("core.parsers.parse_anlage2_table", return_value=[{"funktion": "Anmelden"}]) as m_table,
             patch("core.parsers.ExactParser.parse", return_value=[]) as m_exact,
         ):
             result = parser_manager.parse_anlage2(pf)
         m_exact.assert_called_once()
         m_table.assert_called_once()
-        self.assertEqual(result, [{"funktion": "Login"}])
+        self.assertEqual(result, [{"funktion": "Anmelden"}])
 
     def test_parser_manager_exact_parser_segments(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -1999,12 +1999,12 @@ class LLMTasksTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"x"),
             text_content="",
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
 
         result = run_anlage2_analysis(pf)
 
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["funktion"], "Login")
+        self.assertEqual(result[0]["funktion"], "Anmelden")
         self.assertTrue(
             result[0].get("not_found") or result[0].get("technisch_verfuegbar") is None
         )
@@ -2023,7 +2023,7 @@ class LLMTasksTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"x"),
             text_content="",
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         Anlage2SubQuestion.objects.filter(funktion=func).delete()
         Anlage2SubQuestion.objects.create(funktion=func, frage_text="Warum?")
 
@@ -2031,7 +2031,7 @@ class LLMTasksTests(NoesisTestCase):
 
         self.assertEqual(len(result), 2)
         names = [row["funktion"] for row in result]
-        self.assertIn("Login", names)
+        self.assertIn("Anmelden", names)
         self.assertTrue(any("Warum?" in n for n in names))
         pf.refresh_from_db()
         parser_res = FunktionsErgebnis.objects.filter(
@@ -2047,7 +2047,7 @@ class LLMTasksTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"x"),
             text_content="Logn: ja",
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         cfg = Anlage2Config.get_instance()
         cfg.text_technisch_verfuegbar_true = ["ja"]
         cfg.save()
@@ -2055,7 +2055,7 @@ class LLMTasksTests(NoesisTestCase):
         result = run_anlage2_analysis(pf)
 
         expected = [{
-            "funktion": "Login",
+            "funktion": "Anmelden",
             "not_found": True,
             "technisch_verfuegbar": None,
             "einsatz_telefonica": None,
@@ -2075,7 +2075,7 @@ class LLMTasksTests(NoesisTestCase):
             text_content="",
             processing_status=BVProjectFile.PROCESSING,
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         FunktionsErgebnis.objects.create(
             anlage_datei=pf,
             funktion=func,
@@ -2099,7 +2099,7 @@ class LLMTasksTests(NoesisTestCase):
             text_content="",
             processing_status=BVProjectFile.PROCESSING,
         )
-        Anlage2Function.objects.get(name="Login")
+        Anlage2Function.objects.get(name="Anmelden")
 
         run_anlage2_analysis(pf)
 
@@ -2447,18 +2447,18 @@ class LLMTasksTests(NoesisTestCase):
             second.unlink(missing_ok=True)
 
     def test_parse_anlage2_question_list(self):
-        text = "Welche Funktionen bietet das System?\u00b6- Login\u00b6- Suche"
+        text = "Welche Funktionen bietet das System?\u00b6- Anmelden\u00b6- Suche"
         parsed = _parse_anlage2(text)
-        self.assertEqual(parsed, ["Login", "Suche"])
+        self.assertEqual(parsed, ["Anmelden", "Suche"])
 
     def test_parse_anlage2_table_llm(self):
-        text = "Funktion | Beschreibung\u00b6Login | a\u00b6Suche | b"
+        text = "Funktion | Beschreibung\u00b6Anmelden | a\u00b6Suche | b"
         with patch(
-            "core.llm_tasks.query_llm", return_value='["Login", "Suche"]'
+            "core.llm_tasks.query_llm", return_value='["Anmelden", "Suche"]'
         ) as mock_q:
             parsed = _parse_anlage2(text)
         mock_q.assert_called_once()
-        self.assertEqual(parsed, ["Login", "Suche"])
+        self.assertEqual(parsed, ["Anmelden", "Suche"])
 
 
 class PromptTests(NoesisTestCase):
@@ -2612,7 +2612,7 @@ class Anlage2ReviewTests(NoesisTestCase):
             analysis_json={
                 "functions": [
                     {
-                        "funktion": "Login",
+                        "funktion": "Anmelden",
                         "technisch_vorhanden": {"value": True, "note": None},
                         "einsatz_bei_telefonica": {"value": False, "note": None},
                         "zur_lv_kontrolle": {"value": False, "note": None},
@@ -2622,7 +2622,7 @@ class Anlage2ReviewTests(NoesisTestCase):
             },
             verification_json={"functions": {}},
         )
-        self.func = Anlage2Function.objects.get(name="Login")
+        self.func = Anlage2Function.objects.get(name="Anmelden")
         Anlage2SubQuestion.objects.filter(funktion=self.func).delete()
         self.sub = Anlage2SubQuestion.objects.create(
             funktion=self.func, frage_text="Warum?"
@@ -2631,7 +2631,7 @@ class Anlage2ReviewTests(NoesisTestCase):
     def test_get_shows_table(self):
         url = reverse("projekt_file_edit_json", args=[self.file.pk])
         resp = self.client.get(url)
-        self.assertContains(resp, "Login")
+        self.assertContains(resp, "Anmelden")
         self.assertContains(resp, "Warum?")
         self.assertContains(resp, f'name="func{self.func.id}_technisch_vorhanden"')
 
@@ -2656,7 +2656,7 @@ class Anlage2ReviewTests(NoesisTestCase):
         self.file.analysis_json = {
             "functions": [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_vorhanden": {"value": True, "note": None},
                     "einsatz_bei_telefonica": {"value": True, "note": None},
                     "zur_lv_kontrolle": {"value": True, "note": None},
@@ -3354,17 +3354,17 @@ class FunctionImportExportTests(NoesisTestCase):
         self.client.login(username="adminie", password="pass")
 
     def test_export_returns_json(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         Anlage2SubQuestion.objects.create(funktion=func, frage_text="Warum?")
         url = reverse("anlage2_function_export")
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.content)
-        self.assertEqual(data[0]["name"], "Login")
+        self.assertEqual(data[0]["name"], "Anmelden")
         self.assertEqual(data[0]["subquestions"][0]["frage_text"], "Warum?")
 
     def test_import_creates_functions(self):
-        payload = json.dumps([{"name": "Login", "subquestions": ["Frage"]}])
+        payload = json.dumps([{"name": "Anmelden", "subquestions": ["Frage"]}])
         file = SimpleUploadedFile("func.json", payload.encode("utf-8"))
         url = reverse("anlage2_function_import")
         resp = self.client.post(
@@ -3373,7 +3373,7 @@ class FunctionImportExportTests(NoesisTestCase):
             format="multipart",
         )
         self.assertRedirects(resp, reverse("anlage2_function_list"))
-        self.assertTrue(Anlage2Function.objects.filter(name="Login").exists())
+        self.assertTrue(Anlage2Function.objects.filter(name="Anmelden").exists())
 
     def test_import_accepts_german_keys(self):
         payload = json.dumps(
@@ -3399,7 +3399,7 @@ class FunctionImportExportTests(NoesisTestCase):
         )
 
     def test_roundtrip_preserves_aliases(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         func.detection_phrases = {"name_aliases": ["Sign in"]}
         func.save()
         Anlage2SubQuestion.objects.filter(funktion=func).delete()
@@ -3419,7 +3419,7 @@ class FunctionImportExportTests(NoesisTestCase):
             format="multipart",
         )
         self.assertRedirects(resp, reverse("anlage2_function_list"))
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         self.assertEqual(func.detection_phrases.get("name_aliases"), ["Sign in"])
         sub = func.anlage2subquestion_set.get(frage_text="Warum?")
         self.assertEqual(sub.detection_phrases.get("name_aliases"), ["Why"])
@@ -4180,7 +4180,7 @@ class AjaxAnlage2ReviewTests(NoesisTestCase):
             analysis_json={},
             verification_json={"functions": {}},
         )
-        self.func = Anlage2Function.objects.get(name="Login")
+        self.func = Anlage2Function.objects.get(name="Anmelden")
         Anlage2SubQuestion.objects.filter(funktion=self.func).delete()
 
     def test_manual_result_saved(self):
@@ -4504,7 +4504,7 @@ class SupervisionGapTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("f.txt", b"x"),
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         Anlage2SubQuestion.objects.filter(funktion=func).delete()
         AnlagenFunktionsMetadaten.objects.create(
             anlage_datei=pf,
@@ -4555,7 +4555,7 @@ class SupervisionGapTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("f.txt", b"x"),
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         Anlage2SubQuestion.objects.filter(funktion=func).delete()
         sub = Anlage2SubQuestion.objects.create(funktion=func, frage_text="S?")
 
@@ -4609,7 +4609,7 @@ class SupervisionGapTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("f.txt", b"x"),
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         res = AnlagenFunktionsMetadaten.objects.create(anlage_datei=pf, funktion=func)
         FunktionsErgebnis.objects.create(
             anlage_datei=pf,
@@ -4644,7 +4644,7 @@ class Anlage2ResetTests(NoesisTestCase):
             upload=SimpleUploadedFile("old.txt", b"x"),
         )
         Anlage2Function.objects.all().delete()
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         AnlagenFunktionsMetadaten.objects.create(
             anlage_datei=pf_old,
             funktion=func,
@@ -4662,7 +4662,7 @@ class Anlage2ResetTests(NoesisTestCase):
         with (
             patch(
                 "core.llm_tasks.parse_anlage2_table",
-                return_value=[{"funktion": "Login"}],
+                return_value=[{"funktion": "Anmelden"}],
             ),
             patch("core.text_parser.parse_anlage2_text", return_value=[]),
         ):
@@ -4685,7 +4685,7 @@ class Anlage2ResetTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("old.txt", b"x"),
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         AnlagenFunktionsMetadaten.objects.create(
             anlage_datei=pf_old,
             funktion=func,
@@ -4754,7 +4754,7 @@ class Anlage2ResetTests(NoesisTestCase):
             anlage_nr=3,
             upload=SimpleUploadedFile("b.txt", b"x"),
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         AnlagenFunktionsMetadaten.objects.create(anlage_datei=pf, funktion=func)
         AnlagenFunktionsMetadaten.objects.create(
             anlage_datei=other_pf, funktion=func
@@ -4781,7 +4781,7 @@ class Anlage2ResetTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("a.txt", b"x"),
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         res = AnlagenFunktionsMetadaten.objects.create(
             anlage_datei=pf,
             funktion=func,
@@ -4845,7 +4845,7 @@ class Anlage2ResetTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("a.txt", b"x"),
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         result = AnlagenFunktionsMetadaten.objects.create(
             anlage_datei=pf,
             funktion=func,
@@ -4906,7 +4906,7 @@ class GapReportTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("b.txt", b"data"),
         )
-        self.func = Anlage2Function.objects.get(name="Login")
+        self.func = Anlage2Function.objects.get(name="Anmelden")
         AnlagenFunktionsMetadaten.objects.create(
             anlage_datei=self.pf2,
             funktion=self.func,
@@ -4976,7 +4976,7 @@ class ProjektDetailGapTests(NoesisTestCase):
             anlage_nr=2,
             upload=SimpleUploadedFile("b.txt", b"data"),
         )
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         AnlagenFunktionsMetadaten.objects.create(
             anlage_datei=pf2,
             funktion=func,

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -89,7 +89,7 @@ class DocxExtractTests(NoesisTestCase):
         table.cell(0, 3).text = "Zur LV-Kontrolle"
         table.cell(0, 4).text = "KI-Beteiligung"
 
-        table.cell(1, 0).text = "Login"
+        table.cell(1, 0).text = "Anmelden"
         table.cell(1, 1).text = "Ja"
         table.cell(1, 2).text = "Nein"
         table.cell(1, 3).text = "Nein"
@@ -126,7 +126,7 @@ class DocxExtractTests(NoesisTestCase):
             data,
             [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "einsatz_telefonica": {"value": False, "note": None},
                     "zur_lv_kontrolle": {"value": False, "note": None},
@@ -161,7 +161,7 @@ class DocxExtractTests(NoesisTestCase):
         table.cell(0, 2).text = "Telefonica Einsatz"
         table.cell(0, 3).text = "LV Kontrolle"
         table.cell(0, 4).text = "KI?"
-        table.cell(1, 0).text = "Login"
+        table.cell(1, 0).text = "Anmelden"
         table.cell(1, 1).text = "Ja"
         table.cell(1, 2).text = "Nein"
         table.cell(1, 3).text = "Nein"
@@ -202,7 +202,7 @@ class DocxExtractTests(NoesisTestCase):
         table.cell(0, 3).text = "einsatzweise bei Telefónica: soll zur Überwachung von Leistung oder Verhalten verwendet werden?"
         table.cell(0, 4).text = "KI-Beteiligung"
 
-        table.cell(1, 0).text = "Login"
+        table.cell(1, 0).text = "Anmelden"
         table.cell(1, 1).text = "Ja"
         table.cell(1, 2).text = "Nein"
         table.cell(1, 3).text = "Nein"
@@ -220,7 +220,7 @@ class DocxExtractTests(NoesisTestCase):
             data,
             [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "einsatz_telefonica": {"value": False, "note": None},
                     "zur_lv_kontrolle": {"value": False, "note": None},
@@ -260,7 +260,7 @@ class DocxExtractTests(NoesisTestCase):
         )
         table.cell(0, 4).text = "KI-Beteiligung"
 
-        table.cell(1, 0).text = "Login"
+        table.cell(1, 0).text = "Anmelden"
         table.cell(1, 1).text = "Ja"
         table.cell(1, 2).text = "Nein"
         table.cell(1, 3).text = "Nein"
@@ -278,7 +278,7 @@ class DocxExtractTests(NoesisTestCase):
             data,
             [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "einsatz_telefonica": {"value": False, "note": None},
                     "zur_lv_kontrolle": {"value": False, "note": None},
@@ -295,7 +295,7 @@ class DocxExtractTests(NoesisTestCase):
         table.cell(0, 2).text = "Einsatz bei Telefónica"
         table.cell(0, 3).text = "Zur LV-Kontrolle"
 
-        table.cell(1, 0).text = "Login"
+        table.cell(1, 0).text = "Anmelden"
         table.cell(1, 1).text = "Ja (nur intern)"
         table.cell(1, 2).text = "Nein, später"
         table.cell(1, 3).text = "Nein (k.A.)"
@@ -312,7 +312,7 @@ class DocxExtractTests(NoesisTestCase):
             data,
             [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": "nur intern"},
                     "einsatz_telefonica": {"value": False, "note": "später"},
                     "zur_lv_kontrolle": {"value": False, "note": "k.A."},
@@ -337,7 +337,7 @@ class DocxExtractTests(NoesisTestCase):
         table.cell(0, 2).text = "Einsatz bei Telefónica"
         table.cell(0, 3).text = "Zur LV-Kontrolle"
 
-        table.cell(1, 0).text = "Login"
+        table.cell(1, 0).text = "Anmelden"
         table.cell(1, 1).text = "Ja"
         table.cell(1, 2).text = "Nein"
         table.cell(1, 3).text = "Nein"
@@ -364,7 +364,7 @@ class DocxExtractTests(NoesisTestCase):
 
 
     def test_parse_anlage2_text(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         func.detection_phrases = {"name_aliases": ["login"]}
         func.save()
         Anlage2SubQuestion.objects.filter(funktion=func).delete()
@@ -378,22 +378,22 @@ class DocxExtractTests(NoesisTestCase):
         cfg.text_technisch_verfuegbar_false = ["tv nein"]
         cfg.text_ki_beteiligung_false = ["ki nein"]
         cfg.save()
-        text = "Login tv ja ki nein\nWarum? tv nein"
+        text = "Anmelden tv ja ki nein\nWarum? tv nein"
         data = parse_anlage2_text(text)
         self.assertEqual(
             data,
             [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "ki_beteiligung": {"value": False, "note": None},
                 },
-                {"funktion": "Login: Warum?"},
+                {"funktion": "Anmelden: Warum?"},
             ],
         )
 
     def test_parse_anlage2_text_default_aliases(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         Anlage2SubQuestion.objects.filter(funktion=func).delete()
         Anlage2SubQuestion.objects.create(
             funktion=func,
@@ -404,17 +404,17 @@ class DocxExtractTests(NoesisTestCase):
         cfg.text_technisch_verfuegbar_false = ["tv nein"]
         cfg.text_ki_beteiligung_false = ["ki nein"]
         cfg.save()
-        text = "Login tv ja ki nein\nWarum? tv nein"
+        text = "Anmelden tv ja ki nein\nWarum? tv nein"
         data = parse_anlage2_text(text)
         self.assertEqual(
             data,
             [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "ki_beteiligung": {"value": False, "note": None},
                 },
-                {"funktion": "Login: Warum?"},
+                {"funktion": "Anmelden: Warum?"},
             ],
         )
 
@@ -446,17 +446,17 @@ class DocxExtractTests(NoesisTestCase):
         )
 
     def test_parse_anlage2_text_normalizes_variants(self):
-        func = Anlage2Function.objects.get(name="User Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         cfg = Anlage2Config.get_instance()
         cfg.text_technisch_verfuegbar_true = ["tv ja"]
         cfg.save()
-        text = "User-Login   tv ja"
+        text = "Anmelden   tv ja"
         data = parse_anlage2_text(text)
         self.assertEqual(
             data,
             [
                 {
-                    "funktion": "User Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                 }
             ],
@@ -505,18 +505,18 @@ class DocxExtractTests(NoesisTestCase):
         )
 
     def test_parse_anlage2_text_merges_duplicate_functions(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         cfg = Anlage2Config.get_instance()
         cfg.text_technisch_verfuegbar_true = ["tv ja"]
         cfg.text_ki_beteiligung_false = ["ki nein"]
         cfg.save()
-        text = "Login tv ja\nLogin ki nein"
+        text = "Anmelden tv ja\nAnmelden ki nein"
         data = parse_anlage2_text(text)
         self.assertEqual(
             data,
             [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "ki_beteiligung": {"value": False, "note": None},
                 }
@@ -543,7 +543,7 @@ class DocxExtractTests(NoesisTestCase):
         )
 
     def test_parse_anlage2_text_fuzzy_match(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         cfg = Anlage2Config.get_instance()
         cfg.text_technisch_verfuegbar_true = ["ja"]
         cfg.save()
@@ -551,7 +551,7 @@ class DocxExtractTests(NoesisTestCase):
         self.assertEqual(data, [])
 
     def test_parse_anlage2_text_fuzzy_token_phrase(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         cfg = Anlage2Config.get_instance()
         cfg.text_technisch_verfuegbar_true = ["ja bitte"]
         cfg.save()
@@ -559,7 +559,7 @@ class DocxExtractTests(NoesisTestCase):
         self.assertEqual(data, [])
 
     def test_parse_anlage2_text_fuzzy_rule_phrase(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         AntwortErkennungsRegel.objects.create(
             regel_name="aktiv",
             erkennungs_phrase="aktivv",
@@ -569,7 +569,7 @@ class DocxExtractTests(NoesisTestCase):
         self.assertEqual(data, [])
 
     def test_parse_anlage2_text_multiple_rules_priority(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         AntwortErkennungsRegel.objects.create(
             regel_name="a",
             erkennungs_phrase="foo",
@@ -582,12 +582,12 @@ class DocxExtractTests(NoesisTestCase):
             actions_json=[{"field": "einsatz_telefonica", "value": False}],
             prioritaet=1,
         )
-        data = parse_anlage2_text("Login: foo bar rest")
+        data = parse_anlage2_text("Anmelden: foo bar rest")
         self.assertEqual(
             data,
             [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                     "einsatz_telefonica": {"value": False, "note": "rest"},
                 }
@@ -595,16 +595,16 @@ class DocxExtractTests(NoesisTestCase):
         )
 
     def test_parse_anlage2_text_unknown_question(self):
-        Anlage2Function.objects.get(name="Login")
+        Anlage2Function.objects.get(name="Anmelden")
         cfg = Anlage2Config.get_instance()
         cfg.text_technisch_verfuegbar_true = ["ja"]
         cfg.save()
-        data = parse_anlage2_text("Unbekannt: ja\nLogin: ja")
+        data = parse_anlage2_text("Unbekannt: ja\nAnmelden: ja")
         self.assertEqual(len(data), 1)
         self.assertEqual(
             data[0],
             {
-                "funktion": "Login",
+                "funktion": "Anmelden",
                 "technisch_verfuegbar": {"value": True, "note": None},
             },
         )
@@ -656,7 +656,7 @@ class DocxExtractTests(NoesisTestCase):
         )
 
     def test_exact_parser_handles_segments(self):
-        func1 = Anlage2Function.objects.get(name="Login")
+        func1 = Anlage2Function.objects.get(name="Anmelden")
         func2 = Anlage2Function.objects.get(name="Analyse")
         AntwortErkennungsRegel.objects.create(
             regel_name="aktiv", erkennungs_phrase="aktiv",
@@ -666,7 +666,7 @@ class DocxExtractTests(NoesisTestCase):
             regel_name="einsatz", erkennungs_phrase="kein einsatz",
             actions_json=[{"field": "einsatz_telefonica", "value": False}],
         )
-        text = "Login: aktiv\nAnalyse: kein einsatz"
+        text = "Anmelden: aktiv\nAnalyse: kein einsatz"
         pf = BVProjectFile.objects.create(
             project=BVProject.objects.create(software_typen="A", beschreibung="x"),
             anlage_nr=2,
@@ -678,7 +678,7 @@ class DocxExtractTests(NoesisTestCase):
             data,
             [
                 {
-                    "funktion": "Login",
+                    "funktion": "Anmelden",
                     "technisch_verfuegbar": {"value": True, "note": None},
                 },
                 {
@@ -689,7 +689,7 @@ class DocxExtractTests(NoesisTestCase):
         )
 
     def test_exact_parser_subquestion_requires_main(self):
-        func = Anlage2Function.objects.get(name="Login")
+        func = Anlage2Function.objects.get(name="Anmelden")
         Anlage2SubQuestion.objects.filter(funktion=func).delete()
         Anlage2SubQuestion.objects.create(funktion=func, frage_text="Grund?")
         AntwortErkennungsRegel.objects.create(

--- a/core/tests/test_versioned_results.py
+++ b/core/tests/test_versioned_results.py
@@ -21,7 +21,7 @@ def test_funktions_ergebnisse_sind_versionsabhaengig(db):
     """Prüft, dass Ergebnisse pro Anlagen-Version getrennt gespeichert werden."""
     ProjectStatus.objects.create(name="Offen", is_default=True)
     projekt = BVProject.objects.create(title="P")
-    funktion = Anlage2Function.objects.get(name="Login")
+    funktion = Anlage2Function.objects.get(name="Anmelden")
     pf1 = BVProjectFile.objects.create(
         project=projekt,
         anlage_nr=2,
@@ -63,7 +63,7 @@ def test_neue_version_nutzt_vorhandene_ki_ergebnisse(db):
     """Bei vorhandenen Ergebnissen wird keine neue KI-Prüfung gestartet."""
     ProjectStatus.objects.create(name="Offen", is_default=True)
     projekt = BVProject.objects.create(title="P")
-    funktion = Anlage2Function.objects.get(name="Login")
+    funktion = Anlage2Function.objects.get(name="Anmelden")
     pf1 = BVProjectFile.objects.create(
         project=projekt,
         anlage_nr=2,
@@ -89,14 +89,14 @@ def test_new_version_copies_ai_results(db):
     """KI-Ergebnisse werden in neue Versionen übernommen."""
     ProjectStatus.objects.create(name="Offen", is_default=True)
     projekt = BVProject.objects.create(title="P")
-    funktion = Anlage2Function.objects.get(name="Login")
+    funktion = Anlage2Function.objects.get(name="Anmelden")
     with patch("core.signals.start_analysis_for_file"):
         pf1 = BVProjectFile.objects.create(
             project=projekt,
             anlage_nr=2,
             upload=SimpleUploadedFile("a.docx", b"a"),
             text_content="a",
-            verification_json={"Login": {"ki_begruendung": "x"}},
+            verification_json={"Anmelden": {"ki_begruendung": "x"}},
             processing_status=BVProjectFile.COMPLETE,
         )
     AnlagenFunktionsMetadaten.objects.create(anlage_datei=pf1, funktion=funktion)
@@ -134,7 +134,7 @@ def test_manual_ai_check_disabled(client, db):
     user = User.objects.create_user("u")
     client.force_login(user)
     projekt = BVProject.objects.create(title="P")
-    funktion = Anlage2Function.objects.get(name="Login")
+    funktion = Anlage2Function.objects.get(name="Anmelden")
     pf1 = BVProjectFile.objects.create(
         project=projekt,
         anlage_nr=2,


### PR DESCRIPTION
## Summary
- replace missing Anlage2Function name `Login` with existing `Anmelden` across tests

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_parsing.py::DocxExtractTests::test_parse_anlage2_table -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a896b9ee84832b8bb485a82ec3f4e1