### PR TITLE
feat: Selenium-Tests optional aktivieren

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -6,6 +6,18 @@ pip install -r requirements.txt
 # Entwicklungswerkzeuge installieren
 pip install -r requirements-dev.txt
 
+# Optional Selenium-Tests aktivieren
+read -p "Sollen Selenium-Tests ausgeführt werden? (j/n) " run_selenium
+if [[ $run_selenium == "j" || $run_selenium == "J" ]]; then
+    # Variable für aktuelle Sitzung setzen
+    export NOESIS_RUN_SELENIUM=1
+    # Variable dauerhaft im Aktivierungsskript hinterlegen
+    if ! grep -q "NOESIS_RUN_SELENIUM" venv/bin/activate; then
+        echo "export NOESIS_RUN_SELENIUM=1" >> venv/bin/activate
+    fi
+    echo "NOESIS_RUN_SELENIUM=1 in venv/bin/activate gesetzt."
+fi
+
 # Systemabhängigkeiten installieren (pandoc wird für DOCX-Exporte benötigt)
 if command -v apt-get >/dev/null; then
     sudo apt-get update


### PR DESCRIPTION
## Summary
- add optional Selenium test activation to `setup_env.sh`

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: unrecognized arguments --ds=noesis.settings --reuse-db)*

------
https://chatgpt.com/codex/tasks/task_e_68a9789c5290832b9bb67e056dafc61c