### PR TITLE
fix: avoid duplicate test users

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -13,10 +13,12 @@ def _seed_db(django_db_setup, django_db_blocker) -> None:
 
     with django_db_blocker.unblock():
         seed_test_data()
-        User.objects.create_user("baseuser", password="pass")
-        User.objects.create_superuser(
-            "basesuper", "admin@example.com", password="pass"
-        )
+        if not User.objects.filter(username="baseuser").exists():
+            User.objects.create_user("baseuser", password="pass")
+        if not User.objects.filter(username="basesuper").exists():
+            User.objects.create_superuser(
+                "basesuper", "admin@example.com", password="pass"
+            )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- prevent duplicate base users in tests by checking existence before creation

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: LLMTasksTests and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a98734bcd8832b850f3c7d3c0eb8f4