### PR TITLE
test: mock Google LLM API calls in tests

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Gemeinsame Testkonfiguration für das core-Modul."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_llm_api_calls():
+    """Ersetzt externe LLM-Aufrufe durch statische Antworten."""
+    with (
+        patch("core.llm_utils.query_llm", return_value="Mock-Antwort"),
+        patch("core.llm_utils.query_llm_with_images", return_value="Mock-Antwort"),
+        patch("core.llm_tasks.query_llm", return_value="Mock-Antwort"),
+        patch("core.llm_tasks.query_llm_with_images", return_value="Mock-Antwort"),
+        patch("google.generativeai.configure"),
+        patch("google.generativeai.list_models", return_value=[]),
+    ):
+        yield


### PR DESCRIPTION
## Summary
- block real Google LLM requests in tests via autouse fixture
- mock generative AI configuration and model listing for deterministic test setup

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.PromptTests.test_get_prompt_returns_default -v 2`
- `python manage.py test core.tests.test_parsing.AnalyseAnlage4Tests.test_template_allows_json_data_placeholder -v 2` *(fails: NOT NULL constraint failed: core_bvprojectstatushistory.status_id)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c0abe370832bb87b602c48c00689