### PR TITLE
fix: vereinheitlichte Farben für Gap-Infos

### DIFF
--- a/templates/admin_anlage1.html
+++ b/templates/admin_anlage1.html
@@ -33,18 +33,18 @@
                     <input type="checkbox" name="delete{{ q.id }}">
                 </td>
                 <td class="py-1">
-                      <textarea name="text{{ q.id }}" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ q.text }}</textarea>
+                      <textarea name="text{{ q.id }}" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ q.text }}</textarea>
                 </td>
             </tr>
             <tr class="border-b align-top text-sm">
                 <td colspan="4" class="py-1">
                     {% for v in q.variants.all %}
                         <div class="flex items-center mb-1">
-                              <textarea name="variant{{ v.id }}" rows="1" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 flex-1 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ v.text }}</textarea>
+                              <textarea name="variant{{ v.id }}" rows="1" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 flex-1 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ v.text }}</textarea>
                             <label class="ml-2 text-sm"><input type="checkbox" name="delvar{{ v.id }}"> löschen</label>
                         </div>
                     {% endfor %}
-                      <textarea name="new_variant{{ q.id }}" rows="1" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" placeholder="Neue Variante"></textarea>
+                      <textarea name="new_variant{{ q.id }}" rows="1" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" placeholder="Neue Variante"></textarea>
                 </td>
             </tr>
         {% endfor %}
@@ -58,7 +58,7 @@
             </td>
             <td class="py-1 text-center"></td>
             <td class="py-1">
-                  <textarea name="new_text" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800"></textarea>
+                  <textarea name="new_text" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800"></textarea>
             </td>
         </tr>
         </tbody>

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -55,7 +55,7 @@
                         </label>
                 </td>
                 <td class="py-1">
-                          <textarea name="text" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ p.text }}</textarea>
+                          <textarea name="text" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ p.text }}</textarea>
                         <button name="action" value="save" class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>
@@ -78,7 +78,7 @@
                     <form method="post" class="space-y-2">
                         {% csrf_token %}
                         <input type="hidden" name="action" value="save_a4_config">
-                          <textarea name="prompt_template" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ a4_config.prompt_template }}</textarea>
+                          <textarea name="prompt_template" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ a4_config.prompt_template }}</textarea>
                         <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>
@@ -90,7 +90,7 @@
                         {% csrf_token %}
                         <input type="hidden" name="action" value="save_a4_parser_prompts">
                         <input type="hidden" name="field" value="prompt_plausibility">
-                          <textarea name="prompt_text" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ a4_parser.prompt_plausibility }}</textarea>
+                          <textarea name="prompt_text" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ a4_parser.prompt_plausibility }}</textarea>
                         <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
                     </form>
                 </td>

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -44,7 +44,7 @@
         {% if a.analysis_json %}
         <tr class="border-b">
             <td colspan="3">
-                <div class="prose dark:prose-invert max-w-none bg-muted p-2 rounded">
+                <div class="prose dark:prose-invert max-w-none bg-background dark:bg-background-dark text-text dark:text-text-light border border-gray-300 dark:border-gray-600 p-2 rounded">
                     {{ a.analysis_json|tojson|markdownify }}
                 </div>
                 <div class="mt-1 space-x-2">

--- a/templates/edit_ki_justification.html
+++ b/templates/edit_ki_justification.html
@@ -4,7 +4,7 @@
 <h1 class="text-2xl font-semibold mb-4">KI-Begründung bearbeiten</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
-      <textarea name="ki_begruendung" rows="5" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ ki_begruendung }}</textarea>
+      <textarea name="ki_begruendung" rows="5" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ ki_begruendung }}</textarea>
     {% if object_type == 'function' %}
     <input type="hidden" name="function" value="{{ object.id }}">
     {% else %}

--- a/templates/gap_report.html
+++ b/templates/gap_report.html
@@ -3,7 +3,7 @@
 {% block extra_head %}{% endblock %}
 {% block title %}GAP-Bericht{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">GAP-Bericht für Fachbereich</h1>
+<h1 class="text-2xl font-semibold mb-4 text-text dark:text-text-light">GAP-Bericht für Fachbereich</h1>
 
 <form method="post" class="space-y-4 inline-block mr-2">
     {% csrf_token %}

--- a/templates/partials/anlage1_note.html
+++ b/templates/partials/anlage1_note.html
@@ -5,7 +5,7 @@
     <form hx-post="{% url 'hx_anlage1_note' anlage.pk num field %}"
           hx-target="#note-{{ field }}-{{ num_str }}" hx-swap="outerHTML" class="space-y-2">
       {% url 'hx_anlage1_note' anlage.pk num field as abbrechen_url %}
-        <textarea name="text" rows="3" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
+        <textarea name="text" rows="3" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
       <div class="space-x-2">
         {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='px-2 py-1 rounded' %}
         {% with 'hx-get="'|add:abbrechen_url|add:'"'|add:' hx-target="#note-'|add:field|add:'-'|add:num_str|add:'"'|add:' hx-swap="outerHTML"' as cancel_attrs %}

--- a/templates/partials/markdown_editor.html
+++ b/templates/partials/markdown_editor.html
@@ -3,8 +3,8 @@
   {% if label %}
   <label for="{{ id_prefix }}-textarea" class="font-semibold">{{ label }}</label>
   {% endif %}
-  <div id="{{ id_prefix }}-view" class="prose dark:prose-invert max-w-none bg-muted p-2 rounded">{{ text|markdownify }}</div>
-    <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
+  <div id="{{ id_prefix }}-view" class="prose dark:prose-invert max-w-none bg-background dark:bg-background-dark text-text dark:text-text-light border border-gray-300 dark:border-gray-600 p-2 rounded">{{ text|markdownify }}</div>
+    <textarea id="{{ id_prefix }}-textarea" name="{{ name }}" rows="10" class="hidden w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ text }}</textarea>
   <div class="flex space-x-2">
     {% include 'partials/_button.html' with type='button' id=id_prefix|add:'-edit' label='Bearbeiten' variant='primary' %}
     {% include 'partials/_button.html' with type='submit' id=id_prefix|add:'-save' label='Speichern' variant='primary' classes='hidden' %}

--- a/templates/partials/supervision_row_content.html
+++ b/templates/partials/supervision_row_content.html
@@ -33,7 +33,7 @@
       {% endfor %}
     </div>
     <form hx-post="{% url 'hx_supervision_save_notes' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="space-y-2">
-        <textarea name="notes" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ row.notes }}</textarea>
+        <textarea name="notes" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded w-full p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ row.notes }}</textarea>
       <div class="space-x-2">
         <button type="submit" class="bg-accent text-text px-2 py-1 rounded">Speichern</button>
         <button type="button"

