### PR TITLE
fix: verify project status after flag toggle

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -706,12 +706,14 @@ class BVProjectFileTests(NoesisTestCase):
             upload=SimpleUploadedFile("a6.txt", b"x"),
             verhandlungsfaehig=False,
         )
+        status_before = projekt.status.key
         self.client.login(username=self.superuser.username, password="pass")
         url = reverse("project_file_toggle_flag", args=[pf.pk, "verhandlungsfaehig"])
         resp = self.client.post(url, {"value": "1"})
         self.assertEqual(resp.status_code, 302)
         projekt.refresh_from_db()
-        self.assertEqual(projekt.status.key, status_before)
+        self.assertNotEqual(projekt.status.key, status_before)
+        self.assertEqual(projekt.status.key, "DONE")
         self.assertTrue(all(f.verhandlungsfaehig for f in projekt.anlagen.all()))
 
     def test_hx_project_software_tab(self):


### PR DESCRIPTION
## Summary
- ensure `status_before` defined in project status test
- assert project status switches to DONE when final file marked "verhandlungsfaehig"

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_general.py::BVProjectFileTests::test_toggle_verhandlungsfaehig_sets_project_done -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68ac15e98b20832bbddc4470828de979