### PR TITLE
fix: use prompt model in gap summaries

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -2184,12 +2184,12 @@ def summarize_anlage1_gaps(projekt: BVProject) -> str:
         text=final_prompt_text,
         role=prompt_template.role,
         use_project_context=prompt_template.use_project_context,
+        model=prompt_template.model,
     )
 
     text = query_llm(
         prompt_obj,
         {},
-        model_type="gutachten",
         project_prompt=projekt.project_prompt if prompt_obj.use_project_context else None,
     ).strip()
 
@@ -2259,12 +2259,12 @@ def summarize_anlage2_gaps(projekt: BVProject) -> str:
         text=final_prompt_text,
         role=prompt_template.role,
         use_project_context=prompt_template.use_project_context,
+        model=prompt_template.model,
     )
 
     text = query_llm(
         prompt_obj,
         {},
-        model_type="gutachten",
         project_prompt=projekt.project_prompt if prompt_obj.use_project_context else None,
     ).strip()
 

--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -225,6 +225,7 @@ def create_initial_data(apps) -> None:
                 "Die folgenden Fragen dienen als Input:\n\n{fragen}"
             ),
             True,
+            "gutachten",
         ),
         (
             "gap_report_anlage2",
@@ -236,6 +237,7 @@ def create_initial_data(apps) -> None:
                 "{gap_list}"
             ),
             True,
+            "gutachten",
         ),
     ]
 
@@ -279,8 +281,18 @@ def create_initial_data(apps) -> None:
 
     for q in INITIAL_ANLAGE1_QUESTIONS:
         prompts.append((f"anlage1_q{q['num']}", q["text"], True))
-    for name, text, use_system_role in prompts:
-        Prompt.objects.update_or_create(name=name, defaults={"text": text, "use_system_role": use_system_role})
+    for entry in prompts:
+        if len(entry) == 3:
+            name, text, use_system_role = entry
+            defaults = {"text": text, "use_system_role": use_system_role}
+        else:
+            name, text, use_system_role, model = entry
+            defaults = {
+                "text": text,
+                "use_system_role": use_system_role,
+                "model": model,
+            }
+        Prompt.objects.update_or_create(name=name, defaults=defaults)
 
     # 12. SupervisionStandardNote
     print("\n[12] Verarbeite SupervisionStandardNotes...")


### PR DESCRIPTION
## Summary
- pass the model from gap-report prompts into temporary prompts
- rely on the prompt-defined model instead of forcing gutachten model
- seed gap report prompts with gutachten model and allow optional model in seeding

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ab5a2194f0832ba3babc04e641b50b