### PR TITLE
Fix project file flag test for Unicode checkmark

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -675,7 +675,7 @@ class BVProjectFileTests(NoesisTestCase):
         pf.refresh_from_db()
         self.assertTrue(pf.manual_reviewed)
         self.assertContains(resp, "<tr")
-        self.assertContains(resp, "fa-check")
+        self.assertContains(resp, "✓")
 
     def test_hx_project_software_tab(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")


### PR DESCRIPTION
## Summary
- fix hx toggle project file flag test to check unicode checkmark

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: 20 failed, 83 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a99e13a6d8832ba74f8095e1c1c7c9