### PR TITLE
feat: show negotiable status in compare view

### DIFF
--- a/templates/partials/anlage1_negotiable.html
+++ b/templates/partials/anlage1_negotiable.html
@@ -1,4 +1,4 @@
-<button type="button"
+<button type="submit"
     hx-post="{% url 'hx_toggle_anlage1_ok' anlage.pk num %}"
     hx-target="this" hx-swap="outerHTML"
     class="inline-flex items-center justify-center px-2 py-1 border rounded {% if is_ok %}bg-success/20 text-success-dark{% else %}bg-error-light text-error-dark{% endif %}">

--- a/templates/version_compare_anlage1.html
+++ b/templates/version_compare_anlage1.html
@@ -29,17 +29,11 @@
         {% if row.current.hinweis %}<p>Hinweis: {{ row.current.hinweis }}</p>{% endif %}
         {% if row.current.vorschlag %}<p>Vorschlag: {{ row.current.vorschlag }}</p>{% endif %}
       </td>
-      <td class="border px-2">
-        {% if row.ok %}
-          <span class="text-success">Verhandlungsfähig</span>
-        {% else %}
-          <form method="post" class="inline">
-            {% csrf_token %}
-            <input type="hidden" name="action" value="negotiate">
-            <input type="hidden" name="question" value="{{ row.num }}">
-            <button type="submit" class="px-2 py-1 rounded {% btn_classes 'primary' %}">Verhandlungsfähig</button>
-          </form>
-        {% endif %}
+      <td class="border px-2 text-center">
+        <form method="post" action="{% url 'hx_toggle_anlage1_ok' file.pk row.num %}" class="inline">
+          {% csrf_token %}
+          {% include 'partials/anlage1_negotiable.html' with anlage=file num=row.num is_ok=row.ok %}
+        </form>
       </td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- add visual negotiable indicator for GAP rows in version comparison
- allow toggling negotiable status via htmx or regular POST

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c3901138832b904eff8d3d5a3881