### PR TITLE
Refactor tests to share NoesisTestCase

### DIFF
--- a/core/tests/__init__.py
+++ b/core/tests/__init__.py
@@ -1,5 +1,1 @@
-from .test_admin_views import *
-from .test_forms import *
-from .test_parsing import *
-from .test_general import *
-from .test_gap_notes import *
+"""Testpaket für die core-Anwendung."""

--- a/core/tests/base.py
+++ b/core/tests/base.py
@@ -1,0 +1,16 @@
+from django.contrib.auth.models import User
+from django.test import TransactionTestCase
+
+
+class NoesisTestCase(TransactionTestCase):
+    """Basisklasse für Tests mit vorkonfigurierten Benutzern."""
+
+    @classmethod
+    def setUpClass(cls) -> None:  # pragma: no cover - setup code
+        super().setUpClass()
+        cls.setUpTestData()
+
+    @classmethod
+    def setUpTestData(cls) -> None:  # pragma: no cover - setup code
+        cls.user = User.objects.get(username="baseuser")
+        cls.superuser = User.objects.get(username="basesuper")

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -5,6 +5,20 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _seed_db(django_db_setup, django_db_blocker) -> None:
+    """Initialisiert einmalig die Testdatenbank."""
+    from django.contrib.auth.models import User
+    from .test_general import seed_test_data
+
+    with django_db_blocker.unblock():
+        seed_test_data()
+        User.objects.create_user("baseuser", password="pass")
+        User.objects.create_superuser(
+            "basesuper", "admin@example.com", password="pass"
+        )
+
+
 @pytest.fixture(autouse=True)
 def mock_llm_api_calls():
     """Ersetzt externe LLM-Aufrufe durch statische Antworten."""

--- a/core/tests/test_admin_views.py
+++ b/core/tests/test_admin_views.py
@@ -1,3 +1,4 @@
+from .base import NoesisTestCase
 from .test_general import *
 
 class AdminProjectsTests(NoesisTestCase):

--- a/core/tests/test_compare_versions.py
+++ b/core/tests/test_compare_versions.py
@@ -1,3 +1,4 @@
+from .base import NoesisTestCase
 from .test_general import *
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse

--- a/core/tests/test_fail_stale_processing.py
+++ b/core/tests/test_fail_stale_processing.py
@@ -2,13 +2,13 @@ from datetime import timedelta
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
-from django.test import TestCase
 from django.utils import timezone
 
+from .base import NoesisTestCase
 from core.models import BVProject, BVProjectFile, ProjectStatus
 
 
-class FailStaleProcessingCommandTests(TestCase):
+class FailStaleProcessingCommandTests(NoesisTestCase):
     """Tests für den fail_stale_processing-Command."""
 
     def test_marks_old_entries_failed(self) -> None:

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -1,3 +1,4 @@
+from .base import NoesisTestCase
 from .test_general import *
 from ..forms import Anlage5ReviewForm, BVProjectFileForm
 from ..models import ZweckKategorieA

--- a/core/tests/test_gap_notes.py
+++ b/core/tests/test_gap_notes.py
@@ -1,3 +1,4 @@
+from .base import NoesisTestCase
 from .test_general import *
 from django.core.files.uploadedfile import SimpleUploadedFile
 

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -114,7 +114,7 @@ from unittest.mock import patch, ANY, Mock, call
 from django.core.management import call_command
 from django.test import override_settings
 import json
-import pytest
+from .base import NoesisTestCase
 
 
 def create_statuses() -> None:
@@ -362,17 +362,6 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
         )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _seed_db(django_db_setup, django_db_blocker) -> None:
-    """Initialisiert einmalig die Testdatenbank."""
-    with django_db_blocker.unblock():
-        seed_test_data()
-        User.objects.create_user("baseuser", password="pass")
-        User.objects.create_superuser(
-            "basesuper", "admin@example.com", password="pass"
-        )
-
-
 class SeedInitialDataTests(TransactionTestCase):
     """Tests für das Seeding der Antwortregeln."""
 
