### PR TITLE
fix: use form for knowledge entry deletion

### DIFF
--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -19,7 +19,10 @@
                     {% if row.entry and row.entry.is_known_by_llm is True %}
                         <a href="{% url 'edit_knowledge_description' row.entry.id %}" class="btn btn-primary btn-sm">Bearbeiten</a>
                         <a href="{% url 'download_knowledge_as_word' row.entry.id %}" class="btn btn-secondary btn-sm">Export</a>
-                        <a href="{% url 'delete_knowledge_entry' row.entry.id %}" class="btn btn-error btn-sm">Löschen</a>
+                        <form method="post" action="{% url 'delete_knowledge_entry' row.entry.id %}" class="inline">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-error btn-sm" onclick="return confirm('Eintrag wirklich löschen?');">Löschen</button>
+                        </form>
                     {% elif row.entry and row.entry.is_known_by_llm is False %}
                         <button type="button" class="btn btn-warning btn-sm retry-check-btn" data-knowledge-id="{{ row.entry.id }}">Erneut prüfen</button>
                     {% else %}


### PR DESCRIPTION
## Summary
- switch software entry deletion from link to POST form with CSRF protection
- add optional confirmation prompt for deletion

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68aea64a9318832bbac0f8722a644146