### PR TITLE
fix: seed test data via fixtures

### DIFF
--- a/core/tests/base.py
+++ b/core/tests/base.py
@@ -1,13 +1,9 @@
-"""Basis-Testklasse mit globalem Seed für Initialdaten."""
+"""Basis-Testklasse für NOESIS-Tests."""
 
-from django.core.management import call_command
 from django.test import TestCase
 
 
 class NoesisTestCase(TestCase):
-    """Führt vor allen Tests das Seeding der Standarddaten aus."""
+    """Allgemeine Basisklasse ohne zusätzliches Seeding."""
 
-    @classmethod
-    def setUpTestData(cls) -> None:  # noqa: D401 - Standard-Setup
-        """Initialisiert die Testdatenbank mit Seed-Daten."""
-        call_command("seed_initial_data", verbosity=0)
+    pass

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,18 +1,21 @@
 """Gemeinsame Testkonfiguration für das core-Modul."""
-
 from unittest.mock import patch
 
 import pytest
+from django.core.management import call_command
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _seed_db(django_db_setup, django_db_blocker) -> None:
     """Initialisiert einmalig die Testdatenbank."""
-    from django.contrib.auth.models import User
-    from .test_general import seed_test_data
-
     with django_db_blocker.unblock():
-        seed_test_data()
+        from django.contrib.auth.models import User
+        from core.models import LLMConfig, Anlage4Config, Anlage4ParserConfig
+
+        call_command("seed_initial_data", verbosity=0)
+        LLMConfig.objects.get_or_create()
+        Anlage4Config.objects.get_or_create()
+        Anlage4ParserConfig.objects.get_or_create()
         if not User.objects.filter(username="baseuser").exists():
             User.objects.create_user("baseuser", password="pass")
         # Sicherstellen, dass der Superuser aus dem Seed-Skript

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -6,6 +6,7 @@ from django.db import IntegrityError
 from types import SimpleNamespace
 import os
 import re
+import pytest
 
 
 from django.apps import apps
@@ -140,6 +141,14 @@ def create_statuses() -> None:
                 "is_done_status": key == "ENDGEPRUEFT",
             },
         )
+
+
+@pytest.fixture(autouse=True)
+def _extra_statuses(db) -> None:
+    """Legt zusätzliche Projekt-Status für Tests an."""
+    create_statuses()
+
+
 def create_project(software: list[str] | None = None, **kwargs) -> BVProject:
     projekt = BVProject.objects.create(**kwargs)
     for name in software or []:


### PR DESCRIPTION
## Summary
- remove global seed from test base class
- centralize initial data seeding in tests' conftest
- add fixture for extra project statuses in generic tests

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ab773275a8832b8b2b8ad8f650e1e2