### PR TITLE
test: split compare versions test into focused cases

### DIFF
--- a/core/tests/unit/test_compare_versions.py
+++ b/core/tests/unit/test_compare_versions.py
@@ -10,7 +10,10 @@ pytestmark = [pytest.mark.unit, pytest.mark.usefixtures("seed_db")]
 
 
 class CompareVersionsAnlage1Tests(NoesisTestCase):
-    def test_gap_and_diff_display(self):
+    def _create_versions(self) -> tuple[str, BVProjectFile]:
+        """Erzeugt zwei Versionen einer Anlage und liefert URL und aktuelle Datei."""
+
+        # Arrange
         user = User.objects.create_user("u1", password="pass")
         self.client.login(username="u1", password="pass")
         projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
@@ -29,10 +32,34 @@ class CompareVersionsAnlage1Tests(NoesisTestCase):
             analysis_json={"questions": {"1": {"answer": "neu"}}},
         )
         url = reverse("compare_versions", args=[current.pk])
+        return url, current
+
+    def test_gap_and_diff_display(self) -> None:
+        """Prüft, ob Unterschiede und Hinweise angezeigt werden."""
+
+        # Arrange
+        url, _ = self._create_versions()
+
+        # Act
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertContains(resp, "Hinweis: H")
-        self.assertContains(resp, "bg-warning/20")
+
+        # Assert
+        content = resp.content.decode()
+        assert (
+            resp.status_code == 200
+            and "Hinweis: H" in content
+            and "bg-warning/20" in content
+        ), "Vergleichsansicht zeigt Hinweis oder Differenz nicht an"
+
+    def test_negotiate_sets_flag(self) -> None:
+        """Verhandlungsflag wird nach POST gesetzt."""
+
+        # Arrange
+        url, current = self._create_versions()
+
+        # Act
         self.client.post(url, {"action": "negotiate"})
         current.refresh_from_db()
-        self.assertTrue(current.verhandlungsfaehig)
+
+        # Assert
+        assert current.verhandlungsfaehig, "Verhandlungsstatus sollte gesetzt werden"


### PR DESCRIPTION
## Summary
- extract helper to create versioned files
- split compare-versions test into separate GET and POST scenarios

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b36626e3bc832b9374bc70e4583337