### PR TITLE
fix: load Anlage 1 text from database in test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2445,7 +2445,8 @@ class LLMTasksTests(NoesisTestCase):
         q2 = Anlage1Question.objects.get(num=2)
         q2.parser_enabled = False
         q2.save(update_fields=["parser_enabled"])
-        text = "Frage 1: Extrahiere alle Unternehmen als Liste.\u00b6A1"
+        q1_text = Anlage1Question.objects.get(num=1).text
+        text = f"{q1_text}\u00b6A1"
         parsed = parse_anlage1_questions(text)
         self.assertEqual(parsed, {"1": {"answer": "A1", "found_num": "1"}})
 


### PR DESCRIPTION
## Summary
- retrieve Anlage 1 question text from DB in parser-enabled test

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(fails: 33 failed, 296 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2cbe7720832b8db2194b82483d7a