### PR TITLE
fix: use TestCase base class in tests

### DIFF
--- a/core/tests/base.py
+++ b/core/tests/base.py
@@ -1,5 +1,5 @@
-from django.test import TransactionTestCase
+from django.test import TestCase
 
 
-class NoesisTestCase(TransactionTestCase):
+class NoesisTestCase(TestCase):
     pass


### PR DESCRIPTION
## Summary
- use django.test.TestCase as base for NoesisTestCase

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test --keepdb --verbosity 0` *(fails: failures=3, errors=235)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e4abd5e0832bb04d8e5907c929b3