### PR TITLE
fix: load ui_extras in Anlage2 review template

### DIFF
--- a/templates/projekt_file_anlage2_review.html
+++ b/templates/projekt_file_anlage2_review.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static %}
+{% load static ui_extras %}
 {% block extra_head %}
 {{ block.super }}
 <script src="{% static 'js/popover.js' %}"></script>


### PR DESCRIPTION
## Summary
- load ui_extras in Anlage2 review template to allow btn_classes tag

## Testing
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_68aeef3914c8832b883ab06201bf6553