### PR TITLE
fix: seed initial data once and keep ai results

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -362,11 +362,11 @@ def run_anlage2_analysis(project_file: BVProjectFile) -> list[dict[str, object]]
         "[%s] - PARSER START - Beginne Dokumenten-Analyse.",
         project_file.project_id,
     )
-    # Vorhandene Ergebnisse für das gesamte Projekt entfernen, damit nur
-    # aktuelle Resultate berücksichtigt werden
+    # Vorherige Parser-Ergebnisse entfernen, KI-Bewertungen jedoch behalten
     FunktionsErgebnis.objects.filter(
         anlage_datei__project=project_file.project,
         anlage_datei__anlage_nr=2,
+        quelle="parser",
     ).delete()
     AnlagenFunktionsMetadaten.objects.filter(
         anlage_datei__project=project_file.project,

--- a/core/tests/base.py
+++ b/core/tests/base.py
@@ -1,5 +1,13 @@
+"""Basis-Testklasse mit globalem Seed für Initialdaten."""
+
+from django.core.management import call_command
 from django.test import TestCase
 
 
 class NoesisTestCase(TestCase):
-    pass
+    """Führt vor allen Tests das Seeding der Standarddaten aus."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:  # noqa: D401 - Standard-Setup
+        """Initialisiert die Testdatenbank mit Seed-Daten."""
+        call_command("seed_initial_data", verbosity=0)

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -362,11 +362,10 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
 
 
 class SeedInitialDataTests(NoesisTestCase):
-    """Tests für das Seeding der Antwortregeln."""
+    """Stellt sicher, dass die Seed-Daten vorhanden sind."""
 
     def test_answer_rules_seeded(self) -> None:
-        """Prüft, ob die Antwortregeln angelegt werden."""
-        call_command("seed_initial_data")
+        """Prüft die durch die globale Fixture angelegten Antwortregeln."""
         from ..initial_data_constants import INITIAL_ANSWER_RULES
 
         for rule in INITIAL_ANSWER_RULES:


### PR DESCRIPTION
## Summary
- seed test database once per test case
- stop re-running seed command in `SeedInitialDataTests`
- preserve existing KI results in `run_anlage2_analysis`

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.SeedInitialDataTests`


------
https://chatgpt.com/codex/tasks/task_e_68a8ea5263ec832b91da7db6723eb1ff