### PR TITLE
feat: add per-anlage GAP report

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -1928,10 +1928,19 @@ def check_anlage5(file_id: int) -> dict:
     anlage5_logger.info("check_anlage5 beendet für Projekt %s mit %s", projekt_id, result)
     return result
 
-def summarize_anlage1_gaps(projekt: BVProject) -> str:
-    """Fasst die GAP-Notizen aus Anlage 1 zusammen."""
+def summarize_anlage1_gaps(projekt: BVProject, pf: BVProjectFile | None = None) -> str:
+    """Fasst die GAP-Notizen aus Anlage 1 zusammen.
 
-    pf = get_project_file(projekt, 1)
+    Parameter
+    ---------
+    projekt:
+        Projekt, zu dem die Anlage gehört.
+    pf:
+        Optional bereits ermittelte Projektdatei. Wird keine übergeben,
+        wird die aktive Datei automatisch bestimmt.
+    """
+
+    pf = pf or get_project_file(projekt, 1)
     if not pf:
         return ""
 
@@ -2049,10 +2058,14 @@ def summarize_anlage1_gaps(projekt: BVProject) -> str:
 
     return text
 
-def summarize_anlage2_gaps(projekt: BVProject) -> str:
-    """Fasst externe GAP-Notizen aus Anlage 2 zusammen und ergänzt KI-Begründungen."""
+def summarize_anlage2_gaps(projekt: BVProject, pf: BVProjectFile | None = None) -> str:
+    """Fasst externe GAP-Notizen aus Anlage 2 zusammen und ergänzt
+    KI-Begründungen.
 
-    pf = get_project_file(projekt, 2)
+    Parameter siehe :func:`summarize_anlage1_gaps`.
+    """
+
+    pf = pf or get_project_file(projekt, 2)
     if not pf:
         return ""
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -517,8 +517,13 @@ urlpatterns = [
     ),
     path(
         "work/projekte/<int:pk>/gap-report/",
-        views.gap_report_view,
-        name="gap_report_view",
+        views.projekt_gap_report,
+        name="projekt_gap_report",
+    ),
+    path(
+        "work/projekte/<int:pk>/gap-report/<int:nr>/",
+        views.anlage_gap_report,
+        name="anlage_gap_report",
     ),
     path(
         "work/projekte/<int:pk>/gap-report/delete/",

--- a/templates/gap_report_single.html
+++ b/templates/gap_report_single.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% load static ui_extras %}
+{% block title %}GAP-Bericht Anlage {{ nr }}{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4 text-text dark:text-text-light">GAP-Bericht für Anlage {{ nr }}</h1>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    {% include 'partials/markdown_editor.html' with id_prefix='text' text=text name='text' label=label %}
+</form>
+{% endblock %}
+{% block extra_js %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        initMarkdownEditor('text');
+    });
+</script>
+{% endblock %}

--- a/templates/projekt_detail.html
+++ b/templates/projekt_detail.html
@@ -31,7 +31,7 @@
 </p>
 <p class="mb-4">
     {% if can_gap_report %}
-    {% url 'gap_report_view' projekt.pk as gap_url %}
+    {% url 'projekt_gap_report' projekt.pk as gap_url %}
     {% include 'partials/_button.html' with id='gap-report-btn' href=gap_url label='GAP-Bericht für Fachbereich erstellen' variant='primary' %}
     {% else %}
     {% include 'partials/_button.html' with label='GAP-Bericht für Fachbereich erstellen' variant='disabled' disabled=True %}


### PR DESCRIPTION
## Summary
- allow gap summarization functions to accept project files directly
- add `anlage_gap_report` view for editing gap summaries per document
- rename global gap report view to `projekt_gap_report`
- cover new view with tests and template

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`
- `pre-commit run --files core/llm_tasks.py core/views.py core/urls.py templates/projekt_detail.html templates/gap_report_single.html core/tests/unit/test_general.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5703e5a3c832bb0ec9cdc46c8e138