### PR TITLE
Fix test for parsing unnumbered Anlage1 questions

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -5,6 +5,7 @@ from django.http import QueryDict
 from django.db import IntegrityError
 from types import SimpleNamespace
 import os
+import re
 
 
 from django.apps import apps
@@ -2356,8 +2357,9 @@ class LLMTasksTests(NoesisTestCase):
         # Frage-Texte ohne Präfix "Frage X:" speichern
         q1 = Anlage1Question.objects.get(num=1)
         q2 = Anlage1Question.objects.get(num=2)
-        q1.text = q1.text.split(": ", 1)[1]
-        q2.text = q2.text.split(": ", 1)[1]
+        prefix = r"^Frage\s+\d+(?:\.\d+)?[:.]?\s*"
+        q1.text = re.sub(prefix, "", q1.text)
+        q2.text = re.sub(prefix, "", q2.text)
         q1.save(update_fields=["text"])
         q2.save(update_fields=["text"])
         v1 = q1.variants.first()


### PR DESCRIPTION
## Summary
- Fix `test_parse_anlage1_questions_without_numbers` to remove optional "Frage X" prefixes via regex
- Import `re` in test suite

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ab4fb8b064832bb6228aa2b515e797