### PR TITLE
fix: use staff user for LLMConfig notice test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -3183,10 +3183,15 @@ class TileVisibilityTests(NoesisTestCase):
 class LLMConfigNoticeMiddlewareTests(NoesisTestCase):
     def setUp(self):
         admin_group = Group.objects.create(name="admin")
-        self.user = User.objects.create_user("llmadmin", password="pass")
+        # Middleware benötigt einen Staff-Benutzer
+        self.user = User.objects.create_user(
+            "llmadmin", password="pass", is_staff=True
+        )
         self.user.groups.add(admin_group)
         self.client.login(username="llmadmin", password="pass")
-        LLMConfig.objects.create(models_changed=True)
+        cfg, _ = LLMConfig.objects.get_or_create()
+        cfg.models_changed = True
+        cfg.save()
 
     def test_message_shown(self):
         resp = self.client.get(reverse("home"))


### PR DESCRIPTION
## Summary
- ensure LLMConfig notice middleware test uses staff user
- mark existing LLM configuration as changed to trigger warning

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.LLMConfigNoticeMiddlewareTests.test_message_shown -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a8b495b09c832b81cbeb45d3de45ec