### PR TITLE
fix: Fragenbewertungen erst nach Analyse kopieren

### DIFF
--- a/core/llm_tasks.py
+++ b/core/llm_tasks.py
@@ -14,7 +14,7 @@ from django.db.models import Q
 from django.utils import timezone
 from django_q.tasks import async_task, result
 
-from .utils import get_project_file, update_file_status
+from .utils import get_project_file, update_file_status, propagate_question_review
 from .decorators import updates_file_status
 
 from .models import (
@@ -838,6 +838,8 @@ def check_anlage1(file_id: int) -> dict:
         anlage.processing_status = BVProjectFile.COMPLETE
         save_fields.append("analysis_json")
         update_file_status(anlage.pk, BVProjectFile.COMPLETE)
+        if anlage.parent:
+            propagate_question_review(anlage.parent, anlage, parsed)
     except Exception:
         anlage.processing_status = BVProjectFile.FAILED
         update_file_status(anlage.pk, BVProjectFile.FAILED)

--- a/core/views.py
+++ b/core/views.py
@@ -140,7 +140,12 @@ from .parser_manager import parser_manager
 
 from .decorators import admin_required, tile_required
 from .obs_utils import start_recording, stop_recording, is_recording
-from .utils import get_project_file, start_analysis_for_file, has_any_gap
+from .utils import (
+    get_project_file,
+    start_analysis_for_file,
+    has_any_gap,
+    propagate_question_review,
+)
 from django.forms import formset_factory, modelformset_factory
 
 
@@ -3496,32 +3501,8 @@ def _save_project_file(
         obj.parent = old_file
 
     obj.save()
-    if old_file and obj.anlage_nr == 1:
-        parent_review = old_file.question_review or {}
-        parent_answers = (
-            old_file.analysis_json.get("questions", {})
-            if isinstance(old_file.analysis_json, dict)
-            else {}
-        )
-        current_answers = (
-            obj.analysis_json.get("questions", {})
-            if isinstance(obj.analysis_json, dict)
-            else {}
-        )
-        new_review: dict[str, dict] = {}
-        for num, entry in parent_review.items():
-            new_entry = copy.deepcopy(entry)
-            if (
-                parent_answers.get(num) == current_answers.get(num)
-                and entry.get("ok")
-            ):
-                new_entry["ok"] = True
-            else:
-                new_entry["ok"] = False
-            new_review[str(num)] = new_entry
-        if new_review:
-            obj.question_review = new_review
-            obj.save(update_fields=["question_review"])
+    if old_file:
+        propagate_question_review(old_file, obj)
     if old_file:
         # Ãœbernahme vorhandener KI-PrÃ¼fergebnisse aus der VorgÃ¤ngerversion
         ai_results = FunktionsErgebnis.objects.filter(


### PR DESCRIPTION
## Summary
- verhindern, dass Fragenbewertungen beim Upload zurückgesetzt werden
- Fragenbewertungen erst nach verfügbarer Analyse übernehmen

## Testing
- `pre-commit run --files core/utils.py core/views.py core/llm_tasks.py`
- `python manage.py makemigrations --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c6831784832bae51ab40068777ee