### PR TITLE
feat: return areas with tiles for navigation

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -46,7 +46,7 @@ def user_navigation(request: HttpRequest) -> dict[str, list[NavSection]]:
 
     navigation: list[NavSection] = []
     for area in areas:
-        tiles = get_user_tiles(request.user, area.slug)
+        _, tiles = get_user_tiles(request.user, area.slug)
         navigation.append({"area": area, "tiles": tiles})
 
     return {"user_navigation": navigation}

--- a/core/tests/test_navigation.py
+++ b/core/tests/test_navigation.py
@@ -11,6 +11,7 @@ from core.models import (
     UserAreaAccess,
     UserTileAccess,
 )
+from ..views import get_user_tiles
 
 
 class NavigationSidebarTests(NoesisTestCase):
@@ -25,50 +26,57 @@ class NavigationSidebarTests(NoesisTestCase):
         for tile in tiles:
             UserTileAccess.objects.create(user=user, tile=tile)
 
-    @classmethod
-    def setUpTestData(cls) -> None:
+    def setUp(self) -> None:
         """Legt Bereiche, Tiles und Nutzer für die Tests an."""
-        super().setUpTestData()
-
-        cls.area_work = Area.objects.create(slug="work-test", name="Arbeitsbereich")
-        cls.area_private = Area.objects.create(
+        self.area_work = Area.objects.create(slug="work-test", name="Arbeitsbereich")
+        self.area_private = Area.objects.create(
             slug="personal-test", name="Privatbereich"
         )
 
-        cls.tile_dashboard = Tile.objects.create(
+        self.tile_dashboard = Tile.objects.create(
             slug="dashboard-test", name="Dashboard", url_name="home"
         )
-        cls.tile_dashboard.areas.add(cls.area_work)
-        cls.tile_account = Tile.objects.create(
+        self.tile_dashboard.areas.add(self.area_work)
+        self.tile_account = Tile.objects.create(
             slug="account-tile-test", name="Privatkachel", url_name="account"
         )
-        cls.tile_account.areas.add(cls.area_private)
+        self.tile_account.areas.add(self.area_private)
 
-        cls.tile_hidden = Tile.objects.create(
+        self.tile_hidden = Tile.objects.create(
             slug="hidden-test", name="Versteckt", url_name="home"
         )
-        cls.tile_hidden.areas.add(cls.area_work)
+        self.tile_hidden.areas.add(self.area_work)
 
-        cls.user_alice = User.objects.create_user("alice", password="pw")
-        cls._grant_access(cls.user_alice, [cls.area_work], [cls.tile_dashboard])
+        self.user_alice = User.objects.create_user("alice", password="pw")
+        self._grant_access(self.user_alice, [self.area_work], [self.tile_dashboard])
 
-        cls.user_bob = User.objects.create_user("bob", password="pw")
-        cls._grant_access(
-            cls.user_bob,
-            [cls.area_work, cls.area_private],
-            [cls.tile_dashboard, cls.tile_account],
+        self.user_bob = User.objects.create_user("bob", password="pw")
+        self._grant_access(
+            self.user_bob,
+            [self.area_work, self.area_private],
+            [self.tile_dashboard, self.tile_account],
         )
 
-        cls.user_carol = User.objects.create_user("carol", password="pw")
-        cls._grant_access(cls.user_carol, [cls.area_work], [cls.tile_dashboard])
+        self.user_carol = User.objects.create_user("carol", password="pw")
+        self._grant_access(self.user_carol, [self.area_work], [self.tile_dashboard])
 
-        cls.admin_group = Group.objects.create(name="AdminTest")
-        cls.user_dave = User.objects.create_user("dave", password="pw")
-        cls.user_dave.groups.add(cls.admin_group)
-        cls._grant_access(cls.user_dave, [cls.area_work], [cls.tile_dashboard])
+        self.admin_group = Group.objects.create(name="admin")
+        self.user_dave = User.objects.create_user("dave", password="pw")
+        self.user_dave.groups.add(self.admin_group)
+        self._grant_access(self.user_dave, [self.area_work], [self.tile_dashboard])
 
-        cls.user_eve = User.objects.create_superuser("eve", "eve@example.com", "pw")
-        cls._grant_access(cls.user_eve, [cls.area_work], [cls.tile_dashboard])
+        self.user_eve = User.objects.create_superuser("eve", "eve@example.com", "pw")
+        self._grant_access(self.user_eve, [self.area_work], [self.tile_dashboard])
+
+    def test_get_user_tiles(self) -> None:
+        """Gibt die zugänglichen Bereiche und Tiles zurück."""
+
+        areas, tiles = get_user_tiles(self.user_bob, self.area_work.slug)
+
+        self.assertEqual(len(areas), 2)
+        self.assertCountEqual(areas, [self.area_work, self.area_private])
+        self.assertEqual(len(tiles), 1)
+        self.assertListEqual(tiles, [self.tile_dashboard])
 
     def test_sidebar_single_area_tiles_only(self) -> None:
         """Bei genau einem Bereich werden nur die Tiles angezeigt."""


### PR DESCRIPTION
## Summary
- expand `get_user_tiles` to return both accessible areas and tiles
- adjust navigation context and views to new tuple API
- add regression test verifying tuple-based return values

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_navigation -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a8dd93f108832bb498e6121c12ef02