### PR TITLE
fix: initialize delimiter phrase in parsing test

### DIFF
--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1132,6 +1132,8 @@ class AnalyseAnlage4Tests(NoesisTestCase):
         """Die Analyse nutzt die übergebene Konfiguration."""
         Anlage4ParserConfig.objects.all().delete()
         cfg = Anlage4Config.objects.create(regex_patterns=[r"Zweck: (.+)"])
+        cfg.delimiter_phrase = "Y"
+        cfg.save()
         projekt = BVProject.objects.create(software_typen="A")
         pf = BVProjectFile.objects.create(
             project=projekt,


### PR DESCRIPTION
## Summary
- ensure `test_passes_config_to_parser` seeds `delimiter_phrase` so analysis runs

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test -v 2 core.tests.test_parsing.AnalyseAnlage4Tests.test_passes_config_to_parser`


------
https://chatgpt.com/codex/tasks/task_e_68a8982f74f0832ba66e24cb9085eb61