### PR TITLE
fix: entferne Statusänderung beim Gutachten

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -706,11 +706,7 @@ def generate_gutachten(
         old_path.unlink(missing_ok=True)
     doc.save(path)
     projekt.gutachten_file.name = f"gutachten/{fname}"
-    try:
-        projekt.status = ProjectStatus.objects.get(key="GUTACHTEN_OK")
-    except ProjectStatus.DoesNotExist:
-        pass
-    projekt.save(update_fields=["gutachten_file", "status"])
+    projekt.save(update_fields=["gutachten_file"])
     return path
 
 

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -125,7 +125,6 @@ def create_statuses() -> None:
     data = [
         (DEFAULT_STATUS_KEY, "Neu"),
         ("CLASSIFIED", "Klassifiziert"),
-        ("GUTACHTEN_OK", "Gutachten OK"),
         ("GUTACHTEN_FREIGEGEBEN", "Gutachten freigegeben"),
         ("IN_PRUEFUNG_ANLAGE_X", "In Prüfung Anlage X"),
         ("FB_IN_PRUEFUNG", "FB in Prüfung"),
@@ -2628,7 +2627,6 @@ class WorkerGenerateGutachtenTests(NoesisTestCase):
             path = worker_generate_gutachten(self.projekt.pk, self.knowledge.pk)
         self.projekt.refresh_from_db()
         self.assertTrue(self.projekt.gutachten_file.name)
-        self.assertEqual(self.projekt.status.key, "GUTACHTEN_OK")
         self.assertEqual(
             Gutachten.objects.filter(software_knowledge=self.knowledge).count(), 1
         )


### PR DESCRIPTION
## Summary
- remove changing project status when generating a gutachten
- drop test expectations for non-existent status

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ac09985058832bb2a818716c20909d