### PR TITLE
feat: track Verhandlungsfähigkeit pro Frage

### DIFF
--- a/core/tests/unit/test_compare_versions.py
+++ b/core/tests/unit/test_compare_versions.py
@@ -63,3 +63,17 @@ class CompareVersionsAnlage1Tests(NoesisTestCase):
 
         # Assert
         assert current.verhandlungsfaehig, "Verhandlungsstatus sollte gesetzt werden"
+
+    def test_negotiate_question_marks_ok(self) -> None:
+        """POST mit question setzt das Review und nicht den Datei-Status."""
+
+        # Arrange
+        url, current = self._create_versions()
+
+        # Act
+        self.client.post(url, {"action": "negotiate", "question": "1"})
+        current.refresh_from_db()
+
+        # Assert
+        assert current.question_review["1"]["ok"] is True
+        assert not current.verhandlungsfaehig

--- a/templates/version_compare_anlage1.html
+++ b/templates/version_compare_anlage1.html
@@ -30,12 +30,16 @@
         {% if row.current.vorschlag %}<p>Vorschlag: {{ row.current.vorschlag }}</p>{% endif %}
       </td>
       <td class="border px-2">
-        <form method="post" class="inline">
-          {% csrf_token %}
-          <input type="hidden" name="action" value="negotiate">
-          <input type="hidden" name="question" value="{{ row.num }}">
-          <button type="submit" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Verhandlungsfähig</button>
-        </form>
+        {% if row.ok %}
+          <span class="text-success">Verhandlungsfähig</span>
+        {% else %}
+          <form method="post" class="inline">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="negotiate">
+            <input type="hidden" name="question" value="{{ row.num }}">
+            <button type="submit" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Verhandlungsfähig</button>
+          </form>
+        {% endif %}
       </td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- mark individual Anlage 1 questions as negotiated via POST `question`
- show per-question negotiation status in comparison template
- cover question-specific negotiation with new unit test

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5bde4b76c832bb291784e027a3366