### PR TITLE
fix: korrigiere erwarteten Dashboard-Titel im Selenium-Test

### DIFF
--- a/core/tests/test_selenium.py
+++ b/core/tests/test_selenium.py
@@ -61,7 +61,7 @@ class FileUploadDuplicateTests(StaticLiveServerTestCase):
     def test_duplicate_files_show_warning(self):
         self._login()
         WebDriverWait(self.driver, 10).until(
-            EC.text_to_be_present_in_element((By.TAG_NAME, "h1"), "Meine Aufnahmen")
+            EC.text_to_be_present_in_element((By.TAG_NAME, "h1"), "Meine Projekte")
         )
         self.assertEqual(
             self.driver.current_url,


### PR DESCRIPTION
## Summary
- adjust Selenium test to wait for 'Meine Projekte' heading after login

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: BVProjectFileTests.test_template_shows_disabled_state_when_task_running)*
- `pytest core/tests/test_selenium.py::FileUploadDuplicateTests::test_duplicate_files_show_warning -vv`


------
https://chatgpt.com/codex/tasks/task_e_68aaff7724e0832b9b4e2320956f2fd2