### PR TITLE
fix: entferne Modellfeld aus Prompts

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -2233,7 +2233,6 @@ def summarize_anlage1_gaps(projekt: BVProject) -> str:
         text=final_prompt_text,
         role=prompt_template.role,
         use_project_context=prompt_template.use_project_context,
-        model=prompt_template.model,
     )
 
     text = query_llm(
@@ -2308,7 +2307,6 @@ def summarize_anlage2_gaps(projekt: BVProject) -> str:
         text=final_prompt_text,
         role=prompt_template.role,
         use_project_context=prompt_template.use_project_context,
-        model=prompt_template.model,
     )
 
     text = query_llm(

--- a/core/llm_utils.py
+++ b/core/llm_utils.py
@@ -27,13 +27,10 @@ def query_llm(
     project_prompt: str | None = None,
 ) -> str:
     """Sende eine Anfrage an ein LLM und gib die Antwort zurück."""
-    from .models import LLMConfig, LLMRole, Prompt
+    from .models import LLMConfig, LLMRole
 
     correlation_id = str(uuid.uuid4())
-    if prompt_object.model and getattr(prompt_object.model, "model_name", None):
-        model_name = prompt_object.model.model_name
-    else:
-        model_name = LLMConfig.get_default(model_type)
+    model_name = LLMConfig.get_default(model_type)
 
     final_role_prompt = ""
 

--- a/core/management/commands/seed_initial_data.py
+++ b/core/management/commands/seed_initial_data.py
@@ -282,16 +282,8 @@ def create_initial_data(apps) -> None:
     for q in INITIAL_ANLAGE1_QUESTIONS:
         prompts.append((f"anlage1_q{q['num']}", q["text"], True))
     for entry in prompts:
-        if len(entry) == 3:
-            name, text, use_system_role = entry
-            defaults = {"text": text, "use_system_role": use_system_role}
-        else:
-            name, text, use_system_role, model = entry
-            defaults = {
-                "text": text,
-                "use_system_role": use_system_role,
-                "model": model,
-            }
+        name, text, use_system_role, *rest = entry
+        defaults = {"text": text, "use_system_role": use_system_role}
         Prompt.objects.update_or_create(name=name, defaults=defaults)
 
     # 12. SupervisionStandardNote


### PR DESCRIPTION
## Zusammenfassung
- entferne `model` aus den Seed-Daten der Prompts
- passe LLM-Aufrufe an, sodass keine Modellreferenz mehr verwendet wird
- nutze für LLM-Anfragen stets das Standardmodell

## Testing
- `python manage.py makemigrations --check`
- `pytest` *(Fehlschläge: InitialCheckTests::test_context_is_passed_to_prompt, DocxUtilsTests::test_extract_images)*

------
https://chatgpt.com/codex/tasks/task_e_68ab709ec4e4832bb9f9c3d0c0add163