### PR TITLE
Fix context assertion in initial check prompt test

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -3498,8 +3498,12 @@ class InitialCheckTests(NoesisTestCase):
                 software_name="A",
             )
             worker_run_initial_check(sk.pk, user_context="Hint")
-        prompt_text = mock_q.call_args[0][0].text
-        self.assertIn("Hint", prompt_text)
+        context_data = mock_q.call_args[0][1]
+        assert context_data["user_context"] == "Hint"
+        assert (
+            mock_q.call_args[0][0].name
+            == "initial_check_knowledge_with_context"
+        )
 
 
 class EditKIJustificationTests(NoesisTestCase):


### PR DESCRIPTION
## Summary
- update initial check test to assert on context data instead of prompt text
- ensure the correct prompt template is selected

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ac0ad99750832bb16b7ec4f5dfb4ca