### PR TITLE
Log Langfuse config on worker start

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -1,5 +1,8 @@
-from django.apps import AppConfig
 import logging
+import sys
+
+from django.apps import AppConfig
+from django.conf import settings
 
 
 logger = logging.getLogger(__name__)
@@ -12,4 +15,13 @@ class CoreConfig(AppConfig):
     def ready(self):
         """Registriert Signal-Handler."""
         from . import signals  # noqa: F401
+
+        # Beim Start des qcluster-Workers einmal die Langfuse-Konfiguration ausgeben.
+        if "qcluster" in sys.argv:
+            logger.info(
+                "Langfuse cfg host=%r pk_len=%s sk_len=%s",
+                getattr(settings, "LANGFUSE_HOST", None),
+                len(getattr(settings, "LANGFUSE_PUBLIC_KEY", "") or ""),
+                len(getattr(settings, "LANGFUSE_SECRET_KEY", "") or ""),
+            )
 


### PR DESCRIPTION
## Summary
- log Langfuse host and key lengths when qcluster worker starts

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68ae205fc514832b884ac226d89ea57e