### PR TITLE
test: optionale Seed-Daten-Fixure

### DIFF
--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -9,9 +9,9 @@ import fitz
 from pathlib import Path
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _seed_db(django_db_setup, django_db_blocker) -> None:
-    """Initialisiert einmalig die Testdatenbank."""
+@pytest.fixture(scope="module")
+def seed_db(django_db_setup, django_db_blocker) -> None:
+    """Initialisiert die Testdatenbank mit Seed-Daten."""
     with django_db_blocker.unblock():
         from django.contrib.auth.models import User
         from core.models import LLMConfig, Anlage4Config, Anlage4ParserConfig
@@ -30,7 +30,7 @@ def _seed_db(django_db_setup, django_db_blocker) -> None:
 
 
 @pytest.fixture
-def user(db) -> "User":
+def user(seed_db, db) -> "User":
     """Gibt den Basisbenutzer zurück."""
     from django.contrib.auth.models import User
 
@@ -38,7 +38,7 @@ def user(db) -> "User":
 
 
 @pytest.fixture
-def superuser(db) -> "User":
+def superuser(seed_db, db) -> "User":
     """Gibt den Basis-Superuser zurück."""
     from django.contrib.auth.models import User
 

--- a/core/tests/test_admin_views.py
+++ b/core/tests/test_admin_views.py
@@ -1,5 +1,9 @@
 from .base import NoesisTestCase
 from .test_general import *
+import pytest
+
+pytestmark = pytest.mark.usefixtures("seed_db")
+
 
 class AdminProjectsTests(NoesisTestCase):
     def setUp(self):

--- a/core/tests/test_compare_versions.py
+++ b/core/tests/test_compare_versions.py
@@ -2,6 +2,9 @@ from .base import NoesisTestCase
 from .test_general import *
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
+import pytest
+
+pytestmark = pytest.mark.usefixtures("seed_db")
 
 
 class CompareVersionsAnlage1Tests(NoesisTestCase):

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -363,6 +363,7 @@ def test_build_prompt_context_keys(db) -> None:
         )
 
 
+@pytest.mark.usefixtures("seed_db")
 class SeedInitialDataTests(NoesisTestCase):
     """Stellt sicher, dass die Seed-Daten vorhanden sind."""
 
@@ -393,6 +394,7 @@ class ExtractAnlageNrTests(NoesisTestCase):
         self.assertEqual(extract_anlage_nr("Anlage3.docx"), 3)
 
 
+@pytest.mark.usefixtures("seed_db")
 class BVProjectFileTests(NoesisTestCase):
     def setUp(self) -> None:  # pragma: no cover - setup
         super().setUp()
@@ -2657,6 +2659,7 @@ class ProjektFileDeleteResultTests(NoesisTestCase):
         self.assertFalse(self.file.verhandlungsfaehig)
 
 
+@pytest.mark.usefixtures("seed_db")
 class ProjektFileVersionDeletionTests(NoesisTestCase):
     def setUp(self):
         self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -4384,6 +4387,7 @@ class SupervisionGapTests(NoesisTestCase):
         self.assertEqual(row["ai_reason"], "Func reason")
 
 
+@pytest.mark.usefixtures("seed_db")
 class Anlage2ResetTests(NoesisTestCase):
     """Tests zum Zurücksetzen von Anlage-2-Ergebnissen."""
 
@@ -4644,6 +4648,7 @@ class Anlage2ResetTests(NoesisTestCase):
         # Manueller Eintrag wurde entfernt
 
 
+@pytest.mark.usefixtures("seed_db")
 class GapReportTests(NoesisTestCase):
     def setUp(self):
         super().setUp()
@@ -4719,6 +4724,7 @@ class GapReportTests(NoesisTestCase):
         self.assertEqual(self.pf2.gap_summary, "")
 
 
+@pytest.mark.usefixtures("seed_db")
 class ProjektDetailGapTests(NoesisTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary
- add optional `seed_db` fixture to seed test database on demand
- apply `seed_db` to tests that require seeded data

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b347d8c184832bba6f1ff61e5b1d12