### PR TITLE
Remove obsolete project status auto-update test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -1077,27 +1077,6 @@ class AutoApprovalTests(NoesisTestCase):
         self.assertTrue(pf.manual_reviewed)
         self.assertFalse(pf.verhandlungsfaehig)
 
-    def test_project_status_updated_after_all_anlage3_reviewed(self):
-        pf1 = BVProjectFile.objects.create(
-            project=self.projekt,
-            anlage_nr=3,
-            upload=SimpleUploadedFile("a.txt", b"x"),
-            text_content="x",
-        )
-        pf2 = BVProjectFile.objects.create(
-            project=self.projekt,
-            anlage_nr=3,
-            upload=SimpleUploadedFile("b.txt", b"x"),
-            text_content="y",
-        )
-
-        for pf in (pf1, pf2):
-            url = reverse("project_file_toggle_flag", args=[pf.pk, "manual_reviewed"])
-            self.client.post(url, {"value": "1"})
-
-        self.projekt.refresh_from_db()
-        self.assertEqual(self.projekt.status.key, "ENDGEPRUEFT")
-
 
 class Anlage3AutomationTests(NoesisTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary
- remove outdated test for automatic project status update after reviewing all Anlage 3 files

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ab80a3c720832bbe3bfda5076bb298