### PR TITLE
refactor: remove test case setup methods

### DIFF
--- a/core/tests/base.py
+++ b/core/tests/base.py
@@ -1,16 +1,5 @@
-from django.contrib.auth.models import User
 from django.test import TransactionTestCase
 
 
 class NoesisTestCase(TransactionTestCase):
-    """Basisklasse für Tests mit vorkonfigurierten Benutzern."""
-
-    @classmethod
-    def setUpClass(cls) -> None:  # pragma: no cover - setup code
-        super().setUpClass()
-        cls.setUpTestData()
-
-    @classmethod
-    def setUpTestData(cls) -> None:  # pragma: no cover - setup code
-        cls.user = User.objects.get(username="baseuser")
-        cls.superuser = User.objects.get(username="basesuper")
+    pass


### PR DESCRIPTION
## Summary
- remove obsolete user setup in NoesisTestCase

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test` *(fails: IntegrityError and missing settings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d3e4b818832ba8ca9aa5a55c8578