### PR TITLE
fix: mock return value for start_analysis

### DIFF
--- a/core/tests/test_versioned_results.py
+++ b/core/tests/test_versioned_results.py
@@ -90,7 +90,7 @@ def test_new_version_copies_ai_results(db):
     ProjectStatus.objects.create(name="Offen", is_default=True)
     projekt = BVProject.objects.create(title="P")
     funktion = Anlage2Function.objects.create(name="Anmelden")
-    with patch("core.signals.start_analysis_for_file"):
+    with patch("core.signals.start_analysis_for_file", return_value="tid"):
         pf1 = BVProjectFile.objects.create(
             project=projekt,
             anlage_nr=2,
@@ -115,7 +115,7 @@ def test_new_version_copies_ai_results(db):
     with open(tmp.name, "rb") as fh:
         upload = SimpleUploadedFile("b.docx", fh.read())
     Path(tmp.name).unlink(missing_ok=True)
-    with patch("core.signals.start_analysis_for_file"):
+    with patch("core.signals.start_analysis_for_file", return_value="tid"):
         pf2 = _save_project_file(projekt, upload=upload, anlage_nr=2)
 
     assert pf2.verification_json == pf1.verification_json


### PR DESCRIPTION
## Summary
- ensure start_analysis_for_file mock returns a task id in versioned results test

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_versioned_results.py::test_new_version_copies_ai_results -q`
- `pytest -q` *(fails: BVProjectFileTests.test_hx_toggle_project_file_flag, BVProjectFileTests.test_template_shows_disabled_state_when_task_running)*

------
https://chatgpt.com/codex/tasks/task_e_68aa231f4b54832b8fc6650bde45adf0