### PR TITLE
feat: add user and superuser fixtures

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -19,6 +19,22 @@ def _seed_db(django_db_setup, django_db_blocker) -> None:
         )
 
 
+@pytest.fixture
+def user(db) -> "User":
+    """Gibt den Basisbenutzer zurück."""
+    from django.contrib.auth.models import User
+
+    return User.objects.get(username="baseuser")
+
+
+@pytest.fixture
+def superuser(db) -> "User":
+    """Gibt den Basis-Superuser zurück."""
+    from django.contrib.auth.models import User
+
+    return User.objects.get(username="basesuper")
+
+
 @pytest.fixture(autouse=True)
 def mock_llm_api_calls():
     """Ersetzt externe LLM-Aufrufe durch statische Antworten."""


### PR DESCRIPTION
## Summary
- add `user` and `superuser` pytest fixtures for base accounts

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68a8d642ea64832b97f4082306463da2