### PR TITLE
feat: sync Anlage 1 negotiability with question reviews

### DIFF
--- a/core/tests/unit/test_forms.py
+++ b/core/tests/unit/test_forms.py
@@ -148,6 +148,19 @@ def test_question_review_saved_htmx(client, projekt_file_setup):
     assert anlage1.question_review["1"]["ok"]
 
 
+def test_question_review_toggle_updates_file_flag(client, projekt_file_setup):
+    anlage1 = projekt_file_setup["anlage1"]
+
+    url = reverse("hx_toggle_anlage1_ok", args=[anlage1.pk, 1])
+    client.post(url)
+    anlage1.refresh_from_db()
+    assert anlage1.verhandlungsfaehig
+
+    client.post(url)
+    anlage1.refresh_from_db()
+    assert not anlage1.verhandlungsfaehig
+
+
 def test_question_review_extended_fields_saved(client, projekt_file_setup):
     anlage1 = projekt_file_setup["anlage1"]
 

--- a/core/tests/unit/test_propagate_question_review.py
+++ b/core/tests/unit/test_propagate_question_review.py
@@ -1,0 +1,45 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from ..base import NoesisTestCase
+from ...models import BVProject, BVProjectFile
+from ...utils import propagate_question_review
+
+pytestmark = [pytest.mark.unit, pytest.mark.usefixtures("seed_db")]
+
+
+class PropagateQuestionReviewTests(NoesisTestCase):
+    def test_sets_verhandlungsfaehig_flag(self):
+        projekt = BVProject.objects.create(software_typen="A", beschreibung="x")
+        parent = BVProjectFile.objects.create(
+            project=projekt,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("p.txt", b"x"),
+            analysis_json={"questions": {"1": {"answer": "alt"}}},
+            question_review={"1": {"ok": True}},
+            verhandlungsfaehig=True,
+        )
+
+        current_changed = BVProjectFile.objects.create(
+            project=projekt,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("c.txt", b"x"),
+            analysis_json={"questions": {"1": {"answer": "neu"}}},
+            parent=parent,
+        )
+        propagate_question_review(parent, current_changed)
+        current_changed.refresh_from_db()
+        assert current_changed.question_review["1"]["ok"] is False
+        assert not current_changed.verhandlungsfaehig
+
+        current_same = BVProjectFile.objects.create(
+            project=projekt,
+            anlage_nr=1,
+            upload=SimpleUploadedFile("s.txt", b"x"),
+            analysis_json={"questions": {"1": {"answer": "alt"}}},
+            parent=parent,
+        )
+        propagate_question_review(parent, current_same)
+        current_same.refresh_from_db()
+        assert current_same.question_review["1"]["ok"] is True
+        assert current_same.verhandlungsfaehig

--- a/core/views.py
+++ b/core/views.py
@@ -147,6 +147,7 @@ from .utils import (
     propagate_question_review,
     compute_gap_source_hash,
     is_gap_summary_outdated,
+    update_anlage1_verhandlungsfaehig,
 )
 from django.forms import formset_factory, modelformset_factory
 
@@ -5171,6 +5172,7 @@ def hx_toggle_anlage1_ok(request, pk: int, num: int):
     data[str(num)] = entry
     anlage.question_review = data
     anlage.save(update_fields=["question_review"])
+    update_anlage1_verhandlungsfaehig(anlage)
 
     context = {"anlage": anlage, "num": num, "is_ok": entry["ok"]}
     if request.headers.get("HX-Request", "").lower() == "true":


### PR DESCRIPTION
## Summary
- derive Anlage 1's `verhandlungsfaehig` flag from its question reviews
- update file status when reviewers toggle individual question OK flags
- cover propagation and toggling logic with tests

## Testing
- `python manage.py makemigrations --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6aa2456d4832b93a28dee5f83d27a