### PR TITLE
fix: use valid status in workflow tests

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -1181,9 +1181,9 @@ class WorkflowTests(NoesisTestCase):
 
     def test_set_project_status(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
-        set_project_status(projekt, "CLASSIFIED")
+        set_project_status(projekt, "IN_PROGRESS")
         projekt.refresh_from_db()
-        self.assertEqual(projekt.status.key, "CLASSIFIED")
+        self.assertEqual(projekt.status.key, "IN_PROGRESS")
 
     def test_invalid_status(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -1204,7 +1204,7 @@ class WorkflowTests(NoesisTestCase):
     def test_status_history_created(self):
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
         self.assertEqual(projekt.status_history.count(), 1)
-        set_project_status(projekt, "CLASSIFIED")
+        set_project_status(projekt, "IN_PROGRESS")
         self.assertEqual(projekt.status_history.count(), 2)
 
 


### PR DESCRIPTION
## Summary
- use existing status key `IN_PROGRESS` in workflow tests

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68abfd7fb3a0832ba2a86b5fcac9b231