### PR TITLE
fix: correct file upload input selection

### DIFF
--- a/core/tests/test_selenium.py
+++ b/core/tests/test_selenium.py
@@ -62,9 +62,7 @@ class FileUploadDuplicateTests(StaticLiveServerTestCase):
         self._login()
         url = self.live_server_url + reverse("projekt_file_upload", args=[self.projekt.pk])
         self.driver.get(url)
-        input_el = self.driver.find_element(
-            By.CSS_SELECTOR, "#dropzone input[type='file']"
-        )
+        input_el = self.driver.find_element(By.ID, "id_upload")
 
         doc = Document()
         doc.add_paragraph("x")


### PR DESCRIPTION
## Summary
- fix Selenium file upload test by selecting file input by its ID instead of within dropzone

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: KeyError: 'verhandlungsfaehig', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aafb413e44832b9a7014886481b561