### PR TITLE
fix: vereinheitliche Projektstatus-Schlüssel

### DIFF
--- a/core/initial_data_constants.py
+++ b/core/initial_data_constants.py
@@ -41,11 +41,11 @@ INITIAL_AREAS = {
 
 # 2. Projekt-Status
 INITIAL_PROJECT_STATUSES = [
-    {"key": "new", "name": "Neu", "ordering": 10, "is_default": True},
-    {"key": "in_progress", "name": "In Bearbeitung", "ordering": 20},
-    {"key": "review", "name": "In Prüfung", "ordering": 30},
-    {"key": "done", "name": "Abgeschlossen", "ordering": 40, "is_done_status": True},
-    {"key": "archived", "name": "Archiviert", "ordering": 50},
+    {"key": "NEW", "name": "Neu", "ordering": 10, "is_default": True},
+    {"key": "IN_PROGRESS", "name": "In Bearbeitung", "ordering": 20},
+    {"key": "REVIEW", "name": "In Prüfung", "ordering": 30},
+    {"key": "DONE", "name": "Abgeschlossen", "ordering": 40, "is_done_status": True},
+    {"key": "ARCHIVED", "name": "Archiviert", "ordering": 50},
 ]
 
 # 3. LLM-Rollen (aus llm_roles.json)

--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -78,7 +78,10 @@ def create_initial_data(apps) -> None:
     # 2. Projekt-Status
     print("\n[2] Verarbeite Projekt-Status...")
     for status_data in INITIAL_PROJECT_STATUSES:
-        ProjectStatus.objects.update_or_create(key=status_data["key"], defaults=status_data)
+        ProjectStatus.objects.update_or_create(
+            key__iexact=status_data["key"],
+            defaults=status_data,
+        )
 
     # 3. LLM-Rollen
     print("\n[3] Verarbeite LLM-Rollen...")

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -114,11 +114,17 @@ from django.core.management import call_command
 from django.test import override_settings
 import json
 from .base import NoesisTestCase
+from ..initial_data_constants import INITIAL_PROJECT_STATUSES
+
+
+DEFAULT_STATUS_KEY = next(
+    s["key"] for s in INITIAL_PROJECT_STATUSES if s.get("is_default")
+)
 
 
 def create_statuses() -> None:
     data = [
-        ("NEW", "Neu"),
+        (DEFAULT_STATUS_KEY, "Neu"),
         ("CLASSIFIED", "Klassifiziert"),
         ("GUTACHTEN_OK", "Gutachten OK"),
         ("GUTACHTEN_FREIGEGEBEN", "Gutachten freigegeben"),
@@ -132,7 +138,7 @@ def create_statuses() -> None:
             defaults={
                 "name": name,
                 "ordering": idx,
-                "is_default": key == "NEW",
+                "is_default": key == DEFAULT_STATUS_KEY,
                 "is_done_status": key == "ENDGEPRUEFT",
             },
         )
@@ -1262,7 +1268,7 @@ class AnlagenFunktionsMetadatenModelTests(NoesisTestCase):
 class WorkflowTests(NoesisTestCase):
     def test_default_status(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        self.assertEqual(projekt.status.key, "NEW")
+        self.assertEqual(projekt.status.key, DEFAULT_STATUS_KEY)
 
     def test_set_project_status(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")


### PR DESCRIPTION
## Summary
- ensure initial project statuses use consistent uppercase keys
- update seeding to overwrite existing statuses case-insensitively
- reference default status key in tests

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: KeyError: 'verhandlungsfaehig' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ab00de1adc832b9f66ee378b7df805