### PR TITLE
fix: use gap_list placeholder for Anlage2 gap report

### DIFF
--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -47,6 +47,13 @@ def create_initial_data(apps) -> None:
     AntwortErkennungsRegel = apps.get_model("core", "AntwortErkennungsRegel")
     Prompt = apps.get_model("core", "Prompt")
     SupervisionStandardNote = apps.get_model("core", "SupervisionStandardNote")
+
+    # Bestehende Prompts aktualisieren: {funktionen} -> {gap_list}
+    gap_prompt = Prompt.objects.filter(name="gap_report_anlage2").first()
+    if gap_prompt and "{funktionen}" in gap_prompt.text:
+        gap_prompt.text = gap_prompt.text.replace("{funktionen}", "{gap_list}")
+        gap_prompt.save(update_fields=["text"])
+
     standard_group, _ = Group.objects.get_or_create(name="Standard-Benutzer")
     admin_group, _ = Group.objects.get_or_create(name="Projekt-Admins")
 

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -2500,6 +2500,11 @@ class PromptTests(NoesisTestCase):
         p.save()
         self.assertEqual(get_prompt("classify_system", "x"), "DB")
 
+    def test_gap_report_anlage2_placeholder(self):
+        p = Prompt.objects.get(name="gap_report_anlage2")
+        self.assertIn("{gap_list}", p.text)
+        self.assertNotIn("{funktionen}", p.text)
+
     def test_check_anlage3_vision_prompt_text(self):
         p = Prompt.objects.get(name="check_anlage3_vision")
         expected = (
@@ -4898,6 +4903,10 @@ class GapReportTests(NoesisTestCase):
 
         with patch("core.llm_tasks.query_llm", return_value="T2") as mock_q:
             text = summarize_anlage2_gaps(self.projekt)
+            prompt_sent = mock_q.call_args[0][0]
+            self.assertIn("- **Anmelden**", prompt_sent.text)
+            self.assertNotIn("{gap_list}", prompt_sent.text)
+            self.assertNotIn("{funktionen}", prompt_sent.text)
         self.assertEqual(text, "T2")
         self.assertTrue(mock_q.called)
 


### PR DESCRIPTION
## Summary
- ensure seed command updates existing `gap_report_anlage2` prompts to `{gap_list}`
- cover new placeholder with tests and validate rendered gap list

## Testing
- `python manage.py makemigrations --check`
- `pytest -q` *(fails: KeyError 'verhandlungsfaehig')*

------
https://chatgpt.com/codex/tasks/task_e_68ab331a27b4832ba8026a7adf06ba45