### PR TITLE
docs: mention pytest in contributor checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,4 +71,5 @@ Procfile: Definiert die Prozesse (web, worker) für den Start mit honcho.
 
 ## Tests und Checks
 - Vor jedem Commit `python manage.py makemigrations --check` ausführen.
+- Ebenfalls vor jedem Commit `pytest` ausführen (dank automatischer LLM-Mocking-Fixture ohne echte API-Anfragen).
 


### PR DESCRIPTION
## Summary
- document that contributors should run `pytest` before committing, reassuring them about the automatic LLM-mocking fixture

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a97415ceb8832bbe04286b0b698af7