### PR TITLE
feat: show GAP report preview in details block

### DIFF
--- a/core/tests/unit/test_gap_report_parent.py
+++ b/core/tests/unit/test_gap_report_parent.py
@@ -34,7 +34,7 @@ class GapReportParentTests(NoesisTestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.context["gap_text"], "Alt")
         self.assertTrue(resp.context["has_parent"])
-        self.assertContains(resp, "GAP‑Bericht (Anlage 1)")
+        self.assertContains(resp, "GAP‑Bericht (Vorversion)")
 
     def test_view_hides_report_without_parent(self):
         file = self._create_file()
@@ -42,4 +42,4 @@ class GapReportParentTests(NoesisTestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.context["gap_text"], "")
         self.assertFalse(resp.context["has_parent"])
-        self.assertNotContains(resp, "GAP‑Bericht (Anlage 1)")
+        self.assertNotContains(resp, "GAP‑Bericht (Vorversion)")

--- a/templates/projekt_file_anlage1_review.html
+++ b/templates/projekt_file_anlage1_review.html
@@ -3,16 +3,13 @@
 {% block title %}Anlage 1 Review{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Anlage 1 Fragen prüfen</h1>
-{% if has_parent %}
-<div class="mb-6">
-  <h2 class="text-xl font-semibold mb-2">GAP‑Bericht (Anlage 1)</h2>
-  <form method="post" class="space-y-2">
-    {% csrf_token %}
-    {% include 'partials/markdown_editor.html' with id_prefix='gap1' text=gap_text name='gap_summary' label='GAP-Bericht für Fachbereich' %}
-  </form>
-  <p class="text-sm text-gray-500">Tipp: Der Text wird vorgeschlagen und kann hier projektspezifisch angepasst und gespeichert werden.</p>
-  <hr class="my-4">
-</div>
+{% if gap_text %}
+<details class="mb-6">
+  <summary class="text-xl font-semibold cursor-pointer">GAP‑Bericht (Vorversion)</summary>
+  <div class="prose dark:prose-invert mt-2">
+    {{ gap_text|markdownify }}
+  </div>
+</details>
 {% endif %}
 <div class="space-y-4">
     {% for q in qa %}


### PR DESCRIPTION
## Summary
- replace editable GAP report form with collapsible preview
- update parent gap report tests for new summary label

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`
- `pre-commit run --files templates/projekt_file_anlage1_review.html core/tests/unit/test_gap_report_parent.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5a652dc50832b98befcc7227ad92d