### PR TITLE
feat: simplify Anlage2 parser selection

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -5,6 +5,8 @@ import logging
 from pathlib import Path
 from django.conf import settings
 
+PARSER_MODE_CHOICES: list[tuple[str, str]] = []
+
 
 class MultiFileInput(forms.ClearableFileInput):
     allow_multiple_selected = True
@@ -30,8 +32,6 @@ from .models import (
     Anlage3ParserRule,
     ZweckKategorieA,
     SupervisionStandardNote,
-
-    PARSER_MODE_CHOICES,
     Anlage3Metadata,
 )
 
@@ -712,8 +712,6 @@ class Anlage2ConfigForm(forms.ModelForm):
             if not self.is_bound:
                 current = getattr(self.instance, name, [])
                 self.initial[name] = "\n".join(current)
-        # Vorhandene Instanzwerte nutzen, falls nichts übergeben wurde
-        self.fields["parser_mode"].required = False
 
     def save(self, commit: bool = True) -> Anlage2Config:
         """Speichert nur übergebene Werte."""
@@ -729,8 +727,6 @@ class Anlage2ConfigForm(forms.ModelForm):
                     name,
                     [v.strip() for v in value.splitlines() if v.strip()],
                 )
-        if not self.cleaned_data.get("parser_mode"):
-            instance.parser_mode = self.instance.parser_mode
         if commit:
             instance.save()
         return instance
@@ -740,8 +736,6 @@ class Anlage2ConfigForm(forms.ModelForm):
 
         fields = [
             "enforce_subquestion_override",
-            "parser_mode",
-            "parser_order",
             "text_technisch_verfuegbar_true",
             "text_technisch_verfuegbar_false",
             "text_einsatz_telefonica_true",
@@ -753,8 +747,6 @@ class Anlage2ConfigForm(forms.ModelForm):
         ]
         labels = {
             "enforce_subquestion_override": "Unterfragen überschreiben Hauptfunktion",
-            "parser_mode": "Parser-Modus",
-            "parser_order": "Parser-Reihenfolge",
             "text_technisch_verfuegbar_true": "Text‑Parser: technisch verfügbar – Ja",
             "text_technisch_verfuegbar_false": "Text‑Parser: technisch verfügbar – Nein",
             "text_einsatz_telefonica_true": "Text‑Parser: Einsatz bei Telefónica – Ja",

--- a/core/migrations/0003_remove_parser_fields.py
+++ b/core/migrations/0003_remove_parser_fields.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0002_delete_formatbparserrule"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="anlage2config",
+            name="parser_mode",
+        ),
+        migrations.RemoveField(
+            model_name="anlage2config",
+            name="parser_order",
+        ),
+        migrations.RemoveField(
+            model_name="bvprojectfile",
+            name="parser_mode",
+        ),
+        migrations.RemoveField(
+            model_name="bvprojectfile",
+            name="parser_order",
+        ),
+        migrations.AddField(
+            model_name="anlage2config",
+            name="default_parser",
+            field=models.CharField(
+                choices=[("exact", "ExactParser"), ("table", "TableParser")],
+                default="exact",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/core/parser_manager.py
+++ b/core/parser_manager.py
@@ -34,18 +34,8 @@ class ParserManager:
             project_file.upload.name,
         )
         cfg = Anlage2Config.get_instance()
-        mode = project_file.parser_mode or cfg.parser_mode
-        order = project_file.parser_order or cfg.parser_order or ["exact"]
-        logger.debug("Parser-Modus: %s Reihenfolge: %s", mode, order)
-
-        if mode == "table_only":
-            name = "table"
-        elif mode == "exact_only":
-            name = "exact"
-        elif mode == "text_only":
-            name = "text"
-        else:  # auto or unbekannt
-            name = order[0]
+        name = cfg.default_parser
+        logger.debug("Verwende Parser: %s", name)
 
         parser = self.get(name)
         if parser is None:


### PR DESCRIPTION
## Summary
- remove obsolete parser_mode/parser_order fields
- introduce default_parser setting for Anlage2
- run default parser automatically when Anlage 2 files are saved

## Testing
- `python manage.py makemigrations --name remove_parser_mode` (failed: Unknown field(s) (parser_mode) specified for Anlage2Config)
- `pytest -q` (no output / interrupted)


------
https://chatgpt.com/codex/tasks/task_e_68aaf6ebc3ac832bb18ac8f352dc6a49