### PR TITLE
feat: centralize LLM placeholder context

### DIFF
--- a/core/prompt_context.py
+++ b/core/prompt_context.py
@@ -1,0 +1,28 @@
+"""Registry für Platzhalter in LLM-Prompts."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from .models import BVProject
+
+
+PLACEHOLDER_BUILDERS: dict[str, Callable[[BVProject], str]] = {
+    "project_name": lambda p: p.title,
+    "software_name": lambda p: p.software_string,
+}
+
+
+def build_prompt_context(project: BVProject | None = None, **extra: str) -> dict[str, str]:
+    """Erzeuge ein Kontext-Dictionary für LLM-Prompts."""
+
+    ctx = {key: fn(project) for key, fn in PLACEHOLDER_BUILDERS.items() if project}
+    ctx.update(extra)
+    return ctx
+
+
+def available_placeholders() -> list[str]:
+    """Liste der verfügbaren Platzhalter."""
+
+    return sorted(PLACEHOLDER_BUILDERS.keys())
+

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -114,6 +114,7 @@ from django.test import override_settings
 import json
 from .base import NoesisTestCase
 from ..initial_data_constants import INITIAL_PROJECT_STATUSES
+from ..prompt_context import build_prompt_context, available_placeholders
 
 
 DEFAULT_STATUS_KEY = next(
@@ -217,6 +218,17 @@ def seed_test_data(*, skip_prompts: bool = False) -> None:
 
     for idx, text in enumerate(ANLAGE1_QUESTIONS, start=1):
         Prompt.objects.update_or_create(name=f"anlage1_q{idx}", defaults={"text": text})
+
+
+def test_build_prompt_context_keys(db) -> None:
+    """Prüft, dass ``build_prompt_context`` alle Platzhalter füllt."""
+
+    projekt = create_project(title="Demo", software=["Soft"])
+    ctx = build_prompt_context(projekt)
+    for key in available_placeholders():
+        assert key in ctx
+    assert ctx["project_name"] == "Demo"
+    assert ctx["software_name"] == "Soft"
 
     Prompt.objects.update_or_create(
         name="check_anlage3_vision",

--- a/core/views.py
+++ b/core/views.py
@@ -115,6 +115,7 @@ from .models import (
 )
 from .docx_utils import extract_text, get_docx_page_count
 from .llm_utils import query_llm
+from .prompt_context import build_prompt_context
 from .workflow import set_project_status
 from .reporting import generate_gap_analysis, generate_management_summary
 from .llm_tasks import (
@@ -4351,7 +4352,8 @@ def _run_llm_check(
     )
 
     logger.debug("Starte LLM-Check für %s", name)
-    reply = query_llm(prompt_obj, {}, project_prompt=project_prompt)
+    ctx = build_prompt_context()
+    reply = query_llm(prompt_obj, ctx, project_prompt=project_prompt)
     valid, _ = _validate_llm_output(reply)
     logger.debug("LLM-Antwort für %s: %s", name, reply[:100])
     return reply, valid


### PR DESCRIPTION
## Summary
- add registry and helper for LLM prompt placeholders
- refactor LLM calls to build prompt context automatically
- cover placeholder context with unit test

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68aed03552b8832ba988fa288a088336