### PR TITLE
fix: return empty dict when Anlage 1 parser finds no questions

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -278,7 +278,8 @@ def parse_anlage1_questions(
         )
 
     anlage1_logger.debug("parse_anlage1_questions: Ergebnis: %r", parsed)
-    return parsed
+    # Immer ein leeres Dict zurückgeben, falls keine Treffer vorhanden sind
+    return parsed or {}
 
 
 def _parse_anlage2(text_content: str, project_prompt: str | None = None) -> list[str] | None:

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2476,6 +2476,12 @@ class LLMTasksTests(NoesisTestCase):
         parsed = parse_anlage1_questions(text)
         self.assertEqual(parsed, {"1": {"answer": "A1", "found_num": "1.2"}})
 
+    def test_parse_anlage1_questions_returns_empty_dict(self):
+        """Bei fehlenden Treffern wird ein leeres Dict zur\u00fcckgegeben."""
+        text = "Es gibt hier keine Fragen."
+        parsed = parse_anlage1_questions(text)
+        self.assertEqual(parsed, {})
+
     def test_generate_gutachten_twice_replaces_file(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         first = generate_gutachten(projekt.pk, text="Alt")


### PR DESCRIPTION
## Summary
- ensure `parse_anlage1_questions` returns an empty dict when no questions are found
- add regression test for empty parser result

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: Expected 'parser_manager' tests etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a99f57966c832bb8e2736b74370ebb