### PR TITLE
fix: verbessere Logo-Zugänglichkeit

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,7 +35,10 @@
                     <i class="fa-solid fa-table-columns"></i>
                 </button>
                 <div class="text-xl font-semibold">
-                    <a href="/"><img src="{% static 'images/noesis_logo.png' %}" alt="NEOMIND Logo" class="h-14 inline"></a>
+                    <a href="/" class="flex items-center">
+                        <img src="{% static 'images/noesis_logo.png' %}" alt="" aria-hidden="true" class="h-14">
+                        <span class="brand-name">NEOMIND</span>
+                    </a>
                 </div>
             </div>
         </div>

--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -20,6 +20,10 @@
   .badge-gray {
     @apply bg-background text-text dark:bg-background-dark dark:text-text-light;
   }
+  /* Markenname neben dem Logo */
+  .brand-name {
+    @apply ml-2;
+  }
   .alert {
     @apply p-2 rounded text-text dark:text-text-light;
   }


### PR DESCRIPTION
## Summary
- ergänze sichtbaren Markennamen neben Logo
- markiere Logo-Bild als dekorativ mit leerem Alt-Text
- ergänze CSS-Klasse für Markenname

## Testing
- `python manage.py makemigrations --check`
- `curl -Ls http://localhost:8000 | head -n 40`
- `npx -y pa11y http://localhost:8000` *(fehlt libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ac310f8cc0832b94b2ee8cec3af8df