### PR TITLE
fix: ensure staticfiles directory exists

### DIFF
--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -208,6 +208,8 @@ STATICFILES_DIRS = [BASE_DIR / "static"]
 
 # Hinzufügen für die Produktion:
 STATIC_ROOT = BASE_DIR / "staticfiles"
+# Verzeichnis für gesammelte statische Dateien automatisch anlegen
+os.makedirs(STATIC_ROOT, exist_ok=True)
 
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 


### PR DESCRIPTION
## Summary
- create staticfiles directory with .gitkeep
- ensure Django creates directory automatically to avoid warnings

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ac1b050800832b8d486b0147dfaa99