### PR TITLE
feat: gemeinsame Kopfzeilen-Navigation

### DIFF
--- a/core/tests/test_navigation.py
+++ b/core/tests/test_navigation.py
@@ -1,7 +1,8 @@
-"""Tests für die Sidebar-Navigation."""
+"""Tests für die Sidebar- und Header-Navigation."""
 
 from django.contrib.auth.models import Group, User
 from django.urls import reverse
+from bs4 import BeautifulSoup
 
 from .base import NoesisTestCase
 
@@ -14,8 +15,8 @@ from core.models import (
 from ..views import get_user_tiles
 
 
-class NavigationSidebarTests(NoesisTestCase):
-    """Überprüfung der sichtbaren Bereiche, Tiles und Admin-Links."""
+class NavigationTestBase(NoesisTestCase):
+    """Basisklasse für Navigations-Tests mit gemeinsamer Vorbereitung."""
 
     @staticmethod
     def _grant_access(user: User, areas: list[Area], tiles: list[Tile]) -> None:
@@ -30,20 +31,20 @@ class NavigationSidebarTests(NoesisTestCase):
         """Legt Bereiche, Tiles und Nutzer für die Tests an."""
         self.area_work = Area.objects.create(slug="work-test", name="Arbeitsbereich")
         self.area_private = Area.objects.create(
-            slug="personal-test", name="Privatbereich"
+            slug="personal-test", name="Privatbereich",
         )
 
         self.tile_dashboard = Tile.objects.create(
-            slug="dashboard-test", name="Dashboard", url_name="home"
+            slug="dashboard-test", name="Dashboard", url_name="home",
         )
         self.tile_dashboard.areas.add(self.area_work)
         self.tile_account = Tile.objects.create(
-            slug="account-tile-test", name="Privatkachel", url_name="account"
+            slug="account-tile-test", name="Privatkachel", url_name="account",
         )
         self.tile_account.areas.add(self.area_private)
 
         self.tile_hidden = Tile.objects.create(
-            slug="hidden-test", name="Versteckt", url_name="home"
+            slug="hidden-test", name="Versteckt", url_name="home",
         )
         self.tile_hidden.areas.add(self.area_work)
 
@@ -67,6 +68,10 @@ class NavigationSidebarTests(NoesisTestCase):
 
         self.user_eve = User.objects.create_superuser("eve", "eve@example.com", "pw")
         self._grant_access(self.user_eve, [self.area_work], [self.tile_dashboard])
+
+
+class NavigationSidebarTests(NavigationTestBase):
+    """Überprüfung der sichtbaren Bereiche, Tiles und Admin-Links in der Sidebar."""
 
     def test_get_user_tiles(self) -> None:
         """Gibt die zugänglichen Bereiche und Tiles zurück."""
@@ -134,4 +139,58 @@ class NavigationSidebarTests(NoesisTestCase):
         self.assertContains(response, "System-Admin")
         self.assertContains(response, reverse("admin:auth_user_changelist"))
         self.assertContains(response, reverse("admin:auth_group_changelist"))
+
+
+class NavigationHeaderTests(NavigationTestBase):
+    """Stellt sicher, dass die Kopfzeilen-Navigation korrekt ist."""
+
+    @staticmethod
+    def _header_links(response) -> list[str]:
+        """Extrahiert die Link-Texte aus der Kopfzeilen-Navigation."""
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        return [a.get_text(strip=True) for a in soup.select("#header-nav a")]
+
+    def test_header_single_area_tiles_only(self) -> None:
+        """Bei einem Bereich wird nur das Dashboard angezeigt."""
+
+        self.client.force_login(self.user_alice)
+        response = self.client.get(reverse("account"))
+        links = self._header_links(response)
+        self.assertIn("Dashboard", links)
+        self.assertNotIn("Privatkachel", links)
+
+    def test_header_multiple_areas(self) -> None:
+        """Mehrere Bereiche zeigen alle erlaubten Tiles."""
+
+        self.client.force_login(self.user_bob)
+        response = self.client.get(reverse("account"))
+        links = self._header_links(response)
+        self.assertIn("Dashboard", links)
+        self.assertIn("Privatkachel", links)
+
+    def test_no_admin_links_for_regular_user(self) -> None:
+        """Normale Nutzer sehen keine Admin-Links."""
+
+        self.client.force_login(self.user_carol)
+        response = self.client.get(reverse("account"))
+        links = self._header_links(response)
+        self.assertNotIn("Projekt-Liste", links)
+
+    def test_project_admin_link_for_admin_group(self) -> None:
+        """Admin-Gruppenmitglieder sehen Projekt-Admin-Links."""
+
+        self.client.force_login(self.user_dave)
+        response = self.client.get(reverse("account"))
+        links = self._header_links(response)
+        self.assertIn("Projekt-Liste", links)
+
+    def test_system_admin_link_for_superuser(self) -> None:
+        """Superuser sehen System-Admin-Links."""
+
+        self.client.force_login(self.user_eve)
+        response = self.client.get(reverse("account"))
+        links = self._header_links(response)
+        self.assertIn("Projekt-Liste", links)
+        self.assertIn("Benutzer verwalten", links)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,6 +42,7 @@
                     </a>
                 </div>
             </div>
+            {% include 'partials/_header_nav.html' %}
         </div>
     </header>
 

--- a/templates/partials/_header_nav.html
+++ b/templates/partials/_header_nav.html
@@ -1,0 +1,19 @@
+<nav id="header-nav" class="mt-4 md:mt-0">
+    <ul class="flex flex-wrap items-center gap-2">
+        {% for section in user_navigation %}
+            {% for tile in section.tiles %}
+                <li>{% include 'partials/_nav_link.html' with tile=tile %}</li>
+            {% endfor %}
+        {% endfor %}
+        {% for section in admin_navigation %}
+            {% if section.tiles %}
+                {% for tile in section.tiles %}
+                    <li>{% include 'partials/_nav_link.html' with tile=tile %}</li>
+                {% endfor %}
+            {% endif %}
+            {% if section.groups %}
+                {% include 'partials/_header_nav_groups.html' with groups=section.groups %}
+            {% endif %}
+        {% endfor %}
+    </ul>
+</nav>

--- a/templates/partials/_header_nav_groups.html
+++ b/templates/partials/_header_nav_groups.html
@@ -1,0 +1,10 @@
+{% for group in groups %}
+    {% if group.tiles %}
+        {% for tile in group.tiles %}
+            <li>{% include 'partials/_nav_link.html' with tile=tile %}</li>
+        {% endfor %}
+    {% endif %}
+    {% if group.groups %}
+        {% include 'partials/_header_nav_groups.html' with groups=group.groups %}
+    {% endif %}
+{% endfor %}

--- a/templates/partials/_nav_link.html
+++ b/templates/partials/_nav_link.html
@@ -1,0 +1,3 @@
+<a href="{% url tile.url_name %}" class="{% if extra_classes %}{{ extra_classes }} {% endif %}nav-link {% if request.resolver_match.url_name == tile.url_name %}active-nav-link{% endif %}">
+    {{ tile.name }}
+</a>

--- a/templates/partials/_sidebar.html
+++ b/templates/partials/_sidebar.html
@@ -23,9 +23,7 @@
         <ul class="space-y-2">
             {% for tile in user_navigation.0.tiles %}
             <li>
-                <a href="{% url tile.url_name %}" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light {% if request.resolver_match.url_name == tile.url_name %}active-nav-link{% endif %}">
-                    {{ tile.name }}
-                </a>
+                {% include 'partials/_nav_link.html' with tile=tile extra_classes='block' %}
             </li>
             {% endfor %}
         </ul>
@@ -39,9 +37,7 @@
             <ul id="nav-u{{ forloop.counter }}" class="mt-1 pl-2 space-y-1 hidden">
                 {% for tile in section.tiles %}
                 <li>
-                    <a href="{% url tile.url_name %}" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light {% if request.resolver_match.url_name == tile.url_name %}active-nav-link{% endif %}">
-                        {{ tile.name }}
-                    </a>
+                    {% include 'partials/_nav_link.html' with tile=tile extra_classes='block' %}
                 </li>
                 {% endfor %}
             </ul>
@@ -57,9 +53,7 @@
             <ul id="nav-a{{ forloop.counter }}" class="mt-1 pl-2 space-y-1 hidden">
                 {% for tile in section.tiles %}
                 <li>
-                    <a href="{% url tile.url_name %}" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light {% if request.resolver_match.url_name == tile.url_name %}active-nav-link{% endif %}">
-                        {{ tile.name }}
-                    </a>
+                    {% include 'partials/_nav_link.html' with tile=tile extra_classes='block' %}
                 </li>
                 {% endfor %}
             </ul>

--- a/templates/partials/_sidebar_group.html
+++ b/templates/partials/_sidebar_group.html
@@ -11,9 +11,7 @@
         <ul class="space-y-1">
             {% for tile in group.tiles %}
             <li>
-                <a href="{% url tile.url_name %}" class="block px-4 py-2 rounded hover:bg-accent hover:text-text-light {% if request.resolver_match.url_name == tile.url_name %}active-nav-link{% endif %}">
-                    {{ tile.name }}
-                </a>
+                {% include 'partials/_nav_link.html' with tile=tile extra_classes='block' %}
             </li>
             {% endfor %}
         </ul>

--- a/theme/static_src/src/components.css
+++ b/theme/static_src/src/components.css
@@ -46,6 +46,9 @@
   .sidebar-accordion-btn {
     @apply w-full flex items-center justify-between px-4 py-2 font-semibold rounded hover:bg-accent hover:text-text-light;
   }
+  .nav-link {
+    @apply px-4 py-2 rounded hover:bg-accent hover:text-text-light;
+  }
   .active-nav-link {
     @apply bg-accent text-text-light font-semibold;
   }


### PR DESCRIPTION
## Summary
- add wiederverwendbares Nav-Link-Partial und Kopfzeilen-Navigation
- synchronisiere Sidebar mit neuem Partial
- ergänze nav-link Styles und Tests für verschiedene Rollen

## Testing
- `python manage.py makemigrations --check`
- `pytest --override-ini addopts="" -q core/tests/test_navigation.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac35653bc4832b849f100adecf3f91