### PR TITLE
fix: ergänze fehlenden Platzhalter für Anlage1-Gaps

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -2194,7 +2194,7 @@ def summarize_anlage1_gaps(projekt: BVProject, model_name: str | None = None) ->
 
     context = {
         "system_name": projekt.title or projekt.software_string,
-        "gap_list": gap_list_string.strip(),
+        "fragen": gap_list_string.strip(),
     }
 
     try:

--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -210,7 +210,10 @@ def create_initial_data(apps) -> None:
         ),
         (
             "gap_report_anlage1",
-            "Fasse alle Hinweise und Vorschläge aus Anlage 1 zu einem kurzen Text für den Fachbereich. Nutze {fragen} als Input.",
+            (
+                "Fasse alle Hinweise und Vorschläge aus Anlage 1 zu einem kurzen Text für den Fachbereich. "
+                "Die folgenden Fragen dienen als Input:\n\n{fragen}"
+            ),
             True,
         ),
         (


### PR DESCRIPTION
## Summary
- ergänze fehlenden Platzhalter `fragen` im Prompt für die Anlage-1-Gap-Auswertung
- passe LLM-Task an, um Fragenliste korrekt zu übergeben

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: AssertionError & TypeError in admin views and gap report tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aa152d98c8832bb1ca19de3b1c6847