### PR TITLE
fix: verwende seeded superuser in tests

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -15,10 +15,11 @@ def _seed_db(django_db_setup, django_db_blocker) -> None:
         seed_test_data()
         if not User.objects.filter(username="baseuser").exists():
             User.objects.create_user("baseuser", password="pass")
-        if not User.objects.filter(username="basesuper").exists():
-            User.objects.create_superuser(
-                "basesuper", "admin@example.com", password="pass"
-            )
+        # Sicherstellen, dass der Superuser aus dem Seed-Skript
+        # ein bekanntes Passwort für die Tests besitzt.
+        superuser = User.objects.get(username="frank")
+        superuser.set_password("pass")
+        superuser.save()
 
 
 @pytest.fixture
@@ -34,7 +35,7 @@ def superuser(db) -> "User":
     """Gibt den Basis-Superuser zurück."""
     from django.contrib.auth.models import User
 
-    return User.objects.get(username="basesuper")
+    return User.objects.get(username="frank")
 
 
 @pytest.fixture(autouse=True)

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -379,7 +379,7 @@ class BVProjectFileTests(NoesisTestCase):
     def setUp(self) -> None:  # pragma: no cover - setup
         super().setUp()
         self.anmelden_func = Anlage2Function.objects.create(name="Anmelden")
-        self.superuser = User.objects.get(username="basesuper")
+        self.superuser = User.objects.get(username="frank")
 
     def test_create_project_with_files(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -2864,7 +2864,7 @@ class ProjektFileDeleteResultTests(NoesisTestCase):
 class ProjektFileVersionDeletionTests(NoesisTestCase):
     def setUp(self):
         self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        self.superuser = User.objects.get(username="basesuper")
+        self.superuser = User.objects.get(username="frank")
 
     def test_delete_active_restores_parent(self):
         self.client.login(username=self.superuser.username, password="pass")
@@ -4609,7 +4609,7 @@ class Anlage2ResetTests(NoesisTestCase):
 
     def setUp(self):
         super().setUp()
-        self.superuser = User.objects.get(username="basesuper")
+        self.superuser = User.objects.get(username="frank")
         self.client.login(username=self.superuser.username, password="pass")
         self.func = Anlage2Function.objects.create(name="Anmelden")
 
@@ -4869,7 +4869,7 @@ class Anlage2ResetTests(NoesisTestCase):
 class GapReportTests(NoesisTestCase):
     def setUp(self):
         super().setUp()
-        self.superuser = User.objects.get(username="basesuper")
+        self.superuser = User.objects.get(username="frank")
         self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         self.pf1 = BVProjectFile.objects.create(
             project=self.projekt,
@@ -4936,7 +4936,7 @@ class GapReportTests(NoesisTestCase):
 class ProjektDetailGapTests(NoesisTestCase):
     def setUp(self):
         super().setUp()
-        self.superuser = User.objects.get(username="basesuper")
+        self.superuser = User.objects.get(username="frank")
         self.func = Anlage2Function.objects.create(name="Anmelden")
 
     def test_anlage1_gap_sets_flag(self):


### PR DESCRIPTION
## Zusammenfassung
- Referenzen auf nicht vorhandenen `basesuper` in Tests ersetzt durch den von `seed_initial_data` angelegten Superuser `frank`
- Test-Fixture passt Passwort von `frank` an, damit Logins funktionieren

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_general.py::BVProjectFileTests::test_create_project_with_files -q`
- `pytest core/tests/test_general.py::ProjektFileVersionDeletionTests::test_delete_active_restores_parent -q`
- `pytest core/tests/test_general.py::Anlage2ResetTests::test_run_anlage2_analysis_resets_results -q`
- `pytest core/tests/test_general.py::GapReportTests::test_tasks_return_text -q` *(fehlt Platzhalter 'funktionen')*
- `pytest core/tests/test_general.py::GapReportTests::test_view_saves_text -q`
- `pytest core/tests/test_general.py::ProjektDetailGapTests::test_anlage1_gap_sets_flag -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab00ceb62c832bb9c19d25fcfe7850