### PR TITLE
fix: remove model parameter from gap summary task

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -5309,11 +5309,9 @@ def ajax_generate_gap_summary(request, result_id: int) -> JsonResponse:
     if not _user_can_edit_project(request.user, result.anlage_datei.project):
         return HttpResponseForbidden("Nicht berechtigt")
 
-    model = request.POST.get("model")
     task_id = async_task(
         "core.llm_tasks.worker_generate_gap_summary",
         result.id,
-        model,
     )
     return JsonResponse({"status": "queued", "task_id": task_id})
 


### PR DESCRIPTION
## Summary
- remove unused model parameter from gap summary view
- keep worker_generate_gap_summary signature on result_id only

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_general.py::AjaxAnlage2ReviewTests::test_gap_generated_on_difference -q` *(fails: FieldError: Invalid field name(s) for model Prompt: 'model')*

------
https://chatgpt.com/codex/tasks/task_e_68ab5f1498c4832b962c092e63d9eca4