### PR TITLE
fix: robust Selenium file upload selector

### DIFF
--- a/core/tests/test_selenium.py
+++ b/core/tests/test_selenium.py
@@ -62,7 +62,9 @@ class FileUploadDuplicateTests(StaticLiveServerTestCase):
         self._login()
         url = self.live_server_url + reverse("projekt_file_upload", args=[self.projekt.pk])
         self.driver.get(url)
-        input_el = self.driver.find_element(By.ID, "id_upload")
+        input_el = self.driver.find_element(
+            By.CSS_SELECTOR, "#dropzone input[type='file']"
+        )
 
         doc = Document()
         doc.add_paragraph("x")


### PR DESCRIPTION
## Summary
- use a CSS selector to find the Dropzone file input in Selenium upload test

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: KeyError: 'verhandlungsfaehig', AssertionError, and 18 other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf7c8f6ec832b80a32787d4990a35