### PR TITLE
feat: erweitere GAP-Zusammenfassung um KI-Begründungen

### DIFF
--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -4714,7 +4714,9 @@ class GapReportTests(NoesisTestCase):
         with patch("core.llm_tasks.query_llm", return_value="T2") as mock_q:
             text = summarize_anlage2_gaps(self.projekt)
             prompt_sent = mock_q.call_args[0][0]
-            self.assertIn("- **Anmelden**", prompt_sent.text)
+            self.assertIn("### Anmelden", prompt_sent.text)
+            self.assertIn("- KI-Begründung:", prompt_sent.text)
+            self.assertNotIn("Prüferkommentar", prompt_sent.text)
             self.assertNotIn("{gap_list}", prompt_sent.text)
             self.assertNotIn("{funktionen}", prompt_sent.text)
         self.assertEqual(text, "T2")


### PR DESCRIPTION
## Summary
- include KI reasoning from latest `FunktionsErgebnis` in `summarize_anlage2_gaps`
- format GAP list as markdown blocks with KI-Begründung and external GAP summary
- exclude internal GAP notes from the Anlage-2 report and adjust tests

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68acba9b220c832ba03d63d33eeb62ce