### PR TITLE
fix: build cancel button attrs with num_str

### DIFF
--- a/templates/partials/anlage1_note.html
+++ b/templates/partials/anlage1_note.html
@@ -1,17 +1,19 @@
 {% load recording_extras %}
 <div id="note-{{ field }}-{{ num }}">
 {% if editing %}
-  <form hx-post="{% url 'hx_anlage1_note' anlage.pk num field %}"
-        hx-target="#note-{{ field }}-{{ num }}" hx-swap="outerHTML" class="space-y-2">
-    {% url 'hx_anlage1_note' anlage.pk num field as abbrechen_url %}
-      <textarea name="text" rows="3" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
-    <div class="space-x-2">
-      {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-2 py-1 rounded' %}
-      {% with 'hx-get="'|add:abbrechen_url|add:'" hx-target="#note-'|add:field|add:'-'|add:num|add:'" hx-swap="outerHTML"' as cancel_attrs %}
-        {% include 'partials/_button.html' with type='button' label='Abbrechen' variant='secondary' classes='px-2 py-1 rounded' attrs=cancel_attrs %}
-      {% endwith %}
-    </div>
-  </form>
+  {% with num|stringformat:"s" as num_str %}
+    <form hx-post="{% url 'hx_anlage1_note' anlage.pk num field %}"
+          hx-target="#note-{{ field }}-{{ num_str }}" hx-swap="outerHTML" class="space-y-2">
+      {% url 'hx_anlage1_note' anlage.pk num field as abbrechen_url %}
+        <textarea name="text" rows="3" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
+      <div class="space-x-2">
+        {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-2 py-1 rounded' %}
+        {% with 'hx-get="'|add:abbrechen_url|add:'"'|add:' hx-target="#note-'|add:field|add:'-'|add:num_str|add:'"'|add:' hx-swap="outerHTML"' as cancel_attrs %}
+          {% include 'partials/_button.html' with type='button' label='Abbrechen' variant='secondary' classes='px-2 py-1 rounded' attrs=cancel_attrs %}
+        {% endwith %}
+      </div>
+    </form>
+  {% endwith %}
 {% else %}
   <div class="prose dark:prose-invert max-w-none">{{ text|markdownify }}</div>
   {% url 'hx_anlage1_note' anlage.pk num field as edit_url %}


### PR DESCRIPTION
## Summary
- stringify `num` in anlage note edit form and use it for HTMX targets
- build cancel button attrs using `num_str` to avoid stray quotes

## Testing
- `python manage.py makemigrations --check`
- render partial with `editing=True` and confirm cancel button HTMX attrs

------
https://chatgpt.com/codex/tasks/task_e_68ac6ab16360832b8acd9384b2bfee80