### PR TITLE
Remove duplicate breadcrumb navigation in admin template

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -6,7 +6,6 @@
 {% block extra_head %}{% endblock %}
 
 {% block content %}
-{% include 'partials/_breadcrumbs.html' %}
 <div class="max-w-screen-2xl mx-auto">
     <section class="flex-1 p-4">
         <div class="flex flex-col md:flex-row gap-6">


### PR DESCRIPTION
## Summary
- remove duplicate breadcrumb include from admin base_site.html

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68aecc0fb420832bbdc93be28a5cd3b9