### PR TITLE
fix: add extract_images import to parsing tests

### DIFF
--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -6,6 +6,7 @@ from .base import NoesisTestCase
 from .test_general import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from ..anlage4_parser import parse_anlage4_dual
 from ..models import Anlage4ParserConfig
+from ..docx_utils import extract_images
 from ..docx_utils import _normalize_header_text
 from ..parsers import ExactParser
 from ..llm_tasks import worker_a4_plausibility as check_anlage4_item_plausibility


### PR DESCRIPTION
## Summary
- include `extract_images` import in parsing test module

## Testing
- `python manage.py makemigrations --check`
- `pre-commit run --files core/tests/test_parsing.py`
- `pytest core/tests/test_parsing.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac2115dba8832bb630c09c484a26d8