### PR TITLE
fix: avoid auto analysis in justification link test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2641,6 +2641,9 @@ class ProjektFileCheckViewTests(NoesisTestCase):
 class Anlage2ReviewTests(NoesisTestCase):
     def setUp(self):
         super().setUp()
+        patcher = patch("core.signals.start_analysis_for_file", return_value="")
+        patcher.start()
+        self.addCleanup(patcher.stop)
         self.user = User.objects.create_user("rev", password="pass")
         self.client.login(username="rev", password="pass")
         self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")


### PR DESCRIPTION
## Summary
- prevent automatic analysis triggering in `Anlage2ReviewTests` setup
- ensure `test_subquestion_justification_link` renders final view

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_general.py::Anlage2ReviewTests::test_subquestion_justification_link -q`
- `pytest` *(fails: AssertionError in `BVProjectFileTests.test_hx_toggle_project_file_flag`)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b2472164832bb44b8763650c6682