### PR TITLE
chore: extract test helpers into shared utils

### DIFF
--- a/core/tests/test_admin_views.py
+++ b/core/tests/test_admin_views.py
@@ -1,6 +1,13 @@
-from .base import NoesisTestCase
-from .test_general import *
 import pytest
+from pathlib import Path
+from django.contrib.auth.models import Group, User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from .base import NoesisTestCase
+from .utils import create_project
+from ..models import BVProject, BVProjectFile, Prompt, LLMConfig, Anlage1Question
+from ..llm_tasks import generate_gutachten
 
 pytestmark = pytest.mark.usefixtures("seed_db")
 

--- a/core/tests/test_anlage3_parser.py
+++ b/core/tests/test_anlage3_parser.py
@@ -5,8 +5,17 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from docx import Document
 
 from .base import NoesisTestCase
+import pytest
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from docx import Document
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from .base import NoesisTestCase
 from ..models import BVProject, BVProjectFile
 from ..anlage3_parser import parse_anlage3
+
+pytestmark = pytest.mark.usefixtures("seed_db")
 
 
 class Anlage3ParserTests(NoesisTestCase):

--- a/core/tests/test_compare_versions.py
+++ b/core/tests/test_compare_versions.py
@@ -1,8 +1,10 @@
-from .base import NoesisTestCase
-from .test_general import *
+import pytest
+from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
-import pytest
+
+from .base import NoesisTestCase
+from ..models import BVProject, BVProjectFile
 
 pytestmark = pytest.mark.usefixtures("seed_db")
 

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -1,9 +1,35 @@
-from .base import NoesisTestCase
-from .test_general import *
-from ..forms import Anlage5ReviewForm, BVProjectFileForm
-from ..models import ZweckKategorieA
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import pytest
+from django.http import QueryDict
+from django.urls import reverse
+from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.conf import settings
+from docx import Document
+
+from .base import NoesisTestCase
+from ..forms import (
+    BVProjectForm,
+    BVProjectUploadForm,
+    BVProjectFileJSONForm,
+    BVProjectFileForm,
+    Anlage2ConfigForm,
+    Anlage2ReviewForm,
+    Anlage5ReviewForm,
+)
+from ..models import (
+    BVProject,
+    BVProjectFile,
+    ZweckKategorieA,
+    SoftwareKnowledge,
+    Gutachten,
+    Anlage2Config,
+)
+from ..reporting import generate_gap_analysis
+
+pytestmark = pytest.mark.usefixtures("seed_db")
 
 class BVProjectFormTests(NoesisTestCase):
     def test_project_form_docx_validation(self):

--- a/core/tests/test_gap_notes.py
+++ b/core/tests/test_gap_notes.py
@@ -1,6 +1,12 @@
-from .base import NoesisTestCase
-from .test_general import *
+import pytest
+from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from .base import NoesisTestCase
+from ..models import BVProject, BVProjectFile, ZweckKategorieA
+
+pytestmark = pytest.mark.usefixtures("seed_db")
 
 class GapNotesSaveTests(NoesisTestCase):
     def setUp(self):

--- a/core/tests/test_general.py
+++ b/core/tests/test_general.py
@@ -114,109 +114,15 @@ import json
 from .base import NoesisTestCase
 from ..initial_data_constants import INITIAL_PROJECT_STATUSES
 from ..prompt_context import build_prompt_context, available_placeholders
