### PR TITLE
docs: mention Langfuse SDK 3.3.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Backend: Django 5.x
 Asynchrone Tasks: django-q2 wird für alle langlaufenden Prozesse (LLM-Anfragen, Analysen) verwendet. Dies erfordert einen laufenden qcluster-Prozess.
 Dokumenten-Export: Die Konvertierung von Markdown zu .docx erfordert die System-Abhängigkeit pandoc.
 Datenbank: SQLite für die Entwicklung, für den Produktivbetrieb ist PostgreSQL empfohlen.
+LLM-Logging: Langfuse SDK 3.3.1.
 
 
 ## Projektstruktur

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NOESIS
 
 Dieses Projekt ist eine Django-Anwendung als persönlicher und personalisierter Agent.
+Die LLM-Integration verwendet das Langfuse SDK (Version 3.3.1).
 ## Installation
 
 1. Installiere Python 3.11 und `pip`.


### PR DESCRIPTION
## Summary
- note Langfuse SDK 3.3.1 in AGENTS guidelines
- document Langfuse SDK 3.3.1 usage in README

## Testing
- `python manage.py makemigrations --check`
- `pre-commit run --files AGENTS.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_68ae16f8d6e0832b99490aa18ae2043b