### PR TITLE
feat: add breadcrumb support

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -6,6 +6,7 @@
 {% block extra_head %}{% endblock %}
 
 {% block content %}
+{% include 'partials/_breadcrumbs.html' %}
 <div class="max-w-screen-2xl mx-auto">
     <section class="flex-1 p-4">
         <div class="flex flex-col md:flex-row gap-6">

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+{% include 'partials/_breadcrumbs.html' %}
 <div class="max-w-screen-2xl mx-auto">
     <section class="p-4">
         {% block admin_content %}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,6 +60,7 @@
                 {% endfor %}
             </div>
             {% endif %}
+            {% include 'partials/_breadcrumbs.html' %}
             {% block content %}{% endblock %}
         </main>
     </div>


### PR DESCRIPTION
## Summary
- show breadcrumb trail across base and admin templates
- provide helper to build breadcrumb lists
- add breadcrumbs context to admin views

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68aebb0aa9ec832b8cd04a4d18bb0585