### PR TITLE
fix: isolate Anlage2Function tests

### DIFF
--- a/core/tests/test_versioned_results.py
+++ b/core/tests/test_versioned_results.py
@@ -21,7 +21,7 @@ def test_funktions_ergebnisse_sind_versionsabhaengig(db):
     """Prüft, dass Ergebnisse pro Anlagen-Version getrennt gespeichert werden."""
     ProjectStatus.objects.create(name="Offen", is_default=True)
     projekt = BVProject.objects.create(title="P")
-    funktion = Anlage2Function.objects.get(name="Anmelden")
+    funktion = Anlage2Function.objects.create(name="Anmelden")
     pf1 = BVProjectFile.objects.create(
         project=projekt,
         anlage_nr=2,
@@ -63,7 +63,7 @@ def test_neue_version_nutzt_vorhandene_ki_ergebnisse(db):
     """Bei vorhandenen Ergebnissen wird keine neue KI-Prüfung gestartet."""
     ProjectStatus.objects.create(name="Offen", is_default=True)
     projekt = BVProject.objects.create(title="P")
-    funktion = Anlage2Function.objects.get(name="Anmelden")
+    funktion = Anlage2Function.objects.create(name="Anmelden")
     pf1 = BVProjectFile.objects.create(
         project=projekt,
         anlage_nr=2,
@@ -89,7 +89,7 @@ def test_new_version_copies_ai_results(db):
     """KI-Ergebnisse werden in neue Versionen übernommen."""
     ProjectStatus.objects.create(name="Offen", is_default=True)
     projekt = BVProject.objects.create(title="P")
-    funktion = Anlage2Function.objects.get(name="Anmelden")
+    funktion = Anlage2Function.objects.create(name="Anmelden")
     with patch("core.signals.start_analysis_for_file"):
         pf1 = BVProjectFile.objects.create(
             project=projekt,
@@ -134,7 +134,7 @@ def test_manual_ai_check_disabled(client, db):
     user = User.objects.create_user("u")
     client.force_login(user)
     projekt = BVProject.objects.create(title="P")
-    funktion = Anlage2Function.objects.get(name="Anmelden")
+    funktion = Anlage2Function.objects.create(name="Anmelden")
     pf1 = BVProjectFile.objects.create(
         project=projekt,
         anlage_nr=2,


### PR DESCRIPTION
## Summary
- refactor tests to create `Anlage2Function` instances in `setUp`
- use unique function names in import/export roundtrip tests
- ensure parsing tests purge old functions for isolation

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.BVProjectFileTests.test_check_functions_clears_task_id -v 2`
- `python manage.py test core.tests.test_general.FunctionImportExportTests.test_roundtrip_preserves_aliases -v 2`
- `python manage.py test core.tests.test_parsing.DocxExtractTests.test_parse_anlage2_text -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a8f274a0bc832ba50be8da521682ec