### PR TITLE
fix: improve sidebar toggle accessibility

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,8 @@
         <div class="container mx-auto p-4 flex flex-col md:flex-row md:items-center md:justify-between">
             <div class="flex items-center w-full md:w-auto space-x-4">
                 <button id="sidebar-toggle" class="text-text-light" aria-label="Seitenleiste umschalten">
-                    <i class="fa-solid fa-table-columns"></i>
+                    <i class="fa-solid fa-bars" aria-hidden="true"></i>
+                    <span class="sr-only">Seitenleiste umschalten</span>
                 </button>
                 <div class="text-xl font-semibold">
                     <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>


### PR DESCRIPTION
## Summary
- switch sidebar toggle to burger icon
- add screen-reader-only label for sidebar toggle

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ac3154a350832b9d4762ea00f62c64