### PR TITLE
feat: Parallelisierung der Tests mit pytest-xdist

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = noesis.settings
 pythonpath = .
-addopts = --reuse-db -ra
+addopts = --reuse-db -ra -n auto
 testpaths = core/tests
 markers =
     selenium: runs selenium browser tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest
 rich
 selenium
 pytest-django
+pytest-xdist


### PR DESCRIPTION
## Summary
- enable parallel test runs via pytest-xdist
- document parallel execution in pytest.ini

## Testing
- `python manage.py makemigrations --check`
- `pytest -n auto --maxfail=1 -q` *(fails: ProjectStatus errors, missing selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68ab80a9958c832bab29da4c39f6e050