### PR TITLE
fix: only render Anlage 1 GAP report with predecessor

### DIFF
--- a/core/tests/unit/test_gap_report_parent.py
+++ b/core/tests/unit/test_gap_report_parent.py
@@ -1,0 +1,45 @@
+import pytest
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from ..base import NoesisTestCase
+from ...models import BVProject, BVProjectFile
+
+pytestmark = [pytest.mark.unit, pytest.mark.usefixtures("seed_db")]
+
+
+class GapReportParentTests(NoesisTestCase):
+    """Tests für den GAP-Bericht bei Anlage 1 ohne bzw. mit Vorgänger."""
+
+    def setUp(self) -> None:  # noqa: D401
+        super().setUp()
+        self.user = User.objects.create_user("gapparent", password="pass")
+        self.client.login(username="gapparent", password="pass")
+        self.project = BVProject.objects.create(software_typen="A", beschreibung="x")
+
+    def _create_file(self, parent=None, gap_summary=""):
+        return BVProjectFile.objects.create(
+            project=self.project,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("a.docx", b"data"),
+            parent=parent,
+            gap_summary=gap_summary,
+        )
+
+    def test_view_uses_parent_summary(self):
+        parent = self._create_file(gap_summary="Alt")
+        child = self._create_file(parent=parent)
+        url = reverse("projekt_file_edit_json", args=[child.pk])
+        resp = self.client.get(url)
+        self.assertEqual(resp.context["gap_text"], "Alt")
+        self.assertTrue(resp.context["has_parent"])
+        self.assertContains(resp, "GAP‑Bericht (Anlage 1)")
+
+    def test_view_hides_report_without_parent(self):
+        file = self._create_file()
+        url = reverse("projekt_file_edit_json", args=[file.pk])
+        resp = self.client.get(url)
+        self.assertEqual(resp.context["gap_text"], "")
+        self.assertFalse(resp.context["has_parent"])
+        self.assertNotContains(resp, "GAP‑Bericht (Anlage 1)")

--- a/core/views.py
+++ b/core/views.py
@@ -3905,8 +3905,16 @@ def projekt_file_edit_json(request, pk):
                     "ok": entry.get("ok", False),
                 }
             )
-        # Standard-GAP-Text für Anlage 1 bereitstellen: gespeicherter Text oder frische Zusammenfassung
-        gap_text = anlage.gap_summary or summarize_anlage1_gaps(anlage.project)
+        # GAP-Bericht der Vorgängerversion laden oder berechnen
+        if anlage.parent:
+            gap_text = (
+                anlage.parent.gap_summary
+                or summarize_anlage1_gaps(anlage.project, pf=anlage.parent)
+            )
+            has_parent = True
+        else:
+            gap_text = ""
+            has_parent = False
         form = None
     elif anlage.anlage_nr == 2:
         analysis_init = _analysis_to_initial(anlage)
@@ -4339,6 +4347,7 @@ def projekt_file_edit_json(request, pk):
     if anlage.anlage_nr == 1:
         context["qa"] = qa
         context["gap_text"] = gap_text
+        context["has_parent"] = has_parent
     elif anlage.anlage_nr == 2:
         context.update(
             {

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -3,6 +3,7 @@
 {% block title %}Anlage 1 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen prüfen</h1>
+{% if has_parent %}
 <div class="mb-6">
   <h2 class="text-xl font-semibold mb-2">GAP‑Bericht (Anlage 1)</h2>
   <form method="post" class="space-y-2">
@@ -12,6 +13,7 @@
   <p class="text-sm text-gray-500">Tipp: Der Text wird vorgeschlagen und kann hier projektspezifisch angepasst und gespeichert werden.</p>
   <hr class="my-4">
 </div>
+{% endif %}
 <div class="space-y-4">
     {% for q in qa %}
     <div class="p-4 border rounded space-y-2">


### PR DESCRIPTION
## Summary
- show GAP report for Anlage 1 only when a predecessor exists
- hide GAP report section in template without predecessor
- test GAP report rendering depending on predecessor

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`
- `pre-commit run --files core/views.py templates/projekt_file_anlage1_review.html core/tests/unit/test_gap_report_parent.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5a38c39d4832bbdd9dff7ca8a5256