-
-
-DEFAULT_STATUS_KEY = next(
-    s["key"] for s in INITIAL_PROJECT_STATUSES if s.get("is_default")
+from .utils import (
+    create_project,
+    seed_test_data,
+    DEFAULT_STATUS_KEY,
+    _extra_statuses,
 )
 
 
-def create_statuses() -> None:
-    data = [
-        (DEFAULT_STATUS_KEY, "Neu"),
-        ("CLASSIFIED", "Klassifiziert"),
-        ("GUTACHTEN_FREIGEGEBEN", "Gutachten freigegeben"),
-        ("IN_PRUEFUNG_ANLAGE_X", "In Prüfung Anlage X"),
-        ("FB_IN_PRUEFUNG", "FB in Prüfung"),
-        ("DONE", "Endgeprüft"),
-    ]
-    for idx, (key, name) in enumerate(data, start=1):
-        ProjectStatus.objects.update_or_create(
-            key=key,
-            defaults={
-                "name": name,
-                "ordering": idx,
-                "is_default": key == DEFAULT_STATUS_KEY,
-                "is_done_status": key == "DONE",
-            },
-        )
 
-
-@pytest.fixture(autouse=True)
-def _extra_statuses(db) -> None:
-    """Legt zusätzliche Projekt-Status für Tests an."""
-    create_statuses()
-
-
-def create_project(software: list[str] | None = None, **kwargs) -> BVProject:
-    projekt = BVProject.objects.create(**kwargs)
-    for name in software or []:
-        BVSoftware.objects.create(project=projekt, name=name)
-    return projekt
-
-
-def seed_test_data(*, skip_prompts: bool = False) -> None:
-    """Befüllt die Test-Datenbank mit Initialdaten.
-
-    Bestehende Einträge werden bei Bedarf überschrieben. Optional können die
-    Prompt-Definitionen übersprungen werden.
-    """
-    from django.apps import apps as django_apps
-    from core.management.commands.seed_initial_data import (
-        create_initial_data,
-    )
-    from ..llm_tasks import ANLAGE1_QUESTIONS
-
-    try:
-        create_initial_data(django_apps)
-    except LookupError:
-        # Falls die Migrationsfunktion wegen entfernter Modelle
-        # fehlschlägt, legen wir die benötigten Objekte manuell an.
-        Anlage1QuestionModel = apps.get_model("core", "Anlage1Question")
-        Anlage1QuestionVariant = apps.get_model("core", "Anlage1QuestionVariant")
-        for idx, text in enumerate(ANLAGE1_QUESTIONS, start=1):
-            question, _ = Anlage1QuestionModel.objects.update_or_create(
-                num=idx,
-                defaults={
-                    "text": text,
-                    "enabled": True,
-                    "parser_enabled": True,
-                    "llm_enabled": True,
-                },
-            )
-            Anlage1QuestionVariant.objects.get_or_create(question=question, text=text)
-    create_statuses()
-
-    # Erforderliche Konfigurationen bereitstellen
-    LLMConfig.objects.all().delete()
-    LLMConfig.objects.create()
-    Anlage4Config.objects.get_or_create()
-    Anlage4ParserConfig.objects.get_or_create()
-
-    # Anlage1 Fragen aktualisieren
-    Anlage1QuestionModel = apps.get_model("core", "Anlage1Question")
-    Anlage1QuestionVariant = apps.get_model("core", "Anlage1QuestionVariant")
-    for idx, text in enumerate(ANLAGE1_QUESTIONS, start=1):
-        try:
-            question = Anlage1QuestionModel.objects.get(num=idx)
-            question.text = text
-            question.parser_enabled = True
-            question.llm_enabled = True
-            question.save()
-        except Anlage1QuestionModel.DoesNotExist:
-            question = Anlage1QuestionModel.objects.create(
-                num=idx,
-                text=text,
-                parser_enabled=True,
-                llm_enabled=True,
-            )
-        Anlage1QuestionVariant.objects.get_or_create(question=question, text=text)
-
-    if skip_prompts:
-        return
-
-    for idx, text in enumerate(ANLAGE1_QUESTIONS, start=1):
-        Prompt.objects.update_or_create(name=f"anlage1_q{idx}", defaults={"text": text})
 
 
 def test_build_prompt_context_keys(db) -> None:
@@ -1438,6 +1344,7 @@ class BuildRowDataTests(NoesisTestCase):
         self.assertTrue(row["ai_result"]["technisch_vorhanden"])
 
 
+@pytest.mark.usefixtures("seed_db")
 class LLMTasksTests(NoesisTestCase):
     maxDiff = None
 
@@ -3440,6 +3347,7 @@ class FeatureVerificationTests(NoesisTestCase):
         self.assertTrue(any("Integrit" in msg for msg in cm.output))
 
 
+@pytest.mark.usefixtures("seed_db")
 class InitialCheckTests(NoesisTestCase):
     def setUp(self):
         self.projekt = BVProject.objects.create(software_typen="A", beschreibung="x")

--- a/core/tests/test_parsing.py
+++ b/core/tests/test_parsing.py
@@ -1,15 +1,45 @@
 import pytest
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from django.contrib.auth.models import User
+from PIL import Image
+from docx import Document
+
 from .base import NoesisTestCase
-from .test_general import *  # pylint: disable=wildcard-import,unused-wildcard-import
-from ..anlage4_parser import parse_anlage4_dual
-from ..models import Anlage4ParserConfig
-from ..docx_utils import extract_images
-from ..docx_utils import _normalize_header_text
+from ..anlage4_parser import parse_anlage4, parse_anlage4_dual
+from ..docx_utils import (
+    extract_text,
+    get_docx_page_count,
+    get_pdf_page_count,
+    parse_anlage2_table,
+    _normalize_header_text,
+    extract_images,
+)
+from ..models import (
+    BVProject,
+    BVProjectFile,
+    Anlage2Function,
+    Anlage2Config,
+    Anlage2ColumnHeading,
+    Anlage2SubQuestion,
+    Anlage4ParserConfig,
+    Anlage4Config,
+    AntwortErkennungsRegel,
+)
 from ..parsers import ExactParser
-from ..llm_tasks import worker_a4_plausibility as check_anlage4_item_plausibility
+from ..text_parser import parse_anlage2_text
+from ..llm_tasks import (
+    analyse_anlage4,
+    analyse_anlage4_async,
+    worker_anlage4_evaluate,
+    worker_a4_plausibility as check_anlage4_item_plausibility,
+)
+
+pytestmark = pytest.mark.usefixtures("seed_db")
 
 @pytest.mark.usefixtures("prepared_files")
 class DocxExtractTests(NoesisTestCase):

--- a/core/tests/utils.py
+++ b/core/tests/utils.py
@@ -1,0 +1,118 @@
+"""Gemeinsame Hilfsfunktionen und Fixtures für Tests."""
+
+from __future__ import annotations
+
+import pytest
+from django.apps import apps
+
+from ..initial_data_constants import INITIAL_PROJECT_STATUSES
+from ..llm_tasks import ANLAGE1_QUESTIONS
+from ..management.commands.seed_initial_data import create_initial_data
+from ..models import (
+    BVProject,
+    BVSoftware,
+    ProjectStatus,
+    Prompt,
+    LLMConfig,
+    Anlage4Config,
+    Anlage4ParserConfig,
+)
+
+
+DEFAULT_STATUS_KEY = next(
+    s["key"] for s in INITIAL_PROJECT_STATUSES if s.get("is_default")
+)
+
+
+def create_statuses() -> None:
+    """Legt Basis-Status für Projekte an."""
+    data = [
+        (DEFAULT_STATUS_KEY, "Neu"),
+        ("CLASSIFIED", "Klassifiziert"),
+        ("GUTACHTEN_FREIGEGEBEN", "Gutachten freigegeben"),
+        ("IN_PRUEFUNG_ANLAGE_X", "In Prüfung Anlage X"),
+        ("FB_IN_PRUEFUNG", "FB in Prüfung"),
+        ("DONE", "Endgeprüft"),
+    ]
+    for idx, (key, name) in enumerate(data, start=1):
+        ProjectStatus.objects.update_or_create(
+            key=key,
+            defaults={
+                "name": name,
+                "ordering": idx,
+                "is_default": key == DEFAULT_STATUS_KEY,
+                "is_done_status": key == "DONE",
+            },
+        )
+
+
+@pytest.fixture(autouse=True)
+def _extra_statuses(db) -> None:  # pragma: no cover - Fixture
+    """Stellt zusätzliche Projekt-Status für Tests bereit."""
+    create_statuses()
+
+
+def create_project(software: list[str] | None = None, **kwargs) -> BVProject:
+    """Erzeugt ein Projekt mit optionaler Softwareliste."""
+    projekt = BVProject.objects.create(**kwargs)
+    for name in software or []:
+        BVSoftware.objects.create(project=projekt, name=name)
+    return projekt
+
+
+def seed_test_data(*, skip_prompts: bool = False) -> None:
+    """Befüllt die Test-Datenbank mit Initialdaten.
+
+    Bestehende Einträge werden bei Bedarf überschrieben. Optional können die
+    Prompt-Definitionen übersprungen werden.
+    """
+    try:
+        create_initial_data(apps)
+    except LookupError:
+        # Falls die Migrationsfunktion wegen entfernter Modelle fehlschlägt,
+        # legen wir die benötigten Objekte manuell an.
+        Anlage1QuestionModel = apps.get_model("core", "Anlage1Question")
+        Anlage1QuestionVariant = apps.get_model("core", "Anlage1QuestionVariant")
+        for idx, text in enumerate(ANLAGE1_QUESTIONS, start=1):
+            question, _ = Anlage1QuestionModel.objects.update_or_create(
+                num=idx,
+                defaults={
+                    "text": text,
+                    "enabled": True,
+                    "parser_enabled": True,
+                    "llm_enabled": True,
+                },
+            )
+            Anlage1QuestionVariant.objects.get_or_create(question=question, text=text)
+    create_statuses()
+
+    # Erforderliche Konfigurationen bereitstellen
+    LLMConfig.objects.all().delete()
+    LLMConfig.objects.create()
+    Anlage4Config.objects.get_or_create()
+    Anlage4ParserConfig.objects.get_or_create()
+
+    # Anlage1 Fragen aktualisieren
+    Anlage1QuestionModel = apps.get_model("core", "Anlage1Question")
+    Anlage1QuestionVariant = apps.get_model("core", "Anlage1QuestionVariant")
+    for idx, text in enumerate(ANLAGE1_QUESTIONS, start=1):
+        try:
+            question = Anlage1QuestionModel.objects.get(num=idx)
+            question.text = text
+            question.parser_enabled = True
+            question.llm_enabled = True
+            question.save()
+        except Anlage1QuestionModel.DoesNotExist:
+            question = Anlage1QuestionModel.objects.create(
+                num=idx,
+                text=text,
+                parser_enabled=True,
+                llm_enabled=True,
+            )
+        Anlage1QuestionVariant.objects.get_or_create(question=question, text=text)
+
+    if skip_prompts:
+        return
+
+    for idx, text in enumerate(ANLAGE1_QUESTIONS, start=1):
+        Prompt.objects.update_or_create(name=f"anlage1_q{idx}", defaults={"text": text})


### PR DESCRIPTION
## Summary
- move shared fixtures and helpers from test_general into core/tests/utils.py
- replace wildcard imports with explicit ones across test modules
- ensure tests load seed data via fixtures

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3520ac924832b97198075ce109dd7