### PR TITLE
fix: simplify note button attrs

### DIFF
--- a/templates/partials/anlage1_note.html
+++ b/templates/partials/anlage1_note.html
@@ -7,12 +7,16 @@
       <textarea name="text" rows="3" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
     <div class="space-x-2">
       {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-2 py-1 rounded' %}
-      {% include 'partials/_button.html' with type='button' label='Abbrechen' variant='secondary' classes='px-2 py-1 rounded' attrs='hx-get="'|add:abbrechen_url|add:'" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' %}
+      {% with 'hx-get="'|add:abbrechen_url|add:'" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' as cancel_attrs %}
+        {% include 'partials/_button.html' with type='button' label='Abbrechen' variant='secondary' classes='px-2 py-1 rounded' attrs=cancel_attrs %}
+      {% endwith %}
     </div>
   </form>
 {% else %}
   <div class="prose dark:prose-invert max-w-none">{{ text|markdownify }}</div>
   {% url 'hx_anlage1_note' anlage.pk num field as edit_url %}
-  {% include 'partials/_button.html' with type='button' label='Bearbeiten' variant='secondary' classes='mt-1 px-2 py-1 rounded' attrs='hx-get="'|add:edit_url|add:'?edit=1" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' %}
+  {% with 'hx-get="'|add:edit_url|add:'?edit=1" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' as edit_attrs %}
+    {% include 'partials/_button.html' with type='button' label='Bearbeiten' variant='secondary' classes='mt-1 px-2 py-1 rounded' attrs=edit_attrs %}
+  {% endwith %}
 {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- simplify HTMX attribute construction for Abbrechen and Bearbeiten buttons in Anlage 1 notes

## Testing
- `python manage.py makemigrations --check`
- `python manage.py shell -c "from types import SimpleNamespace; from django.template.loader import render_to_string; anlage=SimpleNamespace(pk=1); ctx={'editing':True,'anlage':anlage,'num':'1','field':'hinweis','text':'foo'}; print(render_to_string('partials/anlage1_note.html', ctx)); ctx['editing']=False; print(render_to_string('partials/anlage1_note.html', ctx))"`


------
https://chatgpt.com/codex/tasks/task_e_68ac501eb664832bafd56ce27e236f10