### PR TITLE
fix: include verhandlungsfaehig result in analyse_anlage3

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -782,15 +782,29 @@ def analyse_anlage3(file_id: int, model_name: str | None = None) -> dict:
         anlage3_logger.debug("Seitenzahl der Datei: %s", pages)
 
         if pages <= 1:
-            data = {"task": "analyse_anlage3", "auto_ok": True, "pages": pages}
+            note = "Dokument umfasst eine Seite oder weniger."
             verhandlungsfaehig = True
+            data = {
+                "task": "analyse_anlage3",
+                "auto_ok": True,
+                "pages": pages,
+                "verhandlungsfaehig": {
+                    "value": verhandlungsfaehig,
+                    "note": note,
+                },
+            }
         else:
+            note = "Dokument umfasst mehr als eine Seite."
+            verhandlungsfaehig = False
             data = {
                 "task": "analyse_anlage3",
                 "manual_required": True,
                 "pages": pages,
+                "verhandlungsfaehig": {
+                    "value": verhandlungsfaehig,
+                    "note": note,
+                },
             }
-            verhandlungsfaehig = False
 
         anlage3_logger.debug("Analyseergebnis: %s", data)
 
@@ -805,7 +819,10 @@ def analyse_anlage3(file_id: int, model_name: str | None = None) -> dict:
             result = data
 
     anlage3_logger.debug("Analyse abgeschlossen mit Ergebnis: %s", result)
-    return result or {}
+    return result or {
+        "task": "analyse_anlage3",
+        "verhandlungsfaehig": {"value": None, "note": None},
+    }
 
 
 def _read_pdf_images(path: Path) -> list[bytes]:


### PR DESCRIPTION
## Summary
- always provide `verhandlungsfaehig` in `analyse_anlage3` results

## Testing
- `python manage.py makemigrations --check`
- `pytest --maxfail=1` (fails: BVProjectFileTests::test_template_shows_disabled_state_when_task_running)
- `pytest core/tests/test_general.py -k test_analyse_anlage3_auto_ok -q`
- `pytest core/tests/test_general.py -k test_analyse_anlage3_manual_required -q`
- `pytest core/tests/test_general.py -k test_analyse_anlage3_pdf_auto_ok -q`
- `pytest core/tests/test_general.py -k test_analyse_anlage3_pdf_manual_required -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa448f53cc832bb402ec887c3dd179