### PR TITLE
fix: format gap report entries

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -2236,11 +2236,13 @@ def summarize_anlage2_gaps(projekt: BVProject) -> str:
 
     gap_list_string = ""
     for entry in entries:
-        gap_list_string += f"- **{entry['funktion']}" + (f" ({entry['unterfrage']})" if entry['unterfrage'] else "") + "**\n"
-        if entry["extern"]:
-            gap_list_string += f"  - Anmerkung (extern): {entry['extern']}\n"
-        if entry["intern"]:
-            gap_list_string += f"  - Notiz (intern): {entry['intern']}\n"
+        gap_list_string += (
+            f"- **{entry['funktion']}"
+            + (f" ({entry['unterfrage']})" if entry['unterfrage'] else "")
+            + "**\n"
+        )
+        gap_list_string += f"  - KI‑Begründung: {entry['extern']}\n"
+        gap_list_string += f"  - Prüferkommentar: {entry['intern']}\n"
 
     prompt_template = Prompt.objects.filter(name__iexact="gap_report_anlage2").first()
     if not prompt_template:

--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -223,7 +223,7 @@ def create_initial_data(apps) -> None:
             "gap_report_anlage2",
             (
                 "Fasse die folgenden GAP-Notizen aus Anlage 2 für den Fachbereich zusammen. "
-                "Die Notizen enthalten interne und externe Anmerkungen. Formuliere eine professionelle "
+                "Jede Notiz enthält eine KI‑Begründung und einen Prüferkommentar. Formuliere eine professionelle "
                 "Zusammenfassung, die für den Fachbereich geeignet ist.\n\n"
                 "Hier sind die Gaps:\n"
                 "{gap_list}"


### PR DESCRIPTION
## Summary
- format Anlage 2 gap entries with explicit AI justification and reviewer comment labels
- update default prompt text to reflect new labels

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_general.py::LLMTasksTests::test_analyse_anlage3_auto_ok -q` *(fails: KeyError: 'verhandlungsfaehig')*

------
https://chatgpt.com/codex/tasks/task_e_68ab33216938832b9df8d381c00dcc6e