### PR TITLE
refactor: unify button styling via template tag

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n static %}
+{% load i18n static ui_extras %}
 
 {% block title %}{{ title }} | NEOMIND Admin{% endblock %}
 
@@ -13,7 +13,7 @@
         <h2 class="text-xl font-bold mb-4">Admin-Navigation</h2>
         <nav class="space-y-4 text-sm">
             <div>
-                <a href="/projects-admin/" class="flex items-center px-3 py-2 rounded bg-accent text-background font-semibold">
+                <a href="/projects-admin/" class="flex items-center px-3 py-2 rounded font-semibold {% btn_classes 'primary' %}">
                     <i class="fa-solid fa-project-diagram fa-fw mr-2"></i>
                     Projekt-Admin
                 </a>
@@ -25,15 +25,15 @@
                     <i data-accordion-icon class="fa-solid fa-chevron-down ml-2 transition-transform duration-300 {% if open_ki in 'admin_llm_roles admin_prompts admin_models' %}rotate-180{% endif %}"></i>
                 </h3>
                 <div class="accordion-content pl-2 space-y-1 {% if open_ki in 'admin_llm_roles admin_prompts admin_models' %}block{% else %}hidden{% endif %}">
-                    <a href="{% url 'admin_llm_roles' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_llm_roles' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_llm_roles' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_llm_roles' %}{% btn_classes 'primary' %} font-semibold{% endif %}">
                         <i class="fa-solid fa-user-gear fa-fw mr-2"></i>
                         LLM-Rollen
                     </a>
-                    <a href="{% url 'admin_prompts' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_prompts' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_prompts' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_prompts' %}{% btn_classes 'primary' %} font-semibold{% endif %}">
                         <i class="fa-solid fa-pencil-alt fa-fw mr-2"></i>
                         Prompts
                     </a>
-                    <a href="{% url 'admin_models' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_models' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_models' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_models' %}{% btn_classes 'primary' %} font-semibold{% endif %}">
                         <i class="fa-solid fa-robot fa-fw mr-2"></i>
                         LLM-Modelle
                     </a>
@@ -47,19 +47,19 @@
                     <i data-accordion-icon class="fa-solid fa-chevron-down ml-2 transition-transform duration-300 {% if open_sys in 'admin_user_list auth_group_changelist' %}rotate-180{% endif %}"></i>
                 </h3>
                 <div class="accordion-content pl-2 space-y-1 {% if open_sys in 'admin_user_list auth_group_changelist' %}block{% else %}hidden{% endif %}">
-                    <a href="{% url 'admin_user_list' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_user_list' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_user_list' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_user_list' %}{% btn_classes 'primary' %} font-semibold{% endif %}">
                         <i class="fa-solid fa-users fa-fw mr-2"></i>
                         Benutzer verwalten
                     </a>
-                    <a href="{% url 'admin:auth_group_changelist' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'auth_group_changelist' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin:auth_group_changelist' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'auth_group_changelist' %}{% btn_classes 'primary' %} font-semibold{% endif %}">
                         <i class="fa-solid fa-user-shield fa-fw mr-2"></i>
                         Gruppen
                     </a>
-                    <a href="{% url 'admin_role_editor' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_role_editor' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'admin_role_editor' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'admin_role_editor' %}{% btn_classes 'primary' %} font-semibold{% endif %}">
                         <i class="fa-solid fa-check-square fa-fw mr-2"></i>
                         Rollen &amp; Rechte
                     </a>
-                    <a href="{% url 'config_transfer' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'config_transfer' %}bg-accent text-background font-semibold{% endif %}">
+                    <a href="{% url 'config_transfer' %}" class="flex items-center px-3 py-2 rounded text-accent-dark dark:text-accent-light hover:bg-accent-light {% if request.resolver_match.url_name == 'config_transfer' %}{% btn_classes 'primary' %} font-semibold{% endif %}">
                         <i class="fa-solid fa-exchange-alt fa-fw mr-2"></i>
                         Konfigurationen übertragen
                     </a>

--- a/templates/admin/config_transfer.html
+++ b/templates/admin/config_transfer.html
@@ -1,14 +1,15 @@
 {% extends "admin/base_site.html" %}
+{% load ui_extras %}
 
 {% block admin_content %}
 <h1 class="text-xl font-bold mb-4">Konfigurationen exportieren / importieren</h1>
 <form method="post" class="mb-6">
     {% csrf_token %}
-    <button type="submit" name="export" class="px-4 py-2 bg-accent text-background rounded">Exportieren</button>
+    <button type="submit" name="export" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Exportieren</button>
 </form>
 <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
     <input type="file" name="config_file" accept="application/json" required>
-    <button type="submit" class="px-4 py-2 bg-success text-background rounded">Importieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'success' %}">Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n static %}
+{% load i18n static ui_extras %}
 {% block title %}{% trans 'Anmelden' %}{% endblock %}
 {% block content %}
 <div class="flex justify-center">
@@ -18,7 +18,7 @@
              <input type="password" name="password" id="id_password" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" required>
         </div>
         <input type="hidden" name="next" value="{{ next }}" />
-        <button type="submit" class="w-full bg-accent hover:bg-accent-dark text-background font-semibold py-2 px-4 rounded">{% trans 'Anmelden' %}</button>
+        <button type="submit" class="w-full font-semibold py-2 px-4 rounded {% btn_classes 'primary' %}">{% trans 'Anmelden' %}</button>
     </form>
 </div>
 {% endblock %}

