### PR TITLE
feat: integrate Langfuse tracing for LLM utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ markdown
 #git+https://github.com/openai/whisper.git
 openai
 google-generativeai
+langfuse
 python-dotenv
 python-docx
 Pillow


### PR DESCRIPTION
## Summary
- add langfuse dependency
- initialize Langfuse client and record traces for LLM calls

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ad65201964832bbcc814fc495ac3c6