### PR TITLE
feat: add breadcrumb navigation

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1301,9 +1301,22 @@ def talkdiary_detail(request, pk):
         if md_path.exists():
             md_text = md_path.read_text(encoding="utf-8")
 
+    area_slug = getattr(rec.bereich, "slug", "")
+    if area_slug == "work":
+        list_url = reverse("talkdiary_work")
+    else:
+        list_url = reverse("talkdiary_personal")
+
+    filename = Path(rec.audio_file.name).name
+    breadcrumbs = [
+        {"url": list_url, "label": "TalkDiary"},
+        {"label": filename},
+    ]
+
     context = {
         "recording": rec,
         "transcript_text": md_text,
+        "breadcrumbs": breadcrumbs,
     }
     return render(request, "talkdiary_detail.html", context)
 
@@ -3061,6 +3074,11 @@ def projekt_detail(request, pk):
 
     can_gap_report = has_any_gap(projekt)
 
+    breadcrumbs = [
+        {"url": reverse("projekt_list"), "label": "Projekte"},
+        {"label": projekt.title},
+    ]
+
     context = {
         "projekt": projekt,
         "cockpit": cockpit_ctx,
@@ -3078,6 +3096,7 @@ def projekt_detail(request, pk):
         "software_list": software_list,
         "activities": activities,
         "can_gap_report": can_gap_report,
+        "breadcrumbs": breadcrumbs,
     }
     return render(request, "projekt_detail.html", context)
 
@@ -5841,11 +5860,25 @@ def justification_detail_edit(request, file_id, function_key):
         form = JustificationForm(initial={"justification": initial_text})
 
     justification_html = markdownify(initial_text)
+    breadcrumbs = [
+        {"url": reverse("projekt_list"), "label": "Projekte"},
+        {
+            "url": reverse("projekt_detail", args=[anlage.project.pk]),
+            "label": anlage.project.title,
+        },
+        {
+            "url": reverse("projekt_file_edit_json", args=[anlage.pk]),
+            "label": f"Anlage {anlage.anlage_nr}",
+        },
+        {"label": function_key},
+    ]
+
     context = {
         "project_file": anlage,
         "function_name": function_key,
         "form": form,
         "justification_html": justification_html,
+        "breadcrumbs": breadcrumbs,
     }
     return render(request, "justification_detail.html", context)
 
@@ -5908,11 +5941,25 @@ def ki_involvement_detail_edit(request, file_id, function_key):
         form = JustificationForm(initial={"justification": initial_text})
 
     involvement_html = markdownify(initial_text)
+    breadcrumbs = [
+        {"url": reverse("projekt_list"), "label": "Projekte"},
+        {
+            "url": reverse("projekt_detail", args=[anlage.project.pk]),
+            "label": anlage.project.title,
+        },
+        {
+            "url": reverse("projekt_file_edit_json", args=[anlage.pk]),
+            "label": f"Anlage {anlage.anlage_nr}",
+        },
+        {"label": function_key},
+    ]
+
     context = {
         "project_file": anlage,
         "function_name": function_key,
         "form": form,
         "involvement_html": involvement_html,
+        "breadcrumbs": breadcrumbs,
     }
     return render(request, "involvement_detail.html", context)
 

--- a/templates/involvement_detail.html
+++ b/templates/involvement_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}KI-Beteiligung{% endblock %}
 {% block content %}
+{% include 'partials/_breadcrumbs.html' %}
 <h3 class="text-xl font-semibold mb-4">Begründung zur KI-Beteiligung: {{ function_name }}</h3>
 <div class="mb-4 p-2 border rounded bg-gray-50">
     {{ involvement_html|safe }}

--- a/templates/justification_detail.html
+++ b/templates/justification_detail.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}Begründung{% endblock %}
 {% block content %}
+{% include 'partials/_breadcrumbs.html' %}
 <h3 class="text-xl font-semibold mb-4">Begründung für: {{ function_name }}</h3>
 <div class="mb-4 p-2 border rounded bg-gray-50">
     {{ justification_html|safe }}

--- a/templates/partials/_breadcrumbs.html
+++ b/templates/partials/_breadcrumbs.html
@@ -1,0 +1,18 @@
+{% if breadcrumbs %}
+<nav class="mb-4 text-sm" aria-label="Breadcrumb">
+  <ol class="flex text-muted">
+    {% for crumb in breadcrumbs %}
+      <li class="flex items-center">
+        {% if crumb.url %}
+          <a href="{{ crumb.url }}" class="text-primary hover:underline">{{ crumb.label }}</a>
+        {% else %}
+          <span class="text-foreground">{{ crumb.label }}</span>
+        {% endif %}
+        {% if not forloop.last %}
+          <span class="mx-2 text-muted-foreground">/</span>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ol>
+</nav>
+{% endif %}

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -3,6 +3,7 @@
 {% load recording_extras %}
 {% block title %}Projekt {{ projekt.title }}{% endblock %}
 {% block content %}
+{% include 'partials/_breadcrumbs.html' %}
 <h1 class="text-2xl font-semibold mb-4">{{ projekt.title }}
 {% if is_admin %}
 {% url 'admin_projects' as admin_url %}

--- a/templates/talkdiary_detail.html
+++ b/templates/talkdiary_detail.html
@@ -2,6 +2,7 @@
 {% load recording_extras %}
 {% block title %}Transcript{% endblock %}
 {% block content %}
+{% include 'partials/_breadcrumbs.html' %}
 <h1 class="text-2xl font-semibold mb-4">{{ recording.audio_file.name|basename }}</h1>
 <p class="text-sm text-muted mb-4">{{ recording.created_at|date:'d.m.Y H:i' }} - {{ recording.bereich }}</p>
 <audio controls src="{{ recording.audio_file.url }}" class="mb-4 w-full"></audio>


### PR DESCRIPTION
## Summary
- add reusable breadcrumbs partial
- generate breadcrumb lists in detail views and forward to templates
- include breadcrumb partial in project and file detail templates

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ace1ffb85c832bab8ae2624d06a4e1