### PR TITLE
Remove model override for LLM selection

### DIFF
--- a/core/llm_utils.py
+++ b/core/llm_utils.py
@@ -22,7 +22,6 @@ def _timestamp() -> str:
 def query_llm(
     prompt_object: "Prompt",
     context_data: dict,
-    model_name: str | None = None,
     model_type: str = "default",
     temperature: float = 0.5,
     project_prompt: str | None = None,
@@ -31,7 +30,9 @@ def query_llm(
     from .models import LLMConfig, LLMRole, Prompt
 
     correlation_id = str(uuid.uuid4())
-    if model_name is None:
+    if prompt_object.model and getattr(prompt_object.model, "model_name", None):
+        model_name = prompt_object.model.model_name
+    else:
         model_name = LLMConfig.get_default(model_type)
 
     final_role_prompt = ""
@@ -71,10 +72,8 @@ def query_llm(
     )
 
     final_prompt_to_llm = prompt
-    model_name_to_use = model_name
-
     logger.debug(
-        f"--- PROMPT SENT TO MODEL {model_name_to_use} ---\n{final_prompt_to_llm}\n--------------------"
+        f"--- PROMPT SENT TO MODEL {model_name} ---\n{final_prompt_to_llm}\n--------------------"
     )
 
     if not settings.GOOGLE_API_KEY and not settings.OPENAI_API_KEY:

--- a/core/management/commands/analyse_anlage4.py
+++ b/core/management/commands/analyse_anlage4.py
@@ -10,12 +10,11 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("file_id", type=int)
-        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, file_id, model=None, **options):
+    def handle(self, file_id, **options):
         if connection.vendor == "sqlite":
-            data = analyse_anlage4_async(file_id, model_name=model)
+            data = analyse_anlage4_async(file_id)
             text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
             print_markdown(text)
         else:
-            async_task("core.llm_tasks.analyse_anlage4_async", file_id, model_name=model)
+            async_task("core.llm_tasks.analyse_anlage4_async", file_id)

--- a/core/management/commands/check_anlage1.py
+++ b/core/management/commands/check_anlage1.py
@@ -8,9 +8,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("file_id", type=int)
-        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, file_id, model=None, **options):
-        data = check_anlage1(file_id, model_name=model)
+    def handle(self, file_id, **options):
+        data = check_anlage1(file_id)
         text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
         print_markdown(text)

--- a/core/management/commands/check_anlage2.py
+++ b/core/management/commands/check_anlage2.py
@@ -8,9 +8,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
-        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, model=None, **options):
-        data = check_anlage2(projekt_id, model_name=model)
+    def handle(self, projekt_id, **options):
+        data = check_anlage2(projekt_id)
         text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
         print_markdown(text)

--- a/core/management/commands/check_anlage2_functions.py
+++ b/core/management/commands/check_anlage2_functions.py
@@ -9,8 +9,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("file_id", type=int)
-        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, file_id, model=None, **options):
-        run_conditional_anlage2_check(file_id, model_name=model)
+    def handle(self, file_id, **options):
+        run_conditional_anlage2_check(file_id)
         print_markdown("Prüfung abgeschlossen")

--- a/core/management/commands/classify_system.py
+++ b/core/management/commands/classify_system.py
@@ -8,9 +8,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
-        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, model=None, **options):
-        data = classify_system(projekt_id, model_name=model)
+    def handle(self, projekt_id, **options):
+        data = classify_system(projekt_id)
         text = f"```json\n{json.dumps(data, indent=2, ensure_ascii=False)}\n```"
         print_markdown(text)

--- a/core/management/commands/generate_gutachten.py
+++ b/core/management/commands/generate_gutachten.py
@@ -7,8 +7,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("projekt_id", type=int)
-        parser.add_argument("--model", dest="model", default=None)
 
-    def handle(self, projekt_id, model=None, **options):
-        path = generate_gutachten(projekt_id, model_name=model)
+    def handle(self, projekt_id, **options):
+        path = generate_gutachten(projekt_id)
         print_markdown(str(path))

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2828,14 +2828,6 @@ class WorkerAnlage3VisionTests(NoesisTestCase):
         file_obj = self.projekt.anlagen.get(anlage_nr=3)
         self.assertTrue(file_obj.analysis_json["ok"]["value"])
 
