### PR TITLE
fix: show full GAP comparison details

### DIFF
--- a/core/tests/factories.py
+++ b/core/tests/factories.py
@@ -1,13 +1,12 @@
 import os
 import django
 import factory
-from django.contrib.auth.models import User, Group
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "noesis.settings")
 django.setup()
 
+from django.contrib.auth.models import User, Group
 from pytest_factoryboy import register
-
 from core.models import Area, Tile, ProjectStatus, BVProject, BVProjectFile
 
 

--- a/core/tests/unit/test_compare_versions.py
+++ b/core/tests/unit/test_compare_versions.py
@@ -35,7 +35,7 @@ class CompareVersionsAnlage1Tests(NoesisTestCase):
         return url, current
 
     def test_gap_and_diff_display(self) -> None:
-        """Prüft, ob Unterschiede und Hinweise angezeigt werden."""
+        """Prüft, ob Unterschiede, Antworten und Hinweise angezeigt werden."""
 
         # Arrange
         url, _ = self._create_versions()
@@ -45,11 +45,11 @@ class CompareVersionsAnlage1Tests(NoesisTestCase):
 
         # Assert
         content = resp.content.decode()
-        assert (
-            resp.status_code == 200
-            and "Hinweis: H" in content
-            and "bg-warning/20" in content
-        ), "Vergleichsansicht zeigt Hinweis oder Differenz nicht an"
+        assert resp.status_code == 200
+        assert "Hinweis: H" in content
+        assert "alt" in content and "neu" in content
+        assert "Gap hinzufügen" not in content
+        assert "bg-warning/20" in content
 
     def test_negotiate_sets_flag(self) -> None:
         """Verhandlungsflag wird nach POST gesetzt."""

--- a/core/views.py
+++ b/core/views.py
@@ -6278,20 +6278,10 @@ def _compare_versions_anlage1(
         if action == "negotiate":
             project_file.verhandlungsfaehig = True
             project_file.save(update_fields=["verhandlungsfaehig"])
-        elif action == "add_gap":
-            qnum = request.POST.get("question")
-            note = request.POST.get("note", "")
-            review = project_file.question_review or {}
-            qdata = review.get(qnum, {})
-            qdata["hinweis"] = note
-            review[qnum] = qdata
-            project_file.question_review = review
-            project_file.save(update_fields=["question_review"])
         return redirect("compare_versions", pk=project_file.pk)
 
     questions_map = {str(q.num): q.text for q in Anlage1Question.objects.all()}
     parent_review = parent.question_review or {}
-    current_review = project_file.question_review or {}
     parent_analysis = parent.analysis_json.get("questions", {}) if parent.analysis_json else {}
     current_analysis = (
         project_file.analysis_json.get("questions", {})
@@ -6306,8 +6296,8 @@ def _compare_versions_anlage1(
                 {
                     "num": num,
                     "text": questions_map.get(num, f"Frage {num}"),
-                    "parent": pdata,
-                    "current": current_review.get(num, {}),
+                    "parent": {**parent_analysis.get(num, {}), **pdata},
+                    "current": current_analysis.get(num, {}),
                 }
             )
 

--- a/templates/version_compare_anlage1.html
+++ b/templates/version_compare_anlage1.html
@@ -20,26 +20,21 @@
     <tr>
       <td class="border px-2">{{ row.text }}</td>
       <td class="border px-2">
+        {% if row.parent.answer %}<p>{{ row.parent.answer }}</p>{% endif %}
         {% if row.parent.hinweis %}<p>Hinweis: {{ row.parent.hinweis }}</p>{% endif %}
         {% if row.parent.vorschlag %}<p>Vorschlag: {{ row.parent.vorschlag }}</p>{% endif %}
       </td>
       <td class="border px-2">
+        {% if row.current.answer %}<p>{{ row.current.answer }}</p>{% endif %}
         {% if row.current.hinweis %}<p>Hinweis: {{ row.current.hinweis }}</p>{% endif %}
         {% if row.current.vorschlag %}<p>Vorschlag: {{ row.current.vorschlag }}</p>{% endif %}
       </td>
-      <td class="border px-2 space-x-2">
+      <td class="border px-2">
         <form method="post" class="inline">
           {% csrf_token %}
           <input type="hidden" name="action" value="negotiate">
           <input type="hidden" name="question" value="{{ row.num }}">
           <button type="submit" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Verhandlungsfähig</button>
-        </form>
-        <form method="post" class="inline">
-          {% csrf_token %}
-          <input type="hidden" name="action" value="add_gap">
-          <input type="hidden" name="question" value="{{ row.num }}">
-          <input type="hidden" name="note" value="Offen">
-          <button type="submit" class="px-2 py-1 rounded {% btn_classes 'success' %}">Gap hinzufügen</button>
         </form>
       </td>
     </tr>


### PR DESCRIPTION
## Summary
- display answer and notes from previous review and parsed current content in GAP comparison
- remove unused GAP-add action and allow marking as negotiable
- ensure tests display answers and factories initialize Django early

## Testing
- `pre-commit run --files core/views.py templates/version_compare_anlage1.html core/tests/unit/test_compare_versions.py`
- `python manage.py makemigrations --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ad98adc4832b9ea0326c7b51b4f9