### PR TITLE
fix: remove Anlage3 vision LLM

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -45,7 +45,6 @@ def mock_llm_api_calls():
         patch("core.llm_utils.query_llm", return_value="Mock-Antwort"),
         patch("core.llm_utils.query_llm_with_images", return_value="Mock-Antwort"),
         patch("core.llm_tasks.query_llm", return_value="Mock-Antwort"),
-        patch("core.llm_tasks.query_llm_with_images", return_value="Mock-Antwort"),
         patch("google.generativeai.configure"),
         patch("google.generativeai.list_models", return_value=[]),
     ):


### PR DESCRIPTION
## Summary
- strip LLM image check for Anlage 3 and add helper to just extract images
- drop unused LLM image mocks in tests and adjust project file tests accordingly

## Testing
- `python manage.py makemigrations --check`
- `pytest -q` *(fails: KeyError: 'verhandlungsfaehig' and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab34efc994832b96ea6e4e6cb281cf