### PR TITLE
fix: make lookup key test order independent

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2727,10 +2727,10 @@ class Anlage2ReviewTests(NoesisTestCase):
         url = reverse("projekt_file_edit_json", args=[self.file.pk])
         resp = self.client.get(url)
         rows = resp.context["rows"]
-        self.assertEqual(rows[0]["verif_key"], self.func.name)
-        self.assertEqual(
-            rows[1]["verif_key"], f"{self.func.name}: {self.sub.frage_text}"
-        )
+        # Verif-Key unabhängig von der Reihenfolge prüfen
+        verif_keys = [row["verif_key"] for row in rows]
+        self.assertIn(self.func.name, verif_keys)
+        self.assertIn(f"{self.func.name}: {self.sub.frage_text}", verif_keys)
 
     def test_subquestion_justification_link(self):
         FunktionsErgebnis.objects.create(


### PR DESCRIPTION
## Summary
- make `test_rows_include_lookup_key` verify the presence of `verif_key` values regardless of ordering

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: BVProjectFileTests.test_hx_toggle_project_file_flag, BVProjectFileTests.test_template_shows_disabled_state_when_task_running, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b1e628f4832b969fe91868138bdc