--- a/templates/projekt_cockpit.html
+++ b/templates/projekt_cockpit.html
@@ -1,4 +1,4 @@
-<div class="bg-muted p-4 rounded">
+<div class="bg-background dark:bg-background-dark text-text dark:text-text-light border border-gray-300 dark:border-gray-600 p-4 rounded">
   <h3 class="font-semibold mb-2">Projektinfo</h3>
   <p><strong>Erstellt am:</strong> {{ projekt.created_at|date:"d.m.Y" }}</p>
   <p class="mt-1"><strong>Software:</strong> {{ projekt.software_string }}</p>

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -88,7 +88,7 @@ function renderLLM(data){
    sec.innerHTML=`<button id="run" class="bg-success text-background px-4 py-2 rounded">LLM-Check starten</button>`;
  }else if(data.ist_llm_geprueft && !data.llm_validated){
     sec.innerHTML=`<div class="text-error mb-2">LLM-Check unvollständig oder technisch fehlerhaft.</div>
-    <textarea id="edit" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 mb-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">${data.llm_initial_output||''}</textarea>
+    <textarea id="edit" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded w-full p-2 mb-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">${data.llm_initial_output||''}</textarea>
     <input id="context" type="text" placeholder="Weiterer Kontext" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 mb-2 hidden focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">
     <div class="space-x-2">
      <button id="edit-btn" class="bg-primary text-background px-4 py-2 rounded">Antwort bearbeiten & erneut prüfen</button>
@@ -96,7 +96,7 @@ function renderLLM(data){
    </div>`;
  }else if(data.ist_llm_geprueft && data.llm_validated){
   sec.innerHTML=`<button id="toggle" class="bg-success text-background px-4 py-2 rounded mb-2">Antwort ein-/ausblenden</button>
-  <div id="output" class="prose dark:prose-invert max-w-none bg-muted p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
+  <div id="output" class="prose dark:prose-invert max-w-none bg-background dark:bg-background-dark text-text dark:text-text-light border border-gray-300 dark:border-gray-600 p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
  }
  if(data.llm_initial_output){
   sec.innerHTML += `<button id="recheck" class="bg-primary text-background px-4 py-2 rounded mt-2">Erneut prüfen</button>`;

--- a/templates/projekt_gutachten_form.html
+++ b/templates/projekt_gutachten_form.html
@@ -4,7 +4,7 @@
 <h1 class="text-2xl font-semibold mb-4">Gutachten für {{ projekt.title }}</h1>
 <form method="post" class="space-y-4">
     {% csrf_token %}
-      <textarea name="prompt" rows="15" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ prompt }}</textarea>
+      <textarea name="prompt" rows="15" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ prompt }}</textarea>
     <div>
         <label for="model_category" class="font-semibold">LLM-Modell:</label>
         {% for key, data in categories.items %}

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -12,7 +12,7 @@
         <button type="submit" class="bg-error text-background px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
       </form>
     </h2>
-    <pre class="whitespace-pre-wrap border p-2 bg-muted">{{ file.manual_analysis_json|default:file.analysis_json|tojson }}</pre>
+    <pre class="whitespace-pre-wrap border border-gray-300 dark:border-gray-600 p-2 bg-background dark:bg-background-dark text-text dark:text-text-light">{{ file.manual_analysis_json|default:file.analysis_json|tojson }}</pre>
   </div>
   {% if parent %}
   <div>
@@ -23,7 +23,7 @@
         <button type="submit" class="bg-error text-background px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
       </form>
     </h2>
-    <pre class="whitespace-pre-wrap border p-2 bg-muted">{{ parent.manual_analysis_json|default:parent.analysis_json|tojson }}</pre>
+    <pre class="whitespace-pre-wrap border border-gray-300 dark:border-gray-600 p-2 bg-background dark:bg-background-dark text-text dark:text-text-light">{{ parent.manual_analysis_json|default:parent.analysis_json|tojson }}</pre>
   </div>
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- align Gap report info blocks with global theme colors
- adjust textarea color scheme for consistent light/dark appearance
- retain borders for clear separation from surrounding content

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ac6e4c77a4832bb79251085446a80f