### PR TITLE
fix: reset LLMConfig before seeding

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -176,7 +176,8 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
     create_statuses()
 
     # Erforderliche Konfigurationen bereitstellen
-    LLMConfig.objects.get_or_create()
+    LLMConfig.objects.all().delete()
+    LLMConfig.objects.create()
     Anlage4Config.objects.get_or_create()
     Anlage4ParserConfig.objects.get_or_create()
 


### PR DESCRIPTION
## Summary
- avoid leftover LLM configurations in test setup
- ensure a single LLMConfig is created when seeding test data

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_general.py::SeedInitialDataTests::test_answer_rules_seeded -q`
- `pytest` *(fails: BVProjectFileTests missing required fixture argument)*

------
https://chatgpt.com/codex/tasks/task_e_68a980e98f30832b86774005fb711c52