### PR TITLE
feat: enable parallel pytest execution

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = noesis.settings
 pythonpath = .
-addopts = --reuse-db -ra
+addopts = --reuse-db -ra -n auto
 testpaths = core/tests
 markers =
     selenium: runs selenium browser tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest
 rich
 selenium
 pytest-django
+pytest-xdist


### PR DESCRIPTION
## Summary
- add pytest-xdist to development requirements
- enable parallel execution via pytest addopts

## Testing
- `python manage.py makemigrations --check`
- `pytest -n auto` *(fails: ProjectStatus.DoesNotExist, ValueError in tests, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab7e9fcbec832ba959781967aa84e1