### PR TITLE
fix: GAP-Felder bei neuen Versionen leeren

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3420,11 +3420,14 @@ def _save_project_file(
     *,
     upload=None,
     anlage_nr: int | None = None,
+    copy_gap_fields: bool = False,
 ) -> BVProjectFile:
     """Speichert eine einzelne hochgeladene Datei.
 
     Kann entweder mit einem bereits validierten Formular oder direkt mit Datei
     und Anlagen-Nummer aufgerufen werden.
+    ``copy_gap_fields`` steuert, ob GAP-Felder der Vorgängerversion
+    übernommen werden.
     """
 
     if form is not None:
@@ -3475,6 +3478,8 @@ def _save_project_file(
     obj.project = projekt
     obj.anlage_nr = anlage_nr
     obj.text_content = content
+    obj.gap_summary = ""
+    obj.gap_notiz = ""
     old_file = (
         BVProjectFile.objects.filter(
             project=projekt,
@@ -3505,8 +3510,8 @@ def _save_project_file(
                     anlage_datei=obj,
                     funktion=m.funktion,
                     subquestion=m.subquestion,
-                    gap_summary=m.gap_summary,
-                    gap_notiz=m.gap_notiz,
+                    gap_summary=m.gap_summary if copy_gap_fields else "",
+                    gap_notiz=m.gap_notiz if copy_gap_fields else "",
                     supervisor_notes=m.supervisor_notes,
                     is_negotiable=m.is_negotiable,
                     is_negotiable_manual_override=m.is_negotiable_manual_override,


### PR DESCRIPTION
## Summary
- `_save_project_file` erhält Parameter `copy_gap_fields` und setzt GAP-Felder neuer Versionen auf leer
- Neue Integrationstests stellen sicher, dass `gap_summary` und `gap_notiz` nach Upload einer neuen Version leer sind

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`
- `pre-commit run --files core/views.py core/tests/integration/test_uploads.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5773253fc832b89ddcb8e1843544f