### PR TITLE
fix: handle verhandlungsfaehig from Anlage 3 parser

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3542,19 +3542,14 @@ def _save_project_file(
 
             meta = parse_anlage3(obj)
             if meta:
+                verhandlungsfaehig = meta.pop("verhandlungsfaehig", False)
                 Anlage3Metadata.objects.update_or_create(
                     project_file=obj, defaults=meta
                 )
-        except Exception:
-            logger.exception("Fehler beim Anlage3 Parser")
-
-        try:
-            pages = get_docx_page_count(Path(obj.upload.path))
-            if pages == 1:
-                obj.verhandlungsfaehig = True
+                obj.verhandlungsfaehig = verhandlungsfaehig
                 obj.save(update_fields=["verhandlungsfaehig"])
         except Exception:
-            logger.exception("Fehler beim Seitenzählen")
+            logger.exception("Fehler beim Anlage3 Parser")
 
     return obj
 


### PR DESCRIPTION
## Summary
- set project file `verhandlungsfaehig` from parsed Anlage 3 metadata

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ada69a1c7c832bb4108badd0a9d020