### PR TITLE
fix: remove model parameter from gap summary tasks

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -2233,7 +2233,6 @@ def summarize_anlage1_gaps(projekt: BVProject) -> str:
         text=final_prompt_text,
         role=prompt_template.role,
         use_project_context=prompt_template.use_project_context,
-        model=prompt_template.model,
     )
 
     text = query_llm(
@@ -2308,7 +2307,6 @@ def summarize_anlage2_gaps(projekt: BVProject) -> str:
         text=final_prompt_text,
         role=prompt_template.role,
         use_project_context=prompt_template.use_project_context,
-        model=prompt_template.model,
     )
 
     text = query_llm(


### PR DESCRIPTION
## Summary
- drop use of `prompt_template.model` when creating gap report prompts

## Testing
- `python manage.py makemigrations --check`
- `python manage.py test core.tests.test_general.GapReportTests.test_tasks_return_text` *(fails: Invalid field name(s) for model Prompt: 'model')*


------
https://chatgpt.com/codex/tasks/task_e_68ab6a2a90dc832bae57502785c8e1da