### PR TITLE
Ensure worker_verify_feature returns empty dict on IntegrityError

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1829,9 +1829,9 @@ def worker_verify_feature(
                 "Anlage-Datei %s wurde während der Verarbeitung gelöscht. Prüfung wird abgebrochen.",
                 pf.pk,
             )
-        else:
-            logger.error("Integritätsfehler beim Speichern der Ergebnisse: %s", exc)
-        return verification_result
+            return {}
+        logger.error("Integritätsfehler beim Speichern der Ergebnisse: %s", exc)
+        return {}
     except DatabaseError:
         if not BVProjectFile.objects.filter(pk=pf.pk).exists():
             logger.warning(


### PR DESCRIPTION
## Summary
- return an empty dict after logging integrity errors in `worker_verify_feature`

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: 87 failed, 486 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0f6273d4832bb9539620868f0e11