@@ -393,16 +382,6 @@ class SeedInitialDataTests(TransactionTestCase):
                 obj.actions_json,
                 rule["actions"],
             )
-
-
-class NoesisTestCase(TransactionTestCase):
-    """Basisklasse für alle Tests mit gefüllter Datenbank."""
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        """Stellt die global angelegten Testbenutzer bereit."""
-        cls.user = User.objects.get(username="baseuser")
-        cls.superuser = User.objects.get(username="basesuper")
 
 
 class ExtractAnlageNrTests(TransactionTestCase):

--- a/core/tests/test_navigation.py
+++ b/core/tests/test_navigation.py
@@ -1,8 +1,9 @@
 """Tests für die Sidebar-Navigation."""
 
 from django.contrib.auth.models import Group, User
-from django.test import TestCase
 from django.urls import reverse
+
+from .base import NoesisTestCase
 
 from core.models import (
     Area,
@@ -12,7 +13,7 @@ from core.models import (
 )
 
 
-class NavigationSidebarTests(TestCase):
+class NavigationSidebarTests(NoesisTestCase):
     """Überprüfung der sichtbaren Bereiche, Tiles und Admin-Links."""
 
     @staticmethod
@@ -27,24 +28,24 @@ class NavigationSidebarTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         """Legt Bereiche, Tiles und Nutzer für die Tests an."""
+        super().setUpTestData()
 
-        cls.area_work = Area.objects.create(slug="work", name="Arbeitsbereich")
+        cls.area_work = Area.objects.create(slug="work-test", name="Arbeitsbereich")
         cls.area_private = Area.objects.create(
-            slug="personal", name="Privatbereich"
+            slug="personal-test", name="Privatbereich"
         )
 
         cls.tile_dashboard = Tile.objects.create(
-            slug="dashboard", name="Dashboard", url_name="home"
+            slug="dashboard-test", name="Dashboard", url_name="home"
         )
         cls.tile_dashboard.areas.add(cls.area_work)
-
         cls.tile_account = Tile.objects.create(
-            slug="account-tile", name="Privatkachel", url_name="account"
+            slug="account-tile-test", name="Privatkachel", url_name="account"
         )
         cls.tile_account.areas.add(cls.area_private)
 
         cls.tile_hidden = Tile.objects.create(
-            slug="hidden", name="Versteckt", url_name="home"
+            slug="hidden-test", name="Versteckt", url_name="home"
         )
         cls.tile_hidden.areas.add(cls.area_work)
 
@@ -61,7 +62,7 @@ class NavigationSidebarTests(TestCase):
         cls.user_carol = User.objects.create_user("carol", password="pw")
         cls._grant_access(cls.user_carol, [cls.area_work], [cls.tile_dashboard])
 
-        cls.admin_group = Group.objects.create(name="Admin")
+        cls.admin_group = Group.objects.create(name="AdminTest")
         cls.user_dave = User.objects.create_user("dave", password="pw")
         cls.user_dave.groups.add(cls.admin_group)
         cls._grant_access(cls.user_dave, [cls.area_work], [cls.tile_dashboard])

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1,3 +1,4 @@
+from .base import NoesisTestCase
 from .test_general import *
 from ..anlage4_parser import parse_anlage4_dual
 from ..models import Anlage4ParserConfig


### PR DESCRIPTION
## Summary
- add reusable `NoesisTestCase` in `core/tests/base.py`
- seed test database once per session via `conftest.py`
- update tests to inherit from shared base and fix navigation test data

## Testing
- `python manage.py makemigrations --check`
- `DJANGO_SETTINGS_MODULE=noesis.settings pytest core/tests/test_navigation.py::NavigationSidebarTests::test_sidebar_single_area_tiles_only -q`
- `DJANGO_SETTINGS_MODULE=noesis.settings pytest core/tests/test_fail_stale_processing.py::FailStaleProcessingCommandTests::test_marks_old_entries_failed -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c5e41bbc832b92ad609a2843c03f