### PR TITLE
fix: korrigiere Prompt-Platzhalter für Gap-Report

### DIFF
--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -221,7 +221,13 @@ def create_initial_data(apps) -> None:
         ),
         (
             "gap_report_anlage2",
-            "Fasse alle GAP-Notizen aus Anlage 2 für den Fachbereich zusammen. Nutze {funktionen} als Input.",
+            (
+                "Fasse die folgenden GAP-Notizen aus Anlage 2 für den Fachbereich zusammen. "
+                "Die Notizen enthalten interne und externe Anmerkungen. Formuliere eine professionelle "
+                "Zusammenfassung, die für den Fachbereich geeignet ist.\n\n"
+                "Hier sind die Gaps:\n"
+                "{gap_list}"
+            ),
             True,
         ),
     ]


### PR DESCRIPTION
## Summary
- setze {gap_list} als Platzhalter für den Gap-Report-Anlage-2-Prompt

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: AssertionError: Couldn't find 'Analyse läuft')*

------
https://chatgpt.com/codex/tasks/task_e_68ab094d309c832bb0b3ea2362684149