### PR TITLE
test: mark slow tests and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ auszuführen. LLM-API-Aufrufe werden in den Tests durch ein
 `pytest`-Fixture automatisch gemockt, sodass keine externen
 Requests stattfinden.
 
+Langsame Tests sind mit `@pytest.mark.slow` gekennzeichnet. Die schnelle Standardsuite startet man mit `pytest -m "not slow"`.
+
 ### Commit-Richtlinien
 
 - Verwende Präfixe wie `feat:`, `fix:` oder `docs:` in Commit-Botschaften.

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -426,6 +426,7 @@ class BVProjectFileTests(NoesisTestCase):
         self.assertTrue(pf.manual_reviewed)
         self.assertTrue(pf.verhandlungsfaehig)
 
+    @pytest.mark.slow
     def test_project_delete_removes_files(self):
         """Sichert, dass beim Löschen eines Projekts die Dateien entfernt werden."""
         with TemporaryDirectory() as tmpdir, override_settings(MEDIA_ROOT=tmpdir):
@@ -762,6 +763,7 @@ class ProjektFileUploadTests(NoesisTestCase):
         self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         self.anmelden_func = Anlage2Function.objects.create(name="Anmelden")
 
+    @pytest.mark.slow
     def test_docx_upload_extracts_text(self):
         with open(self.docx_content_path, "rb") as fh:
             upload = SimpleUploadedFile("Anlage_1.docx", fh.read())

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -28,6 +28,7 @@ class DocxExtractTests(NoesisTestCase):
         count = get_docx_page_count(self.docx_content_path)
         self.assertEqual(count, 1)
 
+    @pytest.mark.slow
     def test_get_docx_page_count_two_pages(self):
         count = get_docx_page_count(self.docx_two_page_path)
         self.assertEqual(count, 2)
@@ -36,6 +37,7 @@ class DocxExtractTests(NoesisTestCase):
         count = get_pdf_page_count(self.pdf_one_page_path)
         self.assertEqual(count, 1)
 
+    @pytest.mark.slow
     def test_get_pdf_page_count_two_pages(self):
         count = get_pdf_page_count(self.pdf_two_page_path)
         self.assertEqual(count, 2)
@@ -51,6 +53,7 @@ class DocxExtractTests(NoesisTestCase):
         for raw, expected in cases.items():
             self.assertEqual(_normalize_header_text(raw), expected)
 
+    @pytest.mark.slow
     def test_parse_anlage2_table(self):
         with patch("core.docx_utils.logging.getLogger") as mock_get_logger:
             mock_logger = mock_get_logger.return_value
@@ -86,6 +89,7 @@ class DocxExtractTests(NoesisTestCase):
             ],
         )
 
+    @pytest.mark.slow
     def test_parse_anlage2_table_multiple_headers(self):
         cfg = Anlage2Config.get_instance()
         Anlage2ColumnHeading.objects.create(
@@ -127,6 +131,7 @@ class DocxExtractTests(NoesisTestCase):
 
         self.assertTrue(data[0]["technisch_verfuegbar"]["value"])
 
+    @pytest.mark.slow
     def test_parse_anlage2_table_alias_headers(self):
         cfg = Anlage2Config.get_instance()
         Anlage2ColumnHeading.objects.create(
@@ -181,6 +186,7 @@ class DocxExtractTests(NoesisTestCase):
         )
 
 
+    @pytest.mark.slow
     def test_parse_anlage2_table_extra_text(self):
         cfg = Anlage2Config.get_instance()
         Anlage2ColumnHeading.objects.create(
@@ -238,6 +244,7 @@ class DocxExtractTests(NoesisTestCase):
             ],
         )
 
+    @pytest.mark.slow
     def test_parse_anlage2_table_notes(self):
         doc = Document()
         table = doc.add_table(rows=2, cols=4)
@@ -271,6 +278,7 @@ class DocxExtractTests(NoesisTestCase):
             ],
         )
 
+    @pytest.mark.slow
     def test_parse_anlage2_table_alias_conflict(self):
         cfg = Anlage2Config.get_instance()
         conflict = "Konflikt"
@@ -302,6 +310,7 @@ class DocxExtractTests(NoesisTestCase):
         finally:
             Path(tmp.name).unlink(missing_ok=True)
 
+    @pytest.mark.slow
     def test_parse_anlage2_table_invalid_docx(self):
         tmp = NamedTemporaryFile(delete=False, suffix=".docx")
         tmp.write(b"invalid")

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ addopts = --reuse-db -ra
 testpaths = core/tests
 markers =
     selenium: runs selenium browser tests
+    slow: marks tests as slow


### PR DESCRIPTION
## Summary
- add `slow` marker to pytest config
- mark I/O-heavy tests with `@pytest.mark.slow`
- document running `pytest -m "not slow"` for quick test runs

## Testing
- `python manage.py makemigrations --check`
- `pre-commit run --files pytest.ini core/tests/test_general.py core/tests/test_parsing.py README.md`


------
https://chatgpt.com/codex/tasks/task_e_68ab7b00e948832baefbe47df6535709