### PR TITLE
fix: align analysis task name in test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -724,11 +724,16 @@ class BVProjectFileTests(NoesisTestCase):
             upload=SimpleUploadedFile("a.txt", b"x"),
             processing_status=BVProjectFile.PENDING,
         )
-        with patch.object(BVProjectFile, "get_analysis_tasks", return_value=[("f.q", pf.pk)]), \
-            patch("core.utils.async_task") as mock_async:
+        with patch.object(
+            BVProjectFile,
+            "get_analysis_tasks",
+            return_value=[("core.llm_tasks.check_anlage1", pf.pk)],
+        ), patch("core.utils.async_task") as mock_async, patch(
+            "core.utils.transaction.on_commit", side_effect=lambda func: func()
+        ):
             mock_async.return_value = "t1"
             task_id = start_analysis_for_file(pf.pk)
-        mock_async.assert_called_with("f.q", pf.pk)
+        mock_async.assert_called_with("core.llm_tasks.check_anlage1", pf.pk)
         self.assertEqual(task_id, "t1")
         pf.refresh_from_db()
         self.assertEqual(pf.processing_status, BVProjectFile.PROCESSING)


### PR DESCRIPTION
## Summary
- verify `start_analysis_for_file` enqueues `core.llm_tasks.check_anlage1`
- patch commit hooks in test so async task trigger executes immediately

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_start_analysis_for_file_enqueues_tasks -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a8accb32a4832b91c868ffcf7a52e1