--- a/templates/admin_anlage1.html
+++ b/templates/admin_anlage1.html
@@ -1,10 +1,11 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Anlage 1 Fragen{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_anlage1_import' %}" class="px-4 py-2 bg-success text-background rounded hover:bg-success-dark">Importieren</a>
-    <a href="{% url 'admin_anlage1_export' %}" class="px-4 py-2 bg-accent text-background rounded hover:bg-accent-dark">Exportieren</a>
+    <a href="{% url 'admin_anlage1_import' %}" class="px-4 py-2 rounded {% btn_classes 'success' %}">Importieren</a>
+    <a href="{% url 'admin_anlage1_export' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Exportieren</a>
 </div>
 <form method="post" class="space-y-4">
     {% csrf_token %}
@@ -64,6 +65,6 @@
         </tbody>
     </table>
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/admin_anlage1_import.html
+++ b/templates/admin_anlage1_import.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Anlage 1 Fragen importieren{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen importieren</h1>
@@ -13,6 +14,6 @@
     <div>
         <label class="mr-2">{{ form.clear_first }} Datenbank vorher leeren</label>
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_anlage2_config.html
+++ b/templates/admin_anlage2_config.html
@@ -1,5 +1,5 @@
 {% extends 'admin_base.html' %}
-{% load recording_extras %}
+{% load recording_extras ui_extras %}
 {% block title %}Anlage 2 Konfiguration{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Konfiguration</h1>
@@ -15,11 +15,11 @@
     <input type="hidden" name="active_tab" id="active_tab" value="{{ active_tab }}">
     <input type="hidden" name="phrase_key" id="phrase_key" value="">
     <nav class="border-b border-gray-200 space-x-2 mb-4">
-        <button type="button" data-tab="table" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Tabellen-Parser</button>
-        <button type="button" data-tab="general" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Allgemein</button>
-        <button type="button" data-tab="rules" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Parser-Antwortregeln</button>
-        <button type="button" data-tab="rules2" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Regeln Fallback</button>
-        <button type="button" data-tab="a4" class="px-4 py-2 text-muted bg-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer">Anlage 4 Parser</button>
+        <button type="button" data-tab="table" class="px-4 py-2 text-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer {% btn_classes 'muted' %}">Tabellen-Parser</button>
+        <button type="button" data-tab="general" class="px-4 py-2 text-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer {% btn_classes 'muted' %}">Allgemein</button>
+        <button type="button" data-tab="rules" class="px-4 py-2 text-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer {% btn_classes 'muted' %}">Parser-Antwortregeln</button>
+        <button type="button" data-tab="rules2" class="px-4 py-2 text-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer {% btn_classes 'muted' %}">Regeln Fallback</button>
+        <button type="button" data-tab="a4" class="px-4 py-2 text-muted border border-gray-300 dark:border-gray-600 border-b-0 rounded-t cursor-pointer {% btn_classes 'muted' %}">Anlage 4 Parser</button>
     </nav>
     <div id="tab-table" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Tabellen-Parser: Spaltenüberschriften (Alias)</h2>
@@ -54,7 +54,7 @@
             </tbody>
         </table>
         </div>
-        <button type="submit" name="action" value="save_table" class="mt-6 px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
+        <button type="submit" name="action" value="save_table" class="mt-6 px-4 py-2 rounded shadow-md {% btn_classes 'primary' %}">Speichern</button>
     </div>
     <div id="tab-general" class="tab-content">
         <div>
@@ -81,7 +81,7 @@
             <div id="parser-order-inputs"></div>
             {{ config_form.parser_order.errors }}
         </div>
-        <button type="submit" name="action" value="save_general" class="mt-6 px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
+        <button type="submit" name="action" value="save_general" class="mt-6 px-4 py-2 rounded shadow-md {% btn_classes 'primary' %}">Speichern</button>
     </div>
     <div id="tab-rules" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Parser-Antwortregeln</h2>
@@ -91,7 +91,7 @@
         <div class="mt-2 space-x-2">
             <!-- HTMX-Funktion vorübergehend deaktiviert -->
             {% include 'partials/_button.html' with type='button' label='Neue Regel hinzufügen' variant='secondary' classes='px-3 py-1 rounded' disabled=True %}
-            <button type="submit" name="action" value="save_rules" class="px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
+            <button type="submit" name="action" value="save_rules" class="px-4 py-2 rounded shadow-md {% btn_classes 'primary' %}">Speichern</button>
         </div>
     </div>
     <div id="tab-rules2" class="tab-content">
@@ -99,7 +99,7 @@
         <div class="overflow-x-auto">
             {% include 'partials/_response_rules_table_simple.html' with formset=rule_formset_fb raw_actions=raw_actions action_formsets=action_formsets %}
         </div>
-        <button type="submit" name="action" value="save_rules_fb" class="mt-2 px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
+        <button type="submit" name="action" value="save_rules_fb" class="mt-2 px-4 py-2 rounded shadow-md {% btn_classes 'primary' %}">Speichern</button>
     </div>
     <div id="tab-a4" class="tab-content">
         <h2 class="text-xl font-semibold mb-2">Anlage 4 Parser</h2>
@@ -124,7 +124,7 @@
                 {{ a4_parser_form.fachbereiche_phrase }}
                 {{ a4_parser_form.fachbereiche_phrase.errors }}
             </div>
-            <button type="submit" name="action" value="save_a4" class="px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
+            <button type="submit" name="action" value="save_a4" class="px-4 py-2 rounded shadow-md {% btn_classes 'primary' %}">Speichern</button>
         </div>
     </div>
 </form>

--- a/templates/admin_anlage2_config_import.html
+++ b/templates/admin_anlage2_config_import.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Anlage 2 Konfiguration importieren{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Konfiguration importieren</h1>
@@ -10,6 +11,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_anlage2_parser_rule_import.html
+++ b/templates/admin_anlage2_parser_rule_import.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Parser-Regeln importieren{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Parser-Regeln importieren</h1>
@@ -10,6 +11,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_anlage4_config.html
+++ b/templates/admin_anlage4_config.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Anlage 4 Konfiguration{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 4 Konfiguration</h1>
@@ -23,15 +24,15 @@
                 {% for val in form.instance.gesellschaft_aliases %}
                 <div class="flex mb-2">
                       <input type="text" name="gesellschaft_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
                       <input type="text" name="gesellschaft_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
             </div>
-            <button type="button" id="add-ges-alias" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
+            <button type="button" id="add-ges-alias" class="px-2 py-1 rounded mt-1 {% btn_classes 'muted' %}">+ Alias hinzufügen</button>
         </div>
         <div>
             <label>{{ form.fachbereiche_phrase.label }}</label>
@@ -44,15 +45,15 @@
                 {% for val in form.instance.fachbereich_aliases %}
                 <div class="flex mb-2">
                       <input type="text" name="fachbereich_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
                       <input type="text" name="fachbereich_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
             </div>
-            <button type="button" id="add-fb-alias" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
+            <button type="button" id="add-fb-alias" class="px-2 py-1 rounded mt-1 {% btn_classes 'muted' %}">+ Alias hinzufügen</button>
         </div>
         <div>
             <label>{{ form.name_aliases.label }}</label>
@@ -60,15 +61,15 @@
                 {% for val in form.instance.name_aliases %}
                 <div class="flex mb-2">
                       <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
                       <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
             </div>
-            <button type="button" id="add-name-alias" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
+            <button type="button" id="add-name-alias" class="px-2 py-1 rounded mt-1 {% btn_classes 'muted' %}">+ Alias hinzufügen</button>
         </div>
         <div class="mb-3">
             <label class="form-label">Negative Patterns (jeweils ein Regex pro Feld):</label>
@@ -76,15 +77,15 @@
                 {% for pat in form.instance.negative_patterns %}
                 <div class="flex mb-2">
                       <input type="text" name="negative_patterns" value="{{ pat }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
                       <input type="text" name="negative_patterns" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
             </div>
-            <button type="button" id="add-negative-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+</button>
+            <button type="button" id="add-negative-btn" class="px-2 py-1 rounded mt-1 {% btn_classes 'muted' %}">+</button>
         </div>
     </section>
     <section class="border rounded p-4 space-y-4">
@@ -95,18 +96,18 @@
                 {% for col in form.instance.table_columns %}
                 <div class="flex mb-2">
                       <input type="text" name="table_columns" value="{{ col }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
                 {% endfor %}
                 <div class="flex mb-2">
                       <input type="text" name="table_columns" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                    <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                    <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
                 </div>
             </div>
-            <button type="button" id="add-column-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Spalte hinzufügen</button>
+            <button type="button" id="add-column-btn" class="px-2 py-1 rounded mt-1 {% btn_classes 'muted' %}">+ Spalte hinzufügen</button>
         </div>
     </section>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded shadow-md hover:bg-accent-dark">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded shadow-md {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}
 {% block extra_js %}
@@ -129,7 +130,7 @@
                 const del = document.createElement('button');
                 del.type = 'button';
                 del.textContent = 'x';
-                del.className = 'px-2 py-1 bg-gray-200 rounded ml-2 remove-btn';
+                del.className = "px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}";
                 del.addEventListener('click', () => wrap.remove());
                 wrap.appendChild(input);
                 wrap.appendChild(del);

--- a/templates/admin_llm_role_form.html
+++ b/templates/admin_llm_role_form.html
@@ -1,5 +1,5 @@
 {% extends 'admin_base.html' %}
-{% load static %}
+{% load static ui_extras %}
 {% block extra_head %}{{ block.super }}{% endblock %}
 {% block title %}{% if role %}Rolle bearbeiten{% else %}Neue Rolle{% endif %}{% endblock %}
 {% block admin_content %}
@@ -20,7 +20,7 @@
         <label>{{ form.is_default }} Standard</label>
         {{ form.is_default.errors }}
     </div>
-<button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
+<button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}
 

--- a/templates/admin_llm_role_import.html
+++ b/templates/admin_llm_role_import.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}LLM Rollen importieren{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">LLM Rollen importieren</h1>
@@ -10,6 +11,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_llm_roles.html
+++ b/templates/admin_llm_roles.html
@@ -1,11 +1,12 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}LLM Rollen{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">LLM Rollen</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_llm_role_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
-    <a href="{% url 'admin_llm_role_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
-    <a href="{% url 'admin_llm_role_new' %}" class="px-4 py-2 bg-accent text-background rounded">Neue Rolle hinzufügen</a>
+    <a href="{% url 'admin_llm_role_import' %}" class="px-4 py-2 rounded {% btn_classes 'success' %}">Importieren</a>
+    <a href="{% url 'admin_llm_role_export' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Exportieren</a>
+    <a href="{% url 'admin_llm_role_new' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Neue Rolle hinzufügen</a>
 </div>
 <div class="overflow-x-auto">
 <table class="min-w-full">
@@ -23,12 +24,12 @@
             <td class="py-1">{{ r.name }}</td>
             <td class="py-1">{{ r.is_default|yesno:"Ja,Nein" }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'admin_llm_role_edit' r.id %}" class="px-2 py-1 bg-accent text-background rounded">Bearbeiten</a>
+                <a href="{% url 'admin_llm_role_edit' r.id %}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form action="{% url 'admin_llm_role_delete' r.id %}" method="post" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Rolle wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Rolle wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/admin_models.html
+++ b/templates/admin_models.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}LLM Modelle{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">LLM Modelle</h1>
@@ -60,6 +61,6 @@
         </tbody>
     </table>
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/admin_project_cleanup.html
+++ b/templates/admin_project_cleanup.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Projekt bereinigen{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Projekt {{ projekt.title }} bereinigen</h1>
@@ -25,7 +26,7 @@
                     {% csrf_token %}
                     <input type="hidden" name="action" value="delete_file">
                     <input type="hidden" name="file_id" value="{{ f.id }}">
-                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Anlage wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Anlage wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>
@@ -41,7 +42,7 @@
 <form method="post" class="mb-4">
     {% csrf_token %}
     <input type="hidden" name="action" value="delete_gutachten">
-    <button type="submit" class="px-4 py-2 bg-error text-background rounded" onclick="return confirm('Gutachten wirklich löschen?');">Gutachten löschen</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'danger' %}" onclick="return confirm('Gutachten wirklich löschen?');">Gutachten löschen</button>
 </form>
 {% else %}
 <p class="mb-4">Kein Gutachten vorhanden.</p>
@@ -52,7 +53,7 @@
 <form method="post" class="mb-4">
     {% csrf_token %}
     <input type="hidden" name="action" value="delete_classification">
-    <button type="submit" class="px-4 py-2 bg-error text-background rounded" onclick="return confirm('Bewertung wirklich löschen?');">Bewertung löschen</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'danger' %}" onclick="return confirm('Bewertung wirklich löschen?');">Bewertung löschen</button>
 </form>
 {% else %}
 <p class="mb-4">Keine Bewertung vorhanden.</p>
@@ -63,7 +64,7 @@
 <form method="post" class="mb-4">
     {% csrf_token %}
     <input type="hidden" name="action" value="delete_gap_report">
-    <button type="submit" class="px-4 py-2 bg-error text-background rounded" onclick="return confirm('GAP-Bericht wirklich löschen?');">GAP-Bericht löschen</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'danger' %}" onclick="return confirm('GAP-Bericht wirklich löschen?');">GAP-Bericht löschen</button>
 </form>
 {% else %}
 <p class="mb-4">Kein GAP-Bericht vorhanden.</p>

--- a/templates/admin_project_status_form.html
+++ b/templates/admin_project_status_form.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}{% if status %}Status bearbeiten{% else %}Neuer Status{% endif %}{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">{% if status %}Status bearbeiten{% else %}Neuer Status{% endif %}</h1>
@@ -28,6 +29,6 @@
         <label>{{ form.is_done_status }} Abschlussstatus</label>
         {{ form.is_done_status.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-text rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/admin_project_status_import.html
+++ b/templates/admin_project_status_import.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Projekt-Status importieren{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Projekt-Status importieren</h1>
@@ -10,6 +11,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_project_statuses.html
+++ b/templates/admin_project_statuses.html
@@ -1,12 +1,13 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Projektstatus{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Projektstatus</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_project_status_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
-    <a href="{% url 'admin_project_status_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
+    <a href="{% url 'admin_project_status_import' %}" class="px-4 py-2 rounded {% btn_classes 'success' %}">Importieren</a>
+    <a href="{% url 'admin_project_status_export' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Exportieren</a>
 </div>
-<a href="{% url 'admin_project_status_new' %}" class="inline-block mb-4 px-4 py-2 bg-accent text-background rounded">Neuen Status hinzufügen</a>
+<a href="{% url 'admin_project_status_new' %}" class="inline-block mb-4 px-4 py-2 rounded {% btn_classes 'primary' %}">Neuen Status hinzufügen</a>
 <div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
@@ -29,12 +30,12 @@
             <td class="py-1 text-center">{{ s.is_default|yesno:"Ja,Nein" }}</td>
             <td class="py-1 text-center">{{ s.is_done_status|yesno:"Ja,Nein" }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'admin_project_status_edit' s.id %}" class="px-2 py-1 bg-accent text-background rounded">Bearbeiten</a>
+                <a href="{% url 'admin_project_status_edit' s.id %}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form action="{% url 'admin_project_status_delete' s.id %}" method="post" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Status wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Status wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/admin_prompt_import.html
+++ b/templates/admin_prompt_import.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Prompts importieren{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Prompts importieren</h1>
@@ -13,6 +14,6 @@
     <div>
         <label class="mr-2">{{ form.clear_first }} Vorhandene Prompts löschen</label>
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_prompts.html
+++ b/templates/admin_prompts.html
@@ -1,15 +1,16 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 
 {% block title %}Admin Prompts{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Admin Prompts</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_prompt_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
-    <a href="{% url 'admin_prompt_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
+    <a href="{% url 'admin_prompt_import' %}" class="px-4 py-2 rounded {% btn_classes 'success' %}">Importieren</a>
+    <a href="{% url 'admin_prompt_export' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Exportieren</a>
 </div>
 <div class="mb-4 space-x-2">
     {% for key, label, items in grouped %}
-        <button data-tab="{{ key }}" class="px-3 py-1 bg-accent text-background rounded">{{ label }}</button>
+        <button data-tab="{{ key }}" class="px-3 py-1 rounded {% btn_classes 'primary' %}">{{ label }}</button>
     {% endfor %}
 </div>
 
@@ -56,7 +57,7 @@
                 </td>
                 <td class="py-1">
                           <textarea name="text" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ p.text }}</textarea>
-                        <button name="action" value="save" class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
+                        <button name="action" value="save" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Speichern</button>
                     </form>
                 </td>
                 <td class="py-1 text-center">
@@ -64,7 +65,7 @@
                         {% csrf_token %}
                         <input type="hidden" name="pk" value="{{ p.id }}">
                         <input type="hidden" name="action" value="delete">
-                        <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Prompt wirklich löschen?');">Löschen</button>
+                        <button type="submit" class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Prompt wirklich löschen?');">Löschen</button>
                     </form>
                 </td>
             </tr>
@@ -79,7 +80,7 @@
                         {% csrf_token %}
                         <input type="hidden" name="action" value="save_a4_config">
                           <textarea name="prompt_template" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ a4_config.prompt_template }}</textarea>
-                        <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
+                        <button class="px-2 py-1 rounded {% btn_classes 'primary' %}">Speichern</button>
                     </form>
                 </td>
             </tr>
@@ -91,7 +92,7 @@
                         <input type="hidden" name="action" value="save_a4_parser_prompts">
                         <input type="hidden" name="field" value="prompt_plausibility">
                           <textarea name="prompt_text" rows="4" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded p-2 w-full focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ a4_parser.prompt_plausibility }}</textarea>
-                        <button class="px-2 py-1 bg-accent text-background rounded">Speichern</button>
+                        <button class="px-2 py-1 rounded {% btn_classes 'primary' %}">Speichern</button>
                     </form>
                 </td>
             </tr>

--- a/templates/admin_roles.html
+++ b/templates/admin_roles.html
@@ -1,4 +1,5 @@
 {% extends 'admin/base_site.html' %}
+{% load ui_extras %}
 {% block title %}Rollen & Kacheln{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Rollen & Kacheln</h1>
@@ -10,7 +11,7 @@
             <option value="{{ g.id }}" {% if selected_group and g.id == selected_group.id %}selected{% endif %}>{{ g.name }}</option>
         {% endfor %}
     </select>
-    <a href="{% url 'admin:auth_group_add' %}" class="ml-2 px-2 py-1 bg-accent text-background rounded">Neue Rolle</a>
+    <a href="{% url 'admin:auth_group_add' %}" class="ml-2 px-2 py-1 rounded {% btn_classes 'primary' %}">Neue Rolle</a>
 </div>
 <div id="role-form">
     {% if selected_group %}

--- a/templates/admin_talkdiary.html
+++ b/templates/admin_talkdiary.html
@@ -1,13 +1,13 @@
 {% extends 'admin_base.html' %}
-{% load recording_extras %}
+{% load recording_extras ui_extras %}
 {% block title %}Admin TalkDiary{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Admin TalkDiary</h1>
 <div class="mb-4 space-x-2">
-    <a href="?" class="px-3 py-1 rounded bg-background {% if not active_filter %}bg-primary text-background{% endif %}">Alle</a>
-    <a href="?filter=missing_audio" class="px-3 py-1 rounded bg-background {% if active_filter == 'missing_audio' %}bg-primary text-background{% endif %}">Missing Audio</a>
-    <a href="?filter=missing_transcript" class="px-3 py-1 rounded bg-background {% if active_filter == 'missing_transcript' %}bg-primary text-background{% endif %}">Missing Transcript</a>
-    <a href="?filter=incomplete" class="px-3 py-1 rounded bg-background {% if active_filter == 'incomplete' %}bg-primary text-background{% endif %}">Incomplete</a>
+    <a href="?" class="px-3 py-1 rounded {% if not active_filter %}{% btn_classes 'primary' %}{% else %}{% btn_classes 'muted' %}{% endif %}">Alle</a>
+    <a href="?filter=missing_audio" class="px-3 py-1 rounded {% if active_filter == 'missing_audio' %}{% btn_classes 'primary' %}{% else %}{% btn_classes 'muted' %}{% endif %}">Missing Audio</a>
+    <a href="?filter=missing_transcript" class="px-3 py-1 rounded {% if active_filter == 'missing_transcript' %}{% btn_classes 'primary' %}{% else %}{% btn_classes 'muted' %}{% endif %}">Missing Transcript</a>
+    <a href="?filter=incomplete" class="px-3 py-1 rounded {% if active_filter == 'incomplete' %}{% btn_classes 'primary' %}{% else %}{% btn_classes 'muted' %}{% endif %}">Incomplete</a>
 </div>
 <form method="post">
     {% csrf_token %}
@@ -43,7 +43,7 @@
     </div>
     {% if recordings %}
     <div class="mt-4">
-        <button type="submit" class="px-4 py-2 bg-error text-background rounded" onclick="return confirm('Einträge wirklich löschen?');">Löschen</button>
+        <button type="submit" class="px-4 py-2 rounded {% btn_classes 'danger' %}" onclick="return confirm('Einträge wirklich löschen?');">Löschen</button>
     </div>
     {% endif %}
 </form>

--- a/templates/admin_user_import.html
+++ b/templates/admin_user_import.html
@@ -1,4 +1,5 @@
 {% extends 'admin/base_site.html' %}
+{% load ui_extras %}
 {% block title %}Benutzer importieren{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Benutzer importieren</h1>
@@ -10,6 +11,6 @@
         {{ form.json_file }}
         {{ form.json_file.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Hochladen &amp; Importieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Hochladen &amp; Importieren</button>
 </form>
 {% endblock %}

--- a/templates/admin_user_list.html
+++ b/templates/admin_user_list.html
@@ -1,10 +1,11 @@
 {% extends 'admin/base_site.html' %}
+{% load ui_extras %}
 {% block title %}Benutzer{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Benutzer</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'admin_import_users_permissions' %}" class="px-4 py-2 bg-success text-background rounded hover:bg-success-dark">Importieren</a>
-    <a href="{% url 'admin_export_users_permissions' %}" class="px-4 py-2 bg-accent text-background rounded hover:bg-accent-dark">Exportieren</a>
+    <a href="{% url 'admin_import_users_permissions' %}" class="px-4 py-2 rounded {% btn_classes 'success' %}">Importieren</a>
+    <a href="{% url 'admin_export_users_permissions' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Exportieren</a>
 </div>
 <div class="overflow-x-auto">
 <table class="min-w-full">
@@ -25,7 +26,7 @@
             <td class="py-1">{{ u.groups.all|join:", " }}</td>
             <td class="py-1">{{ u.tiles.all|join:", " }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'admin_edit_user_permissions' u.id %}" class="px-2 py-1 bg-accent text-background rounded">Berechtigungen bearbeiten</a>
+                <a href="{% url 'admin_edit_user_permissions' u.id %}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Berechtigungen bearbeiten</a>
             </td>
         </tr>
     {% empty %}

--- a/templates/admin_user_permissions_form.html
+++ b/templates/admin_user_permissions_form.html
@@ -1,4 +1,5 @@
 {% extends 'admin/base_site.html' %}
+{% load ui_extras %}
 {% block title %}Berechtigungen bearbeiten{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Berechtigungen für {{ user_obj.username }}</h1>
@@ -15,6 +16,6 @@
         {{ form.tiles }}
         {{ form.tiles.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/anlage2/function_form.html
+++ b/templates/anlage2/function_form.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}{% if funktion %}Funktion bearbeiten{% else %}Neue Funktion{% endif %}{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">{% if funktion %}Funktion bearbeiten{% else %}Neue Funktion{% endif %}</h1>
@@ -16,15 +17,15 @@
             {% for val in aliases %}
             <div class="flex mb-2">
                   <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
             </div>
             {% endfor %}
             <div class="flex mb-2">
                   <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
             </div>
         </div>
-        <button type="button" id="add-alias-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
+        <button type="button" id="add-alias-btn" class="px-2 py-1 rounded mt-1 {% btn_classes 'muted' %}">+ Alias hinzufügen</button>
     </div>
     {% include 'partials/_button.html' with type='submit' label='Speichern' variant='primary' classes='mt-4' %}
 </form>
@@ -46,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const del = document.createElement('button');
         del.type = 'button';
         del.textContent = 'x';
-        del.className = 'px-2 py-1 bg-gray-200 rounded ml-2 remove-btn';
+        del.className = "px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}";
         del.addEventListener('click', () => wrap.remove());
         wrap.appendChild(input);
         wrap.appendChild(del);
@@ -57,7 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 {% if funktion %}
 <h2 class="text-xl font-semibold mt-8 mb-2">Unterfragen</h2>
-<a href="{% url 'anlage2_subquestion_new' funktion.id %}" class="inline-block mb-2 px-3 py-1 bg-success text-background rounded">Neue Unterfrage</a>
+<a href="{% url 'anlage2_subquestion_new' funktion.id %}" class="inline-block mb-2 px-3 py-1 rounded {% btn_classes 'success' %}">Neue Unterfrage</a>
 <div class="overflow-x-auto">
 <table class="min-w-full">
     <thead>
@@ -72,12 +73,12 @@ document.addEventListener('DOMContentLoaded', () => {
         <tr class="border-b text-sm">
             <td class="py-1">{{ q.frage_text|truncatechars:80 }}</td>
             <td class="py-1 text-center">
-                  <a href="{% url 'anlage2_subquestion_edit' q.id %}" class="px-2 py-1 bg-primary text-background rounded">Bearbeiten</a>
+                  <a href="{% url 'anlage2_subquestion_edit' q.id %}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form action="{% url 'anlage2_subquestion_delete' q.id %}" method="post" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Unterfrage wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Unterfrage wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/anlage2/function_import.html
+++ b/templates/anlage2/function_import.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Funktionen importieren{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Funktionen importieren</h1>
@@ -13,6 +14,6 @@
     <div>
         <label class="mr-2">{{ form.clear_first }} Datenbank vorher leeren</label>
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Importieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Importieren</button>
 </form>
 {% endblock %}

--- a/templates/anlage2/function_list.html
+++ b/templates/anlage2/function_list.html
@@ -1,11 +1,12 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Anlage 2 Funktionen{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 2 Funktionen</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'anlage2_function_new' %}" class="px-4 py-2 bg-accent text-background rounded">Neue Funktion</a>
-    <a href="{% url 'anlage2_function_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
-    <a href="{% url 'anlage2_function_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
+    <a href="{% url 'anlage2_function_new' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Neue Funktion</a>
+    <a href="{% url 'anlage2_function_import' %}" class="px-4 py-2 rounded {% btn_classes 'success' %}">Importieren</a>
+    <a href="{% url 'anlage2_function_export' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Exportieren</a>
 </div>
 <div class="overflow-x-auto">
 <table class="min-w-full">
@@ -21,12 +22,12 @@
         <tr class="border-b text-sm">
             <td class="py-1">{{ f.name }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'anlage2_function_edit' f.id %}" class="px-2 py-1 bg-accent text-background rounded">Bearbeiten</a>
+                <a href="{% url 'anlage2_function_edit' f.id %}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form action="{% url 'anlage2_function_delete' f.id %}" method="post" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Funktion wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Funktion wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/anlage2/subquestion_form.html
+++ b/templates/anlage2/subquestion_form.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}{% if subquestion %}Unterfrage bearbeiten{% else %}Neue Unterfrage{% endif %}{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">{% if subquestion %}Unterfrage bearbeiten{% else %}Neue Unterfrage{% endif %}</h1>
@@ -16,15 +17,15 @@
             {% for val in aliases %}
             <div class="flex mb-2">
                   <input type="text" name="name_aliases" value="{{ val }}" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
             </div>
             {% endfor %}
             <div class="flex mb-2">
                   <input type="text" name="name_aliases" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-grow">
-                <button type="button" class="px-2 py-1 bg-gray-200 rounded ml-2 remove-btn">x</button>
+                <button type="button" class="px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}">x</button>
             </div>
         </div>
-        <button type="button" id="add-alias-btn" class="px-2 py-1 bg-gray-200 rounded mt-1">+ Alias hinzufügen</button>
+        <button type="button" id="add-alias-btn" class="px-2 py-1 rounded mt-1 {% btn_classes 'muted' %}">+ Alias hinzufügen</button>
     </div>
     <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -44,7 +45,7 @@
             const del = document.createElement('button');
             del.type = 'button';
             del.textContent = 'x';
-            del.className = 'px-2 py-1 bg-gray-200 rounded ml-2 remove-btn';
+            del.className = "px-2 py-1 rounded ml-2 remove-btn {% btn_classes 'muted' %}";
             del.addEventListener('click', () => wrap.remove());
             wrap.appendChild(input);
             wrap.appendChild(del);

--- a/templates/anlage3_review.html
+++ b/templates/anlage3_review.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load recording_extras %}
+{% load recording_extras ui_extras %}
 {% block title %}Anlage 3 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 3 Dateien für {{ projekt.title }} prüfen</h1>
@@ -20,25 +20,25 @@
             <td class="px-2 py-1 text-center">
                 <form method="post" action="{% url 'projekt_file_check_view' a.pk %}?llm=1">
                     {% csrf_token %}
-                    <button class="bg-primary text-background px-2 py-1 rounded">LLM-Prüfung</button>
+                    <button class="px-2 py-1 rounded {% btn_classes 'primary' %}">LLM-Prüfung</button>
                 </form>
             </td>
             <td class="px-2 py-1 text-center">
                 <form method="post" action="{% url 'project_file_toggle_flag' a.pk 'manual_reviewed' %}">
                     {% csrf_token %}
                     <input type="hidden" name="value" value="{{ a.manual_reviewed|yesno:'0,1' }}">
-                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}bg-success text-background{% else %}bg-gray-300{% endif %}">
+                    <button class="px-2 py-1 rounded {% if a.manual_reviewed %}{% btn_classes 'success' %}{% else %}{% btn_classes 'muted' %}{% endif %}">
                         {% if a.manual_reviewed %}✓{% else %}✗{% endif %}
                     </button>
                 </form>
             </td>
             <td class="px-2 py-1 text-center space-x-1">
-                <a href="{% url 'projekt_file_edit_json' a.pk %}" class="bg-primary text-background px-2 py-1 rounded">Analyse bearbeiten</a>
+                <a href="{% url 'projekt_file_edit_json' a.pk %}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Analyse bearbeiten</a>
                 <form method="post" action="{% url 'projekt_file_delete_result' a.pk %}" class="inline">
                     {% csrf_token %}
-                    <button class="bg-error text-background px-2 py-1 rounded" onclick="return confirm('Ergebnis wirklich löschen?')">Ergebnis löschen</button>
+                    <button class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Ergebnis wirklich löschen?')">Ergebnis löschen</button>
                 </form>
-                <a href="{{ a.upload.url }}" class="bg-accent text-background px-2 py-1 rounded">Download</a>
+                <a href="{{ a.upload.url }}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Download</a>
             </td>
         </tr>
         {% if a.analysis_json %}

--- a/templates/edit_ki_justification.html
+++ b/templates/edit_ki_justification.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load ui_extras %}
 {% block title %}KI-Begründung bearbeiten{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">KI-Begründung bearbeiten</h1>
@@ -10,6 +11,6 @@
     {% else %}
     <input type="hidden" name="subquestion" value="{{ object.id }}">
     {% endif %}
-    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/gap_report.html
+++ b/templates/gap_report.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static ui_extras %}
 {% block extra_head %}{% endblock %}
 {% block title %}GAP-Bericht{% endblock %}
 {% block content %}
@@ -13,7 +13,7 @@
 
 <form method="post" action="{% url 'delete_gap_report' projekt.pk %}" class="inline-block">
     {% csrf_token %}
-    <button type="submit" class="bg-error text-background px-4 py-2 rounded">Bericht verwerfen &amp; neu generieren</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'danger' %}">Bericht verwerfen &amp; neu generieren</button>
 </form>
 {% endblock %}
 {% block extra_js %}

--- a/templates/involvement_detail.html
+++ b/templates/involvement_detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load ui_extras %}
 {% block title %}KI-Beteiligung{% endblock %}
 {% block content %}
 {% include 'partials/_breadcrumbs.html' %}
@@ -10,6 +11,6 @@
     {% csrf_token %}
     {{ form.justification.label_tag }}
     {{ form.justification }}
-    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/justification_detail.html
+++ b/templates/justification_detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load ui_extras %}
 {% block title %}Begründung{% endblock %}
 {% block content %}
 {% include 'partials/_breadcrumbs.html' %}
@@ -10,8 +11,8 @@
     {% csrf_token %}
     {{ form.justification.label_tag }}
     {{ form.justification }}
-    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Speichern</button>
-    <a href="{% url 'justification_delete' project_file.id function_name %}" class="bg-error text-background px-4 py-2 rounded ml-2">Begründung löschen</a>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
+    <a href="{% url 'justification_delete' project_file.id function_name %}" class="px-4 py-2 rounded ml-2 {% btn_classes 'danger' %}">Begründung löschen</a>
 </form>
 {% endblock %}
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load ui_extras %}
 
 {% block title %}Anmelden{% endblock %}
 
@@ -18,7 +19,7 @@
             <label for="id_password" class="block text-sm font-medium text-text mb-1">Passwort</label>
              <input type="password" name="password" id="id_password" class="w-full border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded px-3 py-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800" required>
         </div>
-        <button type="submit" class="w-full bg-accent hover:bg-accent-dark text-background font-semibold py-2 px-4 rounded">Anmelden</button>
+        <button type="submit" class="w-full font-semibold py-2 px-4 rounded {% btn_classes 'primary' %}">Anmelden</button>
     </form>
 </div>
 {% endblock %}

--- a/templates/parser_rules/rule_form.html
+++ b/templates/parser_rules/rule_form.html
@@ -1,4 +1,5 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}{% if form.instance.pk %}Regel bearbeiten{% else %}Neue Regel{% endif %}{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">{% if form.instance.pk %}Regel bearbeiten{% else %}Neue Regel{% endif %}</h1>
@@ -25,7 +26,7 @@
         {{ form.prioritaet.label_tag }}<br>
         {{ form.prioritaet }}{{ form.prioritaet.errors }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 
 {% endblock %}

--- a/templates/parser_rules/rule_list.html
+++ b/templates/parser_rules/rule_list.html
@@ -1,11 +1,12 @@
 {% extends 'admin_base.html' %}
+{% load ui_extras %}
 {% block title %}Exakter Parser Regeln{% endblock %}
 {% block admin_content %}
 <h1 class="text-2xl font-semibold mb-4">Regeln für Exakten Parser</h1>
 <div class="mb-4 space-x-2">
-    <a href="{% url 'parser_rule_add' %}" class="px-4 py-2 bg-accent text-background rounded">Neue Regel</a>
-    <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 bg-success text-background rounded">Importieren</a>
-    <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 bg-accent text-background rounded">Exportieren</a>
+    <a href="{% url 'parser_rule_add' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Neue Regel</a>
+    <a href="{% url 'anlage2_parser_rule_import' %}" class="px-4 py-2 rounded {% btn_classes 'success' %}">Importieren</a>
+    <a href="{% url 'anlage2_parser_rule_export' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Exportieren</a>
 </div>
 <div class="overflow-x-auto">
 <table class="min-w-full">
@@ -23,12 +24,12 @@
             <td class="py-1">{{ r.regel_name }}</td>
             <td class="py-1">{{ r.erkennungs_phrase }}</td>
             <td class="py-1 text-center">
-                <a href="{% url 'parser_rule_edit' r.id %}" class="px-2 py-1 bg-accent text-background rounded">Bearbeiten</a>
+                <a href="{% url 'parser_rule_edit' r.id %}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Bearbeiten</a>
             </td>
             <td class="py-1 text-center">
                 <form method="post" action="{% url 'parser_rule_delete' r.id %}" class="inline">
                     {% csrf_token %}
-                    <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Regel wirklich löschen?');">Löschen</button>
+                    <button type="submit" class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Regel wirklich löschen?');">Löschen</button>
                 </form>
             </td>
         </tr>

--- a/templates/partials/_admin_project_rows.html
+++ b/templates/partials/_admin_project_rows.html
@@ -1,3 +1,4 @@
+{% load ui_extras %}
 {% for p in projekte %}
     <tr class="border-b text-sm">
         <td class="py-1">{{ p.title }}</td>
@@ -7,9 +8,9 @@
             {% include 'partials/status_badge.html' with status_key=p.status.key label=p.status.name %}
         </td>
         <td class="py-1 text-center flex items-center justify-center space-x-2">
-            <a href="{% url 'projekt_edit' p.pk %}" class="px-2 py-1 bg-accent text-text rounded">Bearbeiten</a>
-            <a href="{% url 'admin_project_cleanup' p.pk %}" class="px-2 py-1 bg-accent text-text rounded">Bereinigen</a>
-            <button type="submit" name="delete_single" value="{{ p.id }}" form="post-actions-form" class="px-2 py-1 bg-accent text-text rounded" onclick="return confirm('Projekt wirklich löschen?');">Löschen</button>
+            <a href="{% url 'projekt_edit' p.pk %}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Bearbeiten</a>
+            <a href="{% url 'admin_project_cleanup' p.pk %}" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Bereinigen</a>
+            <button type="submit" name="delete_single" value="{{ p.id }}" form="post-actions-form" class="px-2 py-1 rounded {% btn_classes 'primary' %}" onclick="return confirm('Projekt wirklich löschen?');">Löschen</button>
         </td>
         <td class="py-1 text-center"><input type="checkbox" name="selected_projects" value="{{ p.id }}" form="post-actions-form" class="form-checkbox"></td>
     </tr>

--- a/templates/partials/_role_tile_form.html
+++ b/templates/partials/_role_tile_form.html
@@ -1,3 +1,4 @@
+{% load ui_extras %}
 {% if selected_group %}
 <form method="post" class="space-y-4">
     {% csrf_token %}
@@ -16,6 +17,6 @@
             {% endfor %}
         </div>
     {% endfor %}
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endif %}

--- a/templates/partials/anlagen_assign_row.html
+++ b/templates/partials/anlagen_assign_row.html
@@ -1,3 +1,4 @@
+{% load ui_extras %}
 <tr>
     <td colspan="{% if show_nr %}7{% else %}6{% endif %}">
         <form hx-post="{% url 'projekt_file_upload' projekt.pk %}" hx-target="closest tr" hx-swap="outerHTML" class="space-x-2">
@@ -9,7 +10,7 @@
                 <option value="{{ n }}">{{ n }}</option>
                 {% endfor %}
             </select>
-            <button type="submit" class="bg-accent text-background px-2 py-1 rounded">Speichern</button>
+            <button type="submit" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Speichern</button>
         </form>
     </td>
 </tr>

--- a/templates/partials/review_row.html
+++ b/templates/partials/review_row.html
@@ -1,4 +1,4 @@
-{% load recording_extras %}
+{% load recording_extras ui_extras %}
 <tr class="{% if row.sub %}subquestion-row hidden subquestions-for-{{ row.func_id }} {% endif %}{% if row.is_negotiable %}opacity-80{% endif %}"
     data-relevant="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'true,false,unknown' }}"
     data-parsed-status="{{ row.doc_result|get_item:'technisch_vorhanden'|yesno:'True,False,None' }}"
@@ -12,15 +12,15 @@
     data-func-id="{{ row.func_id }}" {% if row.sub %}data-sub-id="{{ row.sub_id }}"{% endif %}>
     <td class="border px-2 {% if row.sub %}pl-8{% endif %}">
         {% if not row.sub %}
-        <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-muted hover:bg-muted" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
+        <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded {% btn_classes 'muted' %}" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-muted hover:bg-muted">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded text-muted {% btn_classes 'muted' %}">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% else %}
         {{ row.name }}
         {% if row.has_justification %}
-        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-muted hover:bg-muted">Begründung ansehen/bearbeiten</a>
+        <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}" class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded text-muted {% btn_classes 'muted' %}">Begründung ansehen/bearbeiten</a>
         {% endif %}
         {% endif %}
         {% if row.source_text and row.source_text != 'N/A' %}
@@ -42,7 +42,7 @@
     {% endfor %}
     {% include 'partials/negotiable_cell.html' with row=row is_negotiable=row.is_negotiable override=row.negotiable_manual_override %}
     <td class="border px-2 text-center action-column">
-        <button type="button" class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-muted hover:bg-muted"
+        <button type="button" class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded {% btn_classes 'muted' %}"
             data-state="robot" title="KI-Prüfung starten"
             data-project-file-id="{{ anlage.pk }}"
             data-function-id="{{ row.func_id }}"

--- a/templates/partials/software_tab_basic.html
+++ b/templates/partials/software_tab_basic.html
@@ -1,4 +1,4 @@
-{% load recording_extras %}
+{% load recording_extras ui_extras %}
 <div class="space-y-4">
     {% for row in knowledge_rows %}
         <div class="card p-4" data-id="{{ row.entry.id|default:'' }}">
@@ -45,5 +45,5 @@
         </div>
     {% endfor %}
 </div>
-<button id="start-checks" type="button" class="bg-success text-background px-4 py-2 rounded">Prüfung starten</button>
+<button id="start-checks" type="button" class="px-4 py-2 rounded {% btn_classes 'success' %}">Prüfung starten</button>
 

--- a/templates/partials/supervision_row_content.html
+++ b/templates/partials/supervision_row_content.html
@@ -1,3 +1,4 @@
+{% load ui_extras %}
 <div class="p-2 space-y-4">
   <div class="border rounded bg-background p-2 space-y-1">
     <h3 class="font-semibold">Parser</h3>
@@ -19,7 +20,7 @@
   </div>
   <div class="border rounded bg-background p-2 space-y-2">
     <form hx-post="{% url 'hx_supervision_confirm' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="inline">
-      <button class="bg-accent text-text px-2 py-1 rounded" type="submit">GAP bestätigen</button>
+      <button class="px-2 py-1 rounded {% btn_classes 'primary' %}" type="submit">GAP bestätigen</button>
     </form>
     <div class="space-x-2">
       {% for note in standard_notes %}
@@ -27,7 +28,7 @@
               hx-post="{% url 'hx_supervision_add_standard_note' row.result_id %}"
               hx-vals='{"note_text": "{{ note.note_text }}"}'
               hx-target="closest details" hx-swap="outerHTML"
-              class="bg-background px-2 py-1 rounded">
+              class="px-2 py-1 rounded {% btn_classes 'muted' %}">
         {{ note.note_text }}
       </button>
       {% endfor %}
@@ -35,11 +36,11 @@
     <form hx-post="{% url 'hx_supervision_save_notes' row.result_id %}" hx-target="closest details" hx-swap="outerHTML" class="space-y-2">
         <textarea name="notes" rows="2" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded w-full p-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">{{ row.notes }}</textarea>
       <div class="space-x-2">
-        <button type="submit" class="bg-accent text-text px-2 py-1 rounded">Speichern</button>
+        <button type="submit" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Speichern</button>
         <button type="button"
                 hx-post="{% url 'hx_supervision_revert_to_document' row.result_id %}"
                 hx-target="closest details" hx-swap="outerHTML"
-                class="bg-background px-2 py-1 rounded">
+                class="px-2 py-1 rounded {% btn_classes 'muted' %}">
           GAP auflösen
         </button>
       </div>

--- a/templates/partials/version_switcher.html
+++ b/templates/partials/version_switcher.html
@@ -1,4 +1,4 @@
-{% if versions|length > 1 %}
+{% load ui_extras %}{% if versions|length > 1 %}
 <div class="mb-4">
   <label for="version-select" class="font-semibold mr-2">Version:</label>
     <select id="version-select" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded p-1 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">
@@ -11,7 +11,7 @@
   {% for v in versions %}
   <form method="post" action="{% url 'delete_project_file_version' v.pk %}" class="inline">
     {% csrf_token %}
-    <button type="submit" class="bg-error text-background px-2 py-1 rounded" onclick="return confirm('Sind Sie sicher?')">v{{ v.version }} löschen</button>
+    <button type="submit" class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Sind Sie sicher?')">v{{ v.version }} löschen</button>
   </form>
   {% endfor %}
 </div>

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
-{% load recording_extras %}
+{% load recording_extras ui_extras %}
 {% block title %}Projekt {{ projekt.title }}{% endblock %}
 {% block content %}
 {% include 'partials/_breadcrumbs.html' %}
@@ -86,21 +86,21 @@ function renderLLM(data){
  const sec=document.getElementById('llm-section');
  sec.innerHTML='';
  if(!data.ist_llm_geprueft && !data.llm_initial_output){
-   sec.innerHTML=`<button id="run" class="bg-success text-background px-4 py-2 rounded">LLM-Check starten</button>`;
+   sec.innerHTML=`<button id="run" class="px-4 py-2 rounded {% btn_classes 'success' %}">LLM-Check starten</button>`;
  }else if(data.ist_llm_geprueft && !data.llm_validated){
     sec.innerHTML=`<div class="text-error mb-2">LLM-Check unvollständig oder technisch fehlerhaft.</div>
     <textarea id="edit" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-text dark:text-text-light rounded w-full p-2 mb-2 focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">${data.llm_initial_output||''}</textarea>
     <input id="context" type="text" placeholder="Weiterer Kontext" class="border-gray-300 dark:border-gray-600 bg-background dark:bg-background-dark text-gray-900 dark:text-gray-100 rounded w-full p-2 mb-2 hidden focus:border-primary dark:focus:border-primary focus:ring-primary dark:focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-gray-800">
     <div class="space-x-2">
-     <button id="edit-btn" class="bg-primary text-background px-4 py-2 rounded">Antwort bearbeiten & erneut prüfen</button>
-     <button id="ctx-btn" class="bg-primary text-background px-4 py-2 rounded">Zusätzlichen Kontext & erneut prüfen</button>
+     <button id="edit-btn" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Antwort bearbeiten & erneut prüfen</button>
+     <button id="ctx-btn" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Zusätzlichen Kontext & erneut prüfen</button>
    </div>`;
  }else if(data.ist_llm_geprueft && data.llm_validated){
-  sec.innerHTML=`<button id="toggle" class="bg-success text-background px-4 py-2 rounded mb-2">Antwort ein-/ausblenden</button>
+  sec.innerHTML=`<button id="toggle" class="px-4 py-2 rounded mb-2 {% btn_classes 'success' %}">Antwort ein-/ausblenden</button>
   <div id="output" class="prose dark:prose-invert max-w-none bg-background dark:bg-background-dark text-text dark:text-text-light border border-gray-300 dark:border-gray-600 p-2 rounded hidden">${data.llm_initial_output_html}</div>`;
  }
  if(data.llm_initial_output){
-  sec.innerHTML += `<button id="recheck" class="bg-primary text-background px-4 py-2 rounded mt-2">Erneut prüfen</button>`;
+  sec.innerHTML += `<button id="recheck" class="px-4 py-2 rounded mt-2 {% btn_classes 'primary' %}">Erneut prüfen</button>`;
  }
  attachHandlers();
 }

--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -60,11 +60,11 @@
                 data-func-id="{{ row.func_id }}" {% if row.sub %}data-sub-id="{{ row.sub_id }}"{% endif %}>
                 <td class="border px-2 {% if row.sub %}pl-8{% endif %}">
                     {% if not row.sub %}
-                    <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-muted hover:bg-muted" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
+                    <button class="toggle-button mr-2 inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded {% btn_classes 'muted' %}" type="button" data-target-class="subquestions-for-{{ row.func_id }}">+</button>
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-muted hover:bg-muted">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded text-muted {% btn_classes 'muted' %}">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
@@ -72,7 +72,7 @@
                     {{ row.name }}
                     {% if row.has_justification %}
                     <a href="{% url 'justification_detail_edit' anlage.pk row.verif_key %}"
-                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-background text-muted hover:bg-muted">
+                       class="ml-2 inline-flex items-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded text-muted {% btn_classes 'muted' %}">
                         Begründung ansehen/bearbeiten
                     </a>
                     {% endif %}
@@ -98,7 +98,7 @@
                 <td class="border px-2 text-center action-column hidden">
                     {% if allow_ai_check %}
                     <button type="button"
-                        class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded bg-muted hover:bg-muted"
+                        class="review-cycle-btn inline-flex items-center justify-center px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded {% btn_classes 'muted' %}"
                         data-state="robot" data-popover-content="KI-Prüfung starten"
                         data-project-file-id="{{ anlage.pk }}"
                         data-function-id="{{ row.func_id }}"
@@ -114,7 +114,7 @@
         {% if allow_ai_check %}
         {% include 'partials/_button.html' with type='button' id='btn-verify-all' label='Alle Funktionen prüfen 🤖' variant='success' attrs='data-project-id="'|add:anlage.project.pk|add:'"' %}
         {% endif %}
-        <a href="{% url 'projekt_file_parse_anlage2' anlage.pk %}" class="bg-accent text-background px-2 py-1 rounded ml-4">Parser-Analyse starten</a>
+        <a href="{% url 'projekt_file_parse_anlage2' anlage.pk %}" class="px-2 py-1 rounded ml-4 {% btn_classes 'primary' %}">Parser-Analyse starten</a>
     </div>
     </div>
     <p class="mb-2">Gap-Notizen werden automatisch erstellt.</p>
@@ -138,7 +138,7 @@
             {{ parser_form.parser_order }}
             {{ parser_form.parser_order.errors }}
         </div>
-        <button type="submit" name="save_parser_settings" class="bg-accent text-background px-3 py-1 rounded">Einstellungen speichern</button>
+        <button type="submit" name="save_parser_settings" class="px-3 py-1 rounded {% btn_classes 'primary' %}">Einstellungen speichern</button>
     </form>
 </details>
 </div>

--- a/templates/projekt_file_json_form.html
+++ b/templates/projekt_file_json_form.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static ui_extras %}
 {% block extra_head %}{{ block.super }}{% endblock %}
 {% block title %}Analyse bearbeiten{% endblock %}
 {% block content %}
@@ -30,7 +30,7 @@
         {{ form.verhandlungsfaehig }} {{ form.verhandlungsfaehig.label_tag }}
         {{ form.verhandlungsfaehig.errors }}
     </div>
-    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}
 {% block extra_js %}

--- a/templates/recording.html
+++ b/templates/recording.html
@@ -1,14 +1,14 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static ui_extras %}
 {% block title %}Aufnahme {{ bereich|capfirst }}{% endblock %}
 
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Aufnahme {{ bereich|capfirst }}</h1>
 <div class="mb-6">
     {% if is_recording %}
-    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-background bg-error hover:bg-error-dark">Aufnahme stoppen</a>
+    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded {% btn_classes 'danger' %}">Aufnahme stoppen</a>
     {% else %}
-    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-background bg-success hover:bg-success-dark">Aufnahme starten</a>
+    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded {% btn_classes 'success' %}">Aufnahme starten</a>
     {% endif %}
 </div>
 <h2 class="text-xl font-semibold mb-2">Vergangene Aufnahmen</h2>

--- a/templates/talkdiary.html
+++ b/templates/talkdiary.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load recording_extras %}
+{% load recording_extras ui_extras %}
 {% block title %}TalkDiary {{ bereich|capfirst }}{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">TalkDiary {{ bereich|capfirst }}</h1>
@@ -7,21 +7,21 @@
 <h2 class="text-lg font-semibold mb-2">Aufnahme</h2>
 <div class="mb-6 flex flex-wrap items-center space-x-4">
     {% if is_recording %}
-    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-background bg-error hover:bg-error-dark flex items-center">
+    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded flex items-center {% btn_classes 'danger' %}">
         Aufnahme stoppen
         <span class="ml-2 animate-pulse">&#9679;</span>
     </a>
     <span class="text-error-dark font-semibold">Recording…</span>
     {% else %}
-    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded text-background bg-success hover:bg-success-dark">Aufnahme starten</a>
+    <a href="{% url 'toggle_recording' bereich=bereich %}" class="px-4 py-2 rounded {% btn_classes 'success' %}">Aufnahme starten</a>
     {% endif %}
 
     <form method="get" class="inline-block">
-        <button name="rescan" value="1" class="px-4 py-2 bg-background-dark text-background rounded">Rescan</button>
+        <button name="rescan" value="1" class="px-4 py-2 rounded {% btn_classes 'muted' %}">Rescan</button>
     </form>
-    <a href="{% url 'upload_recording' %}" class="px-4 py-2 bg-accent text-background rounded">Datei hochladen</a>
+    <a href="{% url 'upload_recording' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Datei hochladen</a>
     {% if is_admin %}
-    <a href="{% url 'admin_talkdiary' %}" class="px-4 py-2 bg-primary text-background rounded">Admin</a>
+    <a href="{% url 'admin_talkdiary' %}" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Admin</a>
     {% endif %}
 </div>
 
@@ -34,14 +34,14 @@
             <form action="{% url 'transcribe_recording' rec.pk %}" method="post" class="transcribe-form">
                 {% csrf_token %}
                 <input type="hidden" name="track" value="1">
-                <button type="submit" class="px-2 py-1 text-background bg-accent rounded">Transkribieren</button>
+                <button type="submit" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Transkribieren</button>
             </form>
             {% if rec.transcript_file %}
-            <a href="{% url 'talkdiary_detail' rec.pk %}" class="px-2 py-1 bg-success text-background rounded">Transcript</a>
+            <a href="{% url 'talkdiary_detail' rec.pk %}" class="px-2 py-1 rounded {% btn_classes 'success' %}">Transcript</a>
             {% endif %}
             <form action="{% url 'recording_delete' rec.pk %}" method="post">
                 {% csrf_token %}
-                <button type="submit" class="px-2 py-1 bg-error text-background rounded" onclick="return confirm('Aufnahme wirklich löschen?');">Löschen</button>
+                <button type="submit" class="px-2 py-1 rounded {% btn_classes 'danger' %}" onclick="return confirm('Aufnahme wirklich löschen?');">Löschen</button>
             </form>
         </div>
         <p class="mt-1 flex items-center break-all">
@@ -59,7 +59,7 @@
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     {% for rec in recordings %}
         {% if rec.transcript_file %}
-        <a href="{% url 'talkdiary_detail' rec.pk %}" class="block border rounded p-3 bg-background hover:bg-background-dark text-sm">
+        <a href="{% url 'talkdiary_detail' rec.pk %}" class="block border rounded p-3 text-sm {% btn_classes 'muted' %}">
             <h3 class="font-semibold flex items-center">
                 <i class="fa-solid fa-file-alt text-success mr-2"></i>
                 {{ rec.audio_file.name|basename|truncatechars:30 }}

--- a/templates/upload_recording.html
+++ b/templates/upload_recording.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load ui_extras %}
 {% block title %}Upload{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Audio hochladen</h1>
@@ -15,6 +16,6 @@
         {{ form.audio_file }}
         {{ form.audio_file.errors }}
     </div>
-    <button type="submit" class="bg-accent text-background px-4 py-2 rounded">Upload</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Upload</button>
 </form>
 {% endblock %}

--- a/templates/upload_transcript.html
+++ b/templates/upload_transcript.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load ui_extras %}
 {% block title %}Transcript hochladen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Transcript hochladen</h1>
@@ -12,6 +13,6 @@
         {{ form.transcript_file.label_tag }}<br>
         {{ form.transcript_file }}
     </div>
-    <button type="submit" class="px-4 py-2 bg-accent text-background rounded">Speichern</button>
+    <button type="submit" class="px-4 py-2 rounded {% btn_classes 'primary' %}">Speichern</button>
 </form>
 {% endblock %}

--- a/templates/version_compare.html
+++ b/templates/version_compare.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load recording_extras %}
+{% load recording_extras ui_extras %}
 {% block title %}Versionen vergleichen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Version {{ file.version }} mit Vorgänger vergleichen</h1>
@@ -9,7 +9,7 @@
       Aktuelle Version (v{{ file.version }})
       <form method="post" action="{% url 'delete_project_file_version' file.pk %}" class="inline">
         {% csrf_token %}
-        <button type="submit" class="bg-error text-background px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
+        <button type="submit" class="px-2 py-1 rounded ms-2 {% btn_classes 'danger' %}" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
       </form>
     </h2>
     <pre class="whitespace-pre-wrap border border-gray-300 dark:border-gray-600 p-2 bg-background dark:bg-background-dark text-text dark:text-text-light">{{ file.manual_analysis_json|default:file.analysis_json|tojson }}</pre>
@@ -20,7 +20,7 @@
       Vorherige Version (v{{ parent.version }})
       <form method="post" action="{% url 'delete_project_file_version' parent.pk %}" class="inline">
         {% csrf_token %}
-        <button type="submit" class="bg-error text-background px-2 py-1 rounded ms-2" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
+        <button type="submit" class="px-2 py-1 rounded ms-2 {% btn_classes 'danger' %}" onclick="return confirm('Sind Sie sicher?')">Löschen</button>
       </form>
     </h2>
     <pre class="whitespace-pre-wrap border border-gray-300 dark:border-gray-600 p-2 bg-background dark:bg-background-dark text-text dark:text-text-light">{{ parent.manual_analysis_json|default:parent.analysis_json|tojson }}</pre>
@@ -50,12 +50,12 @@
         <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline">
           <input type="hidden" name="result_id" value="{{ gap.id }}">
           <input type="hidden" name="action" value="carry">
-          <button type="submit" class="bg-accent text-background px-2 py-1 rounded">Übernehmen</button>
+          <button type="submit" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Übernehmen</button>
         </form>
         <form hx-post="{% url 'compare_versions' file.pk %}" hx-target="#gap-row-{{ gap.id }}" hx-swap="delete" class="inline ms-2">
           <input type="hidden" name="result_id" value="{{ gap.id }}">
           <input type="hidden" name="action" value="fix">
-          <button type="submit" class="bg-success text-background px-2 py-1 rounded">Behoben</button>
+          <button type="submit" class="px-2 py-1 rounded {% btn_classes 'success' %}">Behoben</button>
         </form>
       </td>
     </tr>

--- a/templates/version_compare_anlage1.html
+++ b/templates/version_compare_anlage1.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load ui_extras %}
 {% block title %}Versionen vergleichen{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 1: Version {{ file.version }} mit Vorgänger vergleichen</h1>
@@ -31,14 +32,14 @@
           {% csrf_token %}
           <input type="hidden" name="action" value="negotiate">
           <input type="hidden" name="question" value="{{ row.num }}">
-          <button type="submit" class="bg-accent text-background px-2 py-1 rounded">Verhandlungsfähig</button>
+          <button type="submit" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Verhandlungsfähig</button>
         </form>
         <form method="post" class="inline">
           {% csrf_token %}
           <input type="hidden" name="action" value="add_gap">
           <input type="hidden" name="question" value="{{ row.num }}">
           <input type="hidden" name="note" value="Offen">
-          <button type="submit" class="bg-success text-background px-2 py-1 rounded">Gap hinzufügen</button>
+          <button type="submit" class="px-2 py-1 rounded {% btn_classes 'success' %}">Gap hinzufügen</button>
         </form>
       </td>
     </tr>


### PR DESCRIPTION
## Summary
- replace color classes with `{% btn_classes %}` in templates
- add `ui_extras` load statements for button styling
- clean up redundant color classes

## Testing
- `python manage.py makemigrations --check`

------
https://chatgpt.com/codex/tasks/task_e_68aee1c3b6ac832b8234d0f378276559