### PR TITLE
Simplify Anlage 3 verhandlungsfaehig check to page count

### DIFF
--- a/core/tests/test_anlage3_parser.py
+++ b/core/tests/test_anlage3_parser.py
@@ -24,24 +24,16 @@ class Anlage3ParserTests(NoesisTestCase):
 
     def test_verhandlungsfaehig_true(self):
         doc = Document()
-        table = doc.add_table(rows=4, cols=2)
-        table.cell(0, 0).text = "Name der Auswertung"
-        table.cell(0, 1).text = "Test"
-        table.cell(1, 0).text = "Beschreibung"
-        table.cell(1, 1).text = "Desc"
-        table.cell(2, 0).text = "Zeitraum"
-        table.cell(2, 1).text = "2024"
-        table.cell(3, 0).text = "Art der Auswertung"
-        table.cell(3, 1).text = "Art"
+        doc.add_paragraph("Nur eine Seite")
         pf = self._create_file(doc)
         data = parse_anlage3(pf)
         self.assertTrue(data["verhandlungsfaehig"])
 
     def test_verhandlungsfaehig_false(self):
         doc = Document()
-        table = doc.add_table(rows=1, cols=2)
-        table.cell(0, 0).text = "Name der Auswertung"
-        table.cell(0, 1).text = "Test"
+        doc.add_paragraph("Seite 1")
+        doc.add_page_break()
+        doc.add_paragraph("Seite 2")
         pf = self._create_file(doc)
         data = parse_anlage3(pf)
         self.assertFalse(data["verhandlungsfaehig"])

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2184,8 +2184,8 @@ class LLMTasksTests(NoesisTestCase):
         pf.refresh_from_db()
         file_obj = pf
         self.assertEqual(data["pages"], 1)
-        self.assertTrue(data["verhandlungsfaehig"]["value"])
-        self.assertTrue(file_obj.analysis_json["verhandlungsfaehig"]["value"])
+        self.assertTrue(data["auto_ok"])
+        self.assertTrue(file_obj.analysis_json["auto_ok"])
         if hasattr(file_obj, "verhandlungsfaehig"):
             self.assertTrue(file_obj.verhandlungsfaehig)
 
@@ -2213,8 +2213,8 @@ class LLMTasksTests(NoesisTestCase):
         pf.refresh_from_db()
         file_obj = pf
         self.assertEqual(data["pages"], 2)
-        self.assertFalse(data["verhandlungsfaehig"]["value"])
-        self.assertFalse(file_obj.analysis_json["verhandlungsfaehig"]["value"])
+        self.assertTrue(data["manual_required"])
+        self.assertTrue(file_obj.analysis_json["manual_required"])
         if hasattr(file_obj, "verhandlungsfaehig"):
             self.assertFalse(file_obj.verhandlungsfaehig)
 
@@ -2240,8 +2240,8 @@ class LLMTasksTests(NoesisTestCase):
         pf.refresh_from_db()
         file_obj = pf
         self.assertEqual(data["pages"], 1)
-        self.assertTrue(data["verhandlungsfaehig"]["value"])
-        self.assertTrue(file_obj.analysis_json["verhandlungsfaehig"]["value"])
+        self.assertTrue(data["auto_ok"])
+        self.assertTrue(file_obj.analysis_json["auto_ok"])
 
     def test_analyse_anlage3_pdf_manual_required(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -2266,8 +2266,8 @@ class LLMTasksTests(NoesisTestCase):
         pf.refresh_from_db()
         file_obj = pf
         self.assertEqual(data["pages"], 2)
-        self.assertFalse(data["verhandlungsfaehig"]["value"])
-        self.assertFalse(file_obj.analysis_json["verhandlungsfaehig"]["value"])
+        self.assertTrue(data["manual_required"])
+        self.assertTrue(file_obj.analysis_json["manual_required"])
 
     def test_analyse_anlage3_multiple_files(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -2349,6 +2349,7 @@ class LLMTasksTests(NoesisTestCase):
         file_obj = projekt.anlagen.get(anlage_nr=1)
         data = check_anlage1(file_obj.pk)
         expected = {"questions": parse_anlage1_questions(text)}
+        file_obj.refresh_from_db()
         self.assertEqual(data, expected)
         self.assertEqual(file_obj.analysis_json, expected)
 


### PR DESCRIPTION
## Summary
- Evaluate Anlage 3 verhandlungsfaehig solely by counting pages
- Adjust Anlage 3 parser tests and LLM task tests to use page-count based logic
- Fix Anlage 1 parser test to refresh stored analysis

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_anlage3_parser.py core/tests/test_general.py::LLMTasksTests::test_analyse_anlage3_auto_ok core/tests/test_general.py::LLMTasksTests::test_analyse_anlage3_manual_required core/tests/test_general.py::LLMTasksTests::test_analyse_anlage3_pdf_auto_ok core/tests/test_general.py::LLMTasksTests::test_analyse_anlage3_pdf_manual_required core/tests/test_general.py::LLMTasksTests::test_check_anlage1_parser -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2e1bbe58832ba58a9f75281b9ca0