### PR TITLE
fix: apply admin-defined role in initial knowledge check

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1918,14 +1918,12 @@ def worker_run_initial_check(
             else "initial_check_knowledge"
         )
         prompt_knowledge = Prompt.objects.get(name=prompt_name)
-        prompt1_text = prompt_knowledge.text.format(
-            name=software_name,
-            user_context=user_context or "",
-        )
-        tmp_prompt = Prompt(text=prompt1_text, use_system_role=False)
         reply1 = query_llm(
-            tmp_prompt,
-            {},
+            prompt_knowledge,
+            {
+                "name": software_name,
+                "user_context": user_context or "",
+            },
             model_type="default",
             project_prompt=sk.project.project_prompt,
         )


### PR DESCRIPTION
## Summary
- ensure initial knowledge check prompt uses admin-defined role

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ab5f537b10832b97fe287aa2ff43b9