### PR TITLE
fix: output complete HTMX attrs for edit button

### DIFF
--- a/templates/partials/anlage1_note.html
+++ b/templates/partials/anlage1_note.html
@@ -15,8 +15,10 @@
 {% else %}
   <div class="prose dark:prose-invert max-w-none">{{ text|markdownify }}</div>
   {% url 'hx_anlage1_note' anlage.pk num field as edit_url %}
-  {% with 'hx-get="'|add:edit_url|add:'?edit=1" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' as edit_attrs %}
-    {% include 'partials/_button.html' with type='button' label='Bearbeiten' variant='secondary' classes='mt-1 px-2 py-1 rounded' attrs=edit_attrs %}
+  {% with num|stringformat:"s" as num_str %}
+    {% with 'hx-get="'|add:edit_url|add:'?edit=1"'|add:' hx-target="#note-'|add:field|add:'-'|add:num_str|add:'"'|add:' hx-swap="outerHTML"' as edit_attrs %}
+      {% include 'partials/_button.html' with type='button' label='Bearbeiten' variant='secondary' classes='mt-1 px-2 py-1 rounded' attrs=edit_attrs %}
+    {% endwith %}
   {% endwith %}
 {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- ensure Anlage 1 note edit button renders hx-get, hx-target, and hx-swap attributes correctly by building attribute string explicitly and treating numeric note index as string

## Testing
- `python manage.py makemigrations --check`
- `python manage.py shell <<'PY'
from django.template.loader import render_to_string
class Obj: pk=1
html = render_to_string('partials/anlage1_note.html', {'text':'Test','editing':False,'anlage':Obj(),'num':1,'field':'hinweis'})
print(html)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac556fe950832baa843128e0831411