### PR TITLE
fix: consolidate markdown editor script

### DIFF
--- a/static/js/markdown_editor.js
+++ b/static/js/markdown_editor.js
@@ -20,6 +20,10 @@ function loadEasyMDE() {
                     document.head.appendChild(link);
                 }
             }
+            if (window.customElements && customElements.get('mce-autosize-textarea')) {
+                resolve();
+                return;
+            }
             const script = document.createElement('script');
             script.src = 'https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js';
             script.onload = resolve;

--- a/templates/admin_llm_role_form.html
+++ b/templates/admin_llm_role_form.html
@@ -25,7 +25,6 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="{% static 'js/markdown_editor.js' %}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     initMarkdownEditor('roleprompt');

--- a/templates/base.html
+++ b/templates/base.html
@@ -70,6 +70,7 @@
      <script src="{% static 'js/utils.js' %}"></script>
      <script src="{% static 'js/theme_toggle.js' %}"></script>
      <script src="{% static 'js/sidebar.js' %}"></script>
+     <script src="{% static 'js/markdown_editor.js' %}"></script>
      {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/templates/edit_knowledge_description.html
+++ b/templates/edit_knowledge_description.html
@@ -10,7 +10,6 @@
 </form>
 {% endblock %}
 {% block extra_js %}
-<script src="{% static 'js/markdown_editor.js' %}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     initMarkdownEditor('description');

--- a/templates/gap_report.html
+++ b/templates/gap_report.html
@@ -17,7 +17,6 @@
 </form>
 {% endblock %}
 {% block extra_js %}
-<script src="{% static 'js/markdown_editor.js' %}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         initMarkdownEditor('text1');

--- a/templates/gutachten_edit.html
+++ b/templates/gutachten_edit.html
@@ -10,7 +10,6 @@
 {% endblock %}
 {% block extra_head %}{% endblock %}
 {% block extra_js %}
-<script src="{% static 'js/markdown_editor.js' %}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     initMarkdownEditor('gutachten');

--- a/templates/projekt_file_anlage4_review.html
+++ b/templates/projekt_file_anlage4_review.html
@@ -51,7 +51,6 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="{% static 'js/markdown_editor.js' %}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () =>
     document.querySelectorAll('textarea').forEach(el => initMarkdownEditor(el.id)));

--- a/templates/projekt_file_anlage5_review.html
+++ b/templates/projekt_file_anlage5_review.html
@@ -18,7 +18,6 @@
 </form>
 {% endblock %}
 {% block extra_js %}
-<script src="{% static 'js/markdown_editor.js' %}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const el = document.getElementById('id_sonstige');

--- a/templates/projekt_file_json_form.html
+++ b/templates/projekt_file_json_form.html
@@ -34,7 +34,6 @@
 </form>
 {% endblock %}
 {% block extra_js %}
-<script src="{% static 'js/markdown_editor.js' %}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     document.querySelectorAll('textarea').forEach(el => initMarkdownEditor(el.id));

--- a/templates/projekt_form.html
+++ b/templates/projekt_form.html
@@ -68,7 +68,6 @@
 
 {% block extra_js %}
 {{ block.super }}
-<script src="{% static 'js/markdown_editor.js' %}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const addSoftwareBtn = document.getElementById('add-software-btn');


### PR DESCRIPTION
## Summary
- load `markdown_editor.js` globally in base template to avoid duplicate includes
- guard markdown editor loader against re-injecting when `mce-autosize-textarea` is already registered
- remove redundant editor script tags from individual templates

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ac43bb9d80832b8834c9eac87e8245