### PR TITLE
fix: aktualisiere Icons in Anlage-2-Review

### DIFF
--- a/templates/partials/review_cell.html
+++ b/templates/partials/review_cell.html
@@ -33,6 +33,8 @@
         <i class="fa-solid fa-user"></i>
         {% elif source == 'KI-Check' %}
         <i class="fa-solid fa-robot"></i>
+        {% elif field_name == 'ki_beteiligung' %}
+        <i class="fa-solid fa-user-gear"></i>
         {% else %}
         <i class="fa-solid fa-file-alt"></i>
         {% endif %}

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -23,17 +23,6 @@
         <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-muted hover:bg-muted">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% endif %}
-        {% if row.source_text and row.source_text != 'N/A' %}
-        <span class="text-muted small source-indicator" title="{{ row.source_text }}">
-            {% if row.source_text == 'Manuell' %}
-            <i class="fa-solid fa-user"></i>
-            {% else %}
-            <i class="fa-solid fa-file-alt"></i>
-            {% endif %}
-        </span>
-        {% elif row.source_text == 'N/A' %}
-        <span class="text-muted small source-indicator"><i class="fa-solid fa-question"></i></span>
-        {% endif %}
     </td>
     {% for field in fields %}
     {% with f=row.form_fields|get_item:field %}

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -77,17 +77,6 @@
                     </a>
                     {% endif %}
                     {% endif %}
-                    {% if row.source_text and row.source_text != 'N/A' %}
-                    <span class="text-muted small source-indicator" data-popover-content="{{ row.source_text }}">
-                        {% if row.source_text == 'Manuell' %}
-                        <i class="fa-solid fa-user"></i>
-                        {% else %}
-                        <i class="fa-solid fa-file-alt"></i>
-                        {% endif %}
-                    </span>
-                    {% elif row.source_text == 'N/A' %}
-                    <span class="text-muted small source-indicator"><i class="fa-solid fa-question"></i></span>
-                    {% endif %}
                 </td>
                 {% for field in fields %}
                 {% with f=row.form_fields|get_item:field %}


### PR DESCRIPTION
## Summary
- remove source indicators from function column on Anlage-2 review
- use combined user/gear icon for KI-Beteiligung status

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68aee1a57b00832bb77a85a895f5d701