### PR TITLE
feat: zentralisiertes Header-Styling

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -28,7 +28,7 @@
     {% block extra_head %}{% endblock %}
 </head>
 <body class="flex flex-col min-h-screen bg-background text-text dark:bg-background-dark dark:text-text-light">
-    <header class="bg-header text-text-light border-b items-center">
+    <header class="header-wrapper">
         <div class="container mx-auto p-4 flex flex-col md:flex-row md:items-center md:justify-between">
             <div class="flex items-center w-full md:w-auto space-x-4">
                 <button id="sidebar-toggle" class="text-text-light" aria-label="Seitenleiste umschalten">

--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -46,6 +46,10 @@
     @apply bg-accent text-text-light font-semibold;
   }
 
+  .header-wrapper {
+    @apply bg-header text-text-light border-b;
+  }
+
   /* Dark-Mode-Stile für den EasyMDE-Markdown-Editor */
   .dark .EasyMDEContainer .CodeMirror,
   .dark .EasyMDEContainer .CodeMirror-scroll {


### PR DESCRIPTION
## Summary
- add reusable `header-wrapper` class for unified header design
- apply `header-wrapper` to base layout

## Testing
- `python manage.py makemigrations --check`
- `pre-commit run --files theme/static_src/src/components.css templates/base.html`
- `npm --prefix theme/static_src run contrast -- base.html` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3123fb8c832b9023f1da0105abd7