### PR TITLE
fix: render raw attrs in button partial

### DIFF
--- a/templates/partials/_button.html
+++ b/templates/partials/_button.html
@@ -1,8 +1,8 @@
 {% load ui_extras %}
 {% btn_classes variant as variant_classes %}
 {% if href %}
-<a href="{{ href }}" {% if id %}id="{{ id }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-3 py-1 rounded {{ variant_classes }} {{ classes|default:'' }}">{{ label }}</a>
+<a href="{{ href }}" {% if id %}id="{{ id }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {{ attrs|default:''|safe }} class="inline-flex items-center px-3 py-1 rounded {{ variant_classes }} {{ classes|default:'' }}">{{ label }}</a>
 {% else %}
-<button type="{{ type|default:'button' }}" {% if id %}id="{{ id }}"{% endif %} {% if name %}name="{{ name }}"{% endif %} {% if formaction %}formaction="{{ formaction }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {% if disabled %}disabled{% endif %} {{ attrs|default:'' }} class="inline-flex items-center px-3 py-1 rounded {{ variant_classes }} {{ classes|default:'' }}">{{ label }}</button>
+<button type="{{ type|default:'button' }}" {% if id %}id="{{ id }}"{% endif %} {% if name %}name="{{ name }}"{% endif %} {% if formaction %}formaction="{{ formaction }}"{% endif %} {% if onclick %}onclick="{{ onclick }}"{% endif %} {% if disabled %}disabled{% endif %} {{ attrs|default:''|safe }} class="inline-flex items-center px-3 py-1 rounded {{ variant_classes }} {{ classes|default:'' }}">{{ label }}</button>
 {% endif %}
 


### PR DESCRIPTION
## Summary
- allow custom attributes like HTMX directives in button partial by marking attribute string as safe

## Testing
- `python manage.py makemigrations --check`
- `python manage.py shell <<'PY'
from django.core.management import call_command
call_command('migrate', verbosity=0)
from django.conf import settings
settings.ALLOWED_HOSTS=['testserver']
from core.models import BVProject, ProjectStatus, BVProjectFile
from django.contrib.auth import get_user_model
from django.test import Client
from django.core.files.base import ContentFile
from django.urls import reverse
User = get_user_model()
status = ProjectStatus.objects.create(name='default', ordering=1, is_default=True)
user = User.objects.create_user(username='u', password='p')
proj = BVProject.objects.create(title='Proj', status=status)
content = ContentFile('dummy', name='dummy.txt')
file = BVProjectFile.objects.create(project=proj, anlage_nr=1, upload=content)
client = Client(); client.force_login(user)
resp = client.get(reverse('projekt_file_edit_json', args=[file.pk]))
hx_url = reverse('hx_anlage1_note', args=[file.pk, 1, 'hinweis'])
resp2 = client.get(hx_url + '?edit=1')
print('page:', resp.status_code)
print('htmx:', resp2.status_code)
print(resp2.content.decode().splitlines()[0])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac4b1bc304832bb6dbd014baa822c1