### PR TITLE
fix: entferne veralteten Text-only Modus

### DIFF
--- a/core/parser_manager.py
+++ b/core/parser_manager.py
@@ -40,10 +40,9 @@ class ParserManager:
 
         if mode == "table_only":
             name = "table"
-        elif mode == "exact_only":
+        elif mode in ("exact_only", "text_only"):
+            # Fallback für veraltete Einträge mit "text_only"
             name = "exact"
-        elif mode == "text_only":
-            name = "text"
         else:  # auto or unbekannt
             name = order[0]
 


### PR DESCRIPTION
## Zusammenfassung
- entferne `text_only`-Block im ParserManager
- leite alte Einträge mit `text_only` auf `exact`-Parser um

## Tests
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68aedf49aaa0832bb328bfabd26461be