### PR TITLE
test: migrate tests from NoesisTestCase to pytest functions

### DIFF
--- a/core/tests/test_clear_async_tasks.py
+++ b/core/tests/test_clear_async_tasks.py
@@ -1,17 +1,20 @@
+"""Smoke-Tests für den ``clear_async_tasks``-Command."""
+
+import pytest
 from django.core.management import call_command
 
-from .base import NoesisTestCase
+
+@pytest.mark.django_db
+def test_command_runs_without_error() -> None:
+    """Erwartet keinen Fehler auch ohne vorhandene Queue-/Task-Einträge."""
+
+    call_command("clear_async_tasks")
 
 
-class ClearAsyncTasksCommandTests(NoesisTestCase):
-    """Smoke-Tests für den clear_async_tasks-Command."""
+@pytest.mark.django_db
+def test_command_flags() -> None:
+    """Läuft auch mit Flags ohne Fehler."""
 
-    def test_command_runs_without_error(self) -> None:
-        # Erwartet keinen Fehler auch ohne vorhandene Queue-/Task-Einträge
-        call_command("clear_async_tasks")
-
-    def test_command_flags(self) -> None:
-        # Läuft auch mit Flags ohne Fehler
-        call_command("clear_async_tasks", queued=True)
-        call_command("clear_async_tasks", failed=True)
+    call_command("clear_async_tasks", queued=True)
+    call_command("clear_async_tasks", failed=True)
 

--- a/core/tests/test_delete_knowledge_entry.py
+++ b/core/tests/test_delete_knowledge_entry.py
@@ -1,46 +1,53 @@
+"""Tests für das Löschen eines ``SoftwareKnowledge``-Eintrags."""
+
+import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from pytest_django.asserts import assertRedirects
 
-from .base import NoesisTestCase
 from ..models import BVProject, SoftwareKnowledge, ProjectStatus
 
 
-class DeleteKnowledgeEntryTests(NoesisTestCase):
-    """Tests für das Löschen eines SoftwareKnowledge-Eintrags."""
+@pytest.fixture
+def project(db):
+    status = ProjectStatus.objects.create(
+        name="Offen", key="offen", ordering=0, is_default=True
+    )
+    return BVProject.objects.create(title="P1", status=status)
 
-    def setUp(self):
-        """Legt ein Projekt, einen Benutzer und einen Knowledge-Eintrag an."""
-        self.status = ProjectStatus.objects.create(
-            name="Offen", key="offen", ordering=0, is_default=True
-        )
-        self.project = BVProject.objects.create(title="P1", status=self.status)
-        self.user = get_user_model().objects.create_user(
-            username="user", password="pass", is_staff=True
-        )
-        self.knowledge = SoftwareKnowledge.objects.create(
-            project=self.project, software_name="Tool"
-        )
 
-    def test_delete_entry_removes_object(self):
-        """Berechtigter Benutzer kann einen Knowledge-Eintrag löschen."""
-        self.client.login(username="user", password="pass")
-        url = reverse("delete_knowledge_entry", args=[self.knowledge.pk])
-        response = self.client.post(url)
-        self.assertRedirects(
-            response,
-            reverse("projekt_detail", args=[self.project.pk]),
-        )
-        self.assertFalse(
-            SoftwareKnowledge.objects.filter(pk=self.knowledge.pk).exists()
-        )
+@pytest.fixture
+def knowledge(project):
+    return SoftwareKnowledge.objects.create(project=project, software_name="Tool")
 
-    def test_delete_entry_requires_permission(self):
-        """Unberechtigter Benutzer erhält einen 403-Status."""
-        other = get_user_model().objects.create_user(username="other", password="pass")
-        self.client.login(username="other", password="pass")
-        url = reverse("delete_knowledge_entry", args=[self.knowledge.pk])
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, 403)
-        self.assertTrue(
-            SoftwareKnowledge.objects.filter(pk=self.knowledge.pk).exists()
-        )
+
+@pytest.mark.django_db
+def test_delete_entry_removes_object(client, project, knowledge):
+    """Berechtigter Benutzer kann einen Knowledge-Eintrag löschen."""
+
+    get_user_model().objects.create_user(
+        username="user", password="pass", is_staff=True
+    )
+    client.login(username="user", password="pass")
+    url = reverse("delete_knowledge_entry", args=[knowledge.pk])
+    response = client.post(url)
+    assertRedirects(response, reverse("projekt_detail", args=[project.pk]))
+    assert not SoftwareKnowledge.objects.filter(pk=knowledge.pk).exists()
+
+
+@pytest.mark.django_db
+def test_delete_entry_requires_permission(client, project, knowledge):
+    """Unberechtigter Benutzer erhält einen 403-Status."""
+
+    get_user_model().objects.create_user(
+        username="user", password="pass", is_staff=True
+    )
+    other = get_user_model().objects.create_user(
+        username="other", password="pass"
+    )
+    client.login(username="other", password="pass")
+    url = reverse("delete_knowledge_entry", args=[knowledge.pk])
+    response = client.post(url)
+    assert response.status_code == 403
+    assert SoftwareKnowledge.objects.filter(pk=knowledge.pk).exists()
+


### PR DESCRIPTION
## Summary
- refactor clear_async_tasks tests into pytest functions
- rewrite delete_knowledge_entry tests with fixtures and pytest style

## Testing
- `python manage.py makemigrations --check`
- `pytest core/tests/test_clear_async_tasks.py core/tests/test_delete_knowledge_entry.py -q -n 0`


------
https://chatgpt.com/codex/tasks/task_e_68b34f0240c4832bb968392213796c3b