### PR TITLE
fix: adjust analyse_anlage3 tests

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2204,7 +2204,7 @@ class LLMTasksTests(NoesisTestCase):
         data = analyse_anlage3(pf.pk)
         pf.refresh_from_db()
         file_obj = pf
-        self.assertEqual(data["pages"]["value"], 1)
+        self.assertEqual(data["pages"], 1)
         self.assertTrue(data["verhandlungsfaehig"]["value"])
         self.assertTrue(file_obj.analysis_json["verhandlungsfaehig"]["value"])
         if hasattr(file_obj, "verhandlungsfaehig"):
@@ -2233,7 +2233,7 @@ class LLMTasksTests(NoesisTestCase):
         data = analyse_anlage3(pf.pk)
         pf.refresh_from_db()
         file_obj = pf
-        self.assertEqual(data["pages"]["value"], 2)
+        self.assertEqual(data["pages"], 2)
         self.assertFalse(data["verhandlungsfaehig"]["value"])
         self.assertFalse(file_obj.analysis_json["verhandlungsfaehig"]["value"])
         if hasattr(file_obj, "verhandlungsfaehig"):
@@ -2260,7 +2260,7 @@ class LLMTasksTests(NoesisTestCase):
         data = analyse_anlage3(pf.pk)
         pf.refresh_from_db()
         file_obj = pf
-        self.assertEqual(data["pages"]["value"], 1)
+        self.assertEqual(data["pages"], 1)
         self.assertTrue(data["verhandlungsfaehig"]["value"])
         self.assertTrue(file_obj.analysis_json["verhandlungsfaehig"]["value"])
 
@@ -2286,7 +2286,7 @@ class LLMTasksTests(NoesisTestCase):
         data = analyse_anlage3(pf.pk)
         pf.refresh_from_db()
         file_obj = pf
-        self.assertEqual(data["pages"]["value"], 2)
+        self.assertEqual(data["pages"], 2)
         self.assertFalse(data["verhandlungsfaehig"]["value"])
         self.assertFalse(file_obj.analysis_json["verhandlungsfaehig"]["value"])
 


### PR DESCRIPTION
## Summary
- align analyse_anlage3 tests with current page return structure

## Testing
- `python manage.py makemigrations --check && echo OK`
- `pytest core/tests/test_general.py::LLMTasksTests::test_analyse_anlage3_auto_ok core/tests/test_general.py::LLMTasksTests::test_analyse_anlage3_manual_required core/tests/test_general.py::LLMTasksTests::test_analyse_anlage3_pdf_auto_ok core/tests/test_general.py::LLMTasksTests::test_analyse_anlage3_pdf_manual_required` *(fails: KeyError: 'verhandlungsfaehig')*
- `pytest` *(fails: missing expectations in test_admin_views and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a99eabdc74832bb2023bf9c7e85e4b