### PR TITLE
feat: add configurable max output tokens for LLM calls

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -691,6 +691,7 @@ def generate_gutachten(
             {},
             model_type="gutachten",
             project_prompt=projekt.project_prompt if prompt_obj.use_project_context else None,
+            max_output_tokens=8192,
         )
     doc = Document()
     for line in text.splitlines():
@@ -757,6 +758,7 @@ def worker_generate_gutachten(
             project_prompt=projekt.project_prompt
             if prompt_obj.use_project_context
             else None,
+            max_output_tokens=8192,
         )
     except RuntimeError as exc:
         logger.error(

--- a/noesis/settings.py
+++ b/noesis/settings.py
@@ -244,6 +244,8 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
 OPENAI_LLM_MODEL = "gpt-4o"
 GOOGLE_VISION_MODEL = "gemini-pro-vision"
 OPENAI_VISION_MODEL = OPENAI_LLM_MODEL
+# Maximale Tokenzahl für LLM-Antworten
+LLM_MAX_OUTPUT_TOKENS = int(os.environ.get("LLM_MAX_OUTPUT_TOKENS", "2048"))
 
 # API-Schlüssel für Langfuse
 LANGFUSE_PUBLIC_KEY = os.environ.get("LANGFUSE_PUBLIC_KEY", "")


### PR DESCRIPTION
## Summary
- add optional `max_output_tokens` to `query_llm` and `call_gemini_api`
- configure default limit via settings and log usage
- allow gutachten generation to request larger outputs

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68adb72829b8832bbed6a2a12bade039