### PR TITLE
test: verify dashboard after login

### DIFF
--- a/core/tests/test_selenium.py
+++ b/core/tests/test_selenium.py
@@ -60,6 +60,13 @@ class FileUploadDuplicateTests(StaticLiveServerTestCase):
 
     def test_duplicate_files_show_warning(self):
         self._login()
+        WebDriverWait(self.driver, 10).until(
+            EC.text_to_be_present_in_element((By.TAG_NAME, "h1"), "Meine Aufnahmen")
+        )
+        self.assertEqual(
+            self.driver.current_url,
+            self.live_server_url + reverse("dashboard"),
+        )
         url = self.live_server_url + reverse("projekt_file_upload", args=[self.projekt.pk])
         self.driver.get(url)
         input_el = self.driver.find_element(By.ID, "id_upload")


### PR DESCRIPTION
## Summary
- ensure Selenium upload test waits for dashboard heading after login
- assert the current URL matches the dashboard after login

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: test_admin_views)*

------
https://chatgpt.com/codex/tasks/task_e_68aafde6b4a4832bba009f6c9a219ee4