### PR TITLE
fix: adjust running analysis test to check spinner

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -524,7 +524,7 @@ class BVProjectFileTests(NoesisTestCase):
             mock_fetch.return_value = SimpleNamespace(success=None)
             url = reverse("projekt_detail", args=[projekt.pk])
             resp = self.client.get(url)
-        self.assertContains(resp, "Analyse läuft")  # Statusmeldung bei laufender Analyse
+        self.assertContains(resp, "animate-spin")  # Spinner-Element bei laufender Analyse
 
     def test_hx_project_file_status_running(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")


### PR DESCRIPTION
## Summary
- update `test_template_shows_disabled_state_when_task_running` to assert spinner CSS class `animate-spin`

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: KeyError: 'verhandlungsfaehig')*

------
https://chatgpt.com/codex/tasks/task_e_68ab10dc9f04832b8b59e1ae94d10e52