### PR TITLE
Refactor navigation sidebar tests to use class fixtures

### DIFF
--- a/core/tests/test_navigation.py
+++ b/core/tests/test_navigation.py
@@ -15,28 +15,8 @@ from core.models import (
 class NavigationSidebarTests(TestCase):
     """Überprüfung der sichtbaren Bereiche, Tiles und Admin-Links."""
 
-    def setUp(self) -> None:
-        """Legt Bereiche und Tiles für die Tests an."""
-
-        self.area_work = Area.objects.create(slug="work", name="Arbeitsbereich")
-        self.area_private = Area.objects.create(slug="personal", name="Privatbereich")
-
-        self.tile_dashboard = Tile.objects.create(
-            slug="dashboard", name="Dashboard", url_name="home"
-        )
-        self.tile_dashboard.areas.add(self.area_work)
-
-        self.tile_account = Tile.objects.create(
-            slug="account-tile", name="Privatkachel", url_name="account"
-        )
-        self.tile_account.areas.add(self.area_private)
-
-        self.tile_hidden = Tile.objects.create(
-            slug="hidden", name="Versteckt", url_name="home"
-        )
-        self.tile_hidden.areas.add(self.area_work)
-
-    def _grant_access(self, user: User, areas: list[Area], tiles: list[Tile]) -> None:
+    @staticmethod
+    def _grant_access(user: User, areas: list[Area], tiles: list[Tile]) -> None:
         """Erteilt einem Benutzer Zugriff auf Bereiche und Tiles."""
 
         for area in areas:
@@ -44,12 +24,55 @@ class NavigationSidebarTests(TestCase):
         for tile in tiles:
             UserTileAccess.objects.create(user=user, tile=tile)
 
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """Legt Bereiche, Tiles und Nutzer für die Tests an."""
+
+        cls.area_work = Area.objects.create(slug="work", name="Arbeitsbereich")
+        cls.area_private = Area.objects.create(
+            slug="personal", name="Privatbereich"
+        )
+
+        cls.tile_dashboard = Tile.objects.create(
+            slug="dashboard", name="Dashboard", url_name="home"
+        )
+        cls.tile_dashboard.areas.add(cls.area_work)
+
+        cls.tile_account = Tile.objects.create(
+            slug="account-tile", name="Privatkachel", url_name="account"
+        )
+        cls.tile_account.areas.add(cls.area_private)
+
+        cls.tile_hidden = Tile.objects.create(
+            slug="hidden", name="Versteckt", url_name="home"
+        )
+        cls.tile_hidden.areas.add(cls.area_work)
+
+        cls.user_alice = User.objects.create_user("alice", password="pw")
+        cls._grant_access(cls.user_alice, [cls.area_work], [cls.tile_dashboard])
+
+        cls.user_bob = User.objects.create_user("bob", password="pw")
+        cls._grant_access(
+            cls.user_bob,
+            [cls.area_work, cls.area_private],
+            [cls.tile_dashboard, cls.tile_account],
+        )
+
+        cls.user_carol = User.objects.create_user("carol", password="pw")
+        cls._grant_access(cls.user_carol, [cls.area_work], [cls.tile_dashboard])
+
+        cls.admin_group = Group.objects.create(name="Admin")
+        cls.user_dave = User.objects.create_user("dave", password="pw")
+        cls.user_dave.groups.add(cls.admin_group)
+        cls._grant_access(cls.user_dave, [cls.area_work], [cls.tile_dashboard])
+
+        cls.user_eve = User.objects.create_superuser("eve", "eve@example.com", "pw")
+        cls._grant_access(cls.user_eve, [cls.area_work], [cls.tile_dashboard])
+
     def test_sidebar_single_area_tiles_only(self) -> None:
         """Bei genau einem Bereich werden nur die Tiles angezeigt."""
 
-        user = User.objects.create_user("alice", password="pw")
-        self._grant_access(user, [self.area_work], [self.tile_dashboard])
-        self.client.login(username="alice", password="pw")
+        self.client.force_login(self.user_alice)
 
         response = self.client.get(reverse("account"))
 
@@ -61,13 +84,7 @@ class NavigationSidebarTests(TestCase):
     def test_sidebar_multiple_areas(self) -> None:
         """Mehrere Bereiche werden mit Überschriften dargestellt."""
 
-        user = User.objects.create_user("bob", password="pw")
-        self._grant_access(
-            user,
-            [self.area_work, self.area_private],
-            [self.tile_dashboard, self.tile_account],
-        )
-        self.client.login(username="bob", password="pw")
+        self.client.force_login(self.user_bob)
 
         response = self.client.get(reverse("account"))
 
@@ -80,9 +97,7 @@ class NavigationSidebarTests(TestCase):
     def test_no_admin_links_for_regular_user(self) -> None:
         """Ohne Sonderrechte erscheinen keine Admin-Links."""
 
-        user = User.objects.create_user("carol", password="pw")
-        self._grant_access(user, [self.area_work], [self.tile_dashboard])
-        self.client.login(username="carol", password="pw")
+        self.client.force_login(self.user_carol)
 
         response = self.client.get(reverse("account"))
 
@@ -92,11 +107,7 @@ class NavigationSidebarTests(TestCase):
     def test_project_admin_link_for_admin_group(self) -> None:
         """Mitglied der Admin-Gruppe sieht Projekt-Admin-Link."""
 
-        admin_group = Group.objects.create(name="Admin")
-        user = User.objects.create_user("dave", password="pw")
-        user.groups.add(admin_group)
-        self._grant_access(user, [self.area_work], [self.tile_dashboard])
-        self.client.login(username="dave", password="pw")
+        self.client.force_login(self.user_dave)
 
         response = self.client.get(reverse("account"))
 
@@ -106,9 +117,7 @@ class NavigationSidebarTests(TestCase):
     def test_system_admin_link_for_superuser(self) -> None:
         """Superuser sieht Projekt- und System-Admin-Link."""
 
-        user = User.objects.create_superuser("eve", "eve@example.com", "pw")
-        self._grant_access(user, [self.area_work], [self.tile_dashboard])
-        self.client.login(username="eve", password="pw")
+        self.client.force_login(self.user_eve)
 
         response = self.client.get(reverse("account"))
 


### PR DESCRIPTION
## Summary
- refactor NavigationSidebarTests to use `setUpTestData` and shared fixtures
- log in pre-created users via `force_login` for clearer assertions

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_navigation.NavigationSidebarTests --verbosity 2`


------
https://chatgpt.com/codex/tasks/task_e_68a8b9be7a78832bad717f244ee5b6c5