-    def test_model_name_is_forwarded(self):
-        with patch(
-            "core.llm_tasks.query_llm_with_images",
-            return_value=json.dumps({"ok": False}),
-        ) as mock_q:
-            worker_run_anlage3_vision(self.projekt.pk, model_name="vision")
-        self.assertEqual(mock_q.call_args[0][2], "vision")
-
 
 class ProjektFileDeleteResultTests(NoesisTestCase):
     def setUp(self):
@@ -2974,7 +2966,7 @@ class ProjektFileCheckResultTests(NoesisTestCase):
         self.assertRedirects(
             resp, reverse("projekt_file_edit_json", args=[self.file.pk])
         )
-        mock_func.assert_called_with(self.file.pk, model_name=None)
+        mock_func.assert_called_with(self.file.pk)
 
     def test_anlage2_uses_parser_by_default(self):
         url = reverse("projekt_file_check_view", args=[self.file2.pk])
@@ -2994,7 +2986,7 @@ class ProjektFileCheckResultTests(NoesisTestCase):
         self.assertRedirects(
             resp, reverse("projekt_file_edit_json", args=[self.file2.pk])
         )
-        mock_func.assert_called_with(self.file2.pk, model_name=None)
+        mock_func.assert_called_with(self.file2.pk)
 
     def test_anlage3_uses_analysis(self):
         pf = BVProjectFile.objects.create(
@@ -3008,7 +3000,7 @@ class ProjektFileCheckResultTests(NoesisTestCase):
             mock_func.return_value = {"task": "analyse_anlage3"}
             resp = self.client.get(url)
         self.assertRedirects(resp, reverse("anlage3_review", args=[self.projekt.pk]))
-        mock_func.assert_called_with(pf.pk, model_name=None)
+        mock_func.assert_called_with(pf.pk)
 
     def test_anlage3_llm_param_triggers_vision_check(self):
         pf = BVProjectFile.objects.create(
@@ -3022,7 +3014,7 @@ class ProjektFileCheckResultTests(NoesisTestCase):
             mock_func.return_value = {"task": "check_anlage3_vision"}
             resp = self.client.get(url)
         self.assertRedirects(resp, reverse("anlage3_review", args=[self.projekt.pk]))
-        mock_func.assert_called_with(pf.pk, model_name=None)
+        mock_func.assert_called_with(pf.pk)
 
     def test_parse_view_runs_parser(self):
         url = reverse("projekt_file_check_view", args=[self.file2.pk])

--- a/core/views.py
+++ b/core/views.py
@@ -3652,7 +3652,7 @@ def projekt_file_check(request, pk, nr):
 
     use_llm = request.POST.get("llm") or request.GET.get("llm")
 
-    def parse_only(pid: int, model_name: str | None = None):
+    def parse_only(pid: int):
         pf = BVProjectFile.objects.filter(project_id=pid, anlage_nr=2).first()
         if pf:
             run_anlage2_analysis(pf)
@@ -3697,7 +3697,7 @@ def projekt_file_check_pk(request, pk):
 
     use_llm = request.POST.get("llm") or request.GET.get("llm")
 
-    def parse_only(_pid: int, model_name: str | None = None):
+    def parse_only(_pid: int):
         run_anlage2_analysis(anlage)
 
     funcs = {
@@ -3751,7 +3751,7 @@ def projekt_file_check_view(request, pk):
 
     use_llm = request.POST.get("llm") or request.GET.get("llm")
 
-    def parse_only(_pid: int, model_name: str | None = None):
+    def parse_only(_pid: int):
         run_anlage2_analysis(anlage)
 
     funcs = {
@@ -5735,10 +5735,8 @@ def gutachten_llm_check(request, pk):
     """Löst den LLM-Funktionscheck für das Gutachten aus."""
     gutachten = get_object_or_404(Gutachten, pk=pk)
     projekt = gutachten.software_knowledge.project
-    category = request.POST.get("model_category")
-    model = LLMConfig.get_default(category) if category else None
     try:
-        note = check_gutachten_functions(projekt.pk, model_name=model)
+        note = check_gutachten_functions(projekt.pk)
         if note:
             projekt.gutachten_function_note = note
             projekt.save(update_fields=["gutachten_function_note"])


### PR DESCRIPTION
## Summary
- select LLM models solely from prompt configuration
- drop model override parameters across tasks and views
- update tests for revised function signatures

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: BVProjectFileTests.test_template_shows_disabled_state_when_task_running)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0d0809f8832baf55af9be7c4c2ee