### PR TITLE
fix: adjust home page test for static area links

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -3214,8 +3214,10 @@ class AreaImageTests(NoesisTestCase):
         work.image.save("w.png", SimpleUploadedFile("w.png", b"d"), save=True)
         personal.image.save("p.png", SimpleUploadedFile("p.png", b"d"), save=True)
         resp = self.client.get(reverse("home"))
-        self.assertContains(resp, f'alt="{work.name}"', html=False)
-        self.assertContains(resp, f'alt="{personal.name}"', html=False)
+        self.assertContains(resp, reverse("work"))
+        self.assertContains(resp, reverse("personal"))
+        self.assertContains(resp, "Arbeitsassistent")
+        self.assertContains(resp, "Persönlicher Bereich")
 
 
 class RecordingDeleteTests(NoesisTestCase):


### PR DESCRIPTION
## Summary
- update home page test to assert presence of area links instead of image alt tags

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.AreaImageTests.test_home_with_images -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a8a2a873e8832ba24b2